### PR TITLE
feat(validators): implement Layer 2 validator helpers

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -41,8 +41,9 @@ jobs:
 
       - uses: codecov/codecov-action@v5
         with:
-          # Fail if error if not on PR, or if on PR and token is given
-          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          # Don't fail CI on upload errors — Codecov requires a token for
+          # private repos. Set the CODECOV_TOKEN secret to enable enforcement.
+          fail_ci_if_error: false
           files: ./cobertura.xml
           plugins: noop
           disable_search: true

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -41,9 +41,8 @@ jobs:
 
       - uses: codecov/codecov-action@v5
         with:
-          # Don't fail CI on upload errors — Codecov requires a token for
-          # private repos. Set the CODECOV_TOKEN secret to enable enforcement.
-          fail_ci_if_error: false
+          # Fail if error if not on PR, or if on PR and token is given
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
           files: ./cobertura.xml
           plugins: noop
           disable_search: true

--- a/R/02-validators.R
+++ b/R/02-validators.R
@@ -1,0 +1,342 @@
+# R/02-validators.R
+#
+# Layer 2 validator helpers for the surveycore package.
+#
+# These functions are called by constructors (Layer 3) and update_design()
+# to validate input BEFORE creating S7 objects. All return invisible(TRUE)
+# on success; call cli_abort() or cli_warn() on failure.
+#
+# The 3-layer validator architecture (per phase-0-implementation-plan-v2.md):
+#   Layer 1 — S7 class validators    (R/00-s7-classes.R)
+#   Layer 2 — these helpers          (R/02-validators.R)  <-- this file
+#   Layer 3 — constructor validation (R/03-constructors.R)
+#
+# No logic from one layer is duplicated in another.
+# Error classes match plans/error-messages.md exactly.
+# All functions are internal (not exported), prefixed with `.`.
+
+#' Internal Validator Helpers
+#'
+#' Layer 2 reusable validation helpers called by constructors and
+#' `update_design()` to validate input before creating S7 objects.
+#' Return `invisible(TRUE)` on success; call [cli::cli_abort()] or
+#' [cli::cli_warn()] on failure.
+#'
+#' @name validators
+#' @keywords internal
+#' @noRd
+NULL
+
+
+# ── .validate_weights ──────────────────────────────────────────────────────────
+
+# Validates that `weights_var` column exists in `data`, is numeric, and has
+# all non-NA values strictly positive (with the all-zero/all-missing case
+# caught first for a more actionable error).
+#' @noRd
+.validate_weights <- function(weights_var, data) {
+  # Existence check
+  if (!weights_var %in% names(data)) {
+    cli::cli_abort(
+      c(
+        "x" = "Weight column {.field {weights_var}} not found in {.arg data}.",
+        "i" = "Available columns: {.field {names(data)}}."
+      ),
+      class = "surveycore_error_design_var_missing"
+    )
+  }
+
+  wt_col <- data[[weights_var]]
+
+  # Numeric check
+  if (!is.numeric(wt_col)) {
+    cli::cli_abort(
+      c(
+        "x" = paste0(
+          "Weight column {.field {weights_var}} must be numeric, ",
+          "not {.cls {class(wt_col)}}."
+        )
+      ),
+      class = "surveycore_error_weights_not_numeric"
+    )
+  }
+
+  # All zero or all missing → no valid weights at all
+  non_na <- wt_col[!is.na(wt_col)]
+  if (length(non_na) == 0L || all(non_na == 0)) {
+    cli::cli_abort(
+      c(
+        "x" = paste0(
+          "All values in {.arg weights} ({.field {weights_var}}) are zero ",
+          "or missing \u2014 no valid weights."
+        )
+      ),
+      class = "surveycore_error_weights_all_zero"
+    )
+  }
+
+  # Non-positive check (some bad weights mixed with good ones)
+  n_bad <- sum(non_na <= 0)
+  if (n_bad > 0L) {
+    cli::cli_abort(
+      c(
+        "x" = paste0(
+          "Weight column {.field {weights_var}} has {n_bad} non-positive ",
+          "value(s). All non-NA weights must be > 0."
+        )
+      ),
+      class = "surveycore_error_weights_nonpositive"
+    )
+  }
+
+  invisible(TRUE)
+}
+
+
+# ── .validate_design_vars ──────────────────────────────────────────────────────
+
+# Validates that all column names in `vars` exist in `data` and are atomic
+# (not list-columns). Pass `vars = NULL` or `vars = character(0)` to no-op.
+#' @noRd
+.validate_design_vars <- function(vars, data) {
+  if (is.null(vars) || length(vars) == 0L) return(invisible(TRUE))
+
+  # Existence check
+  missing_vars <- setdiff(vars, names(data))
+  if (length(missing_vars) > 0L) {
+    cli::cli_abort(
+      c(
+        "x" = paste0(
+          "Design variable(s) not found in {.arg data}: ",
+          "{.field {missing_vars}}."
+        )
+      ),
+      class = "surveycore_error_design_var_missing"
+    )
+  }
+
+  # Atomic check (not list-columns)
+  for (v in vars) {
+    if (!is.atomic(data[[v]])) {
+      cli::cli_abort(
+        c(
+          "x" = paste0(
+            "Design variable {.field {v}} is a list-column. ",
+            "Design variables must be atomic vectors."
+          )
+        ),
+        class = "surveycore_error_design_var_list"
+      )
+    }
+  }
+
+  invisible(TRUE)
+}
+
+
+# ── .validate_fpc ─────────────────────────────────────────────────────────────
+
+# Validates that `fpc_var` column exists in `data` and contains no NA values.
+# Pass `fpc_var = NULL` to no-op.
+#' @noRd
+.validate_fpc <- function(fpc_var, data) {
+  if (is.null(fpc_var)) return(invisible(TRUE))
+
+  # Existence check
+  if (!fpc_var %in% names(data)) {
+    cli::cli_abort(
+      c(
+        "x" = "FPC column {.field {fpc_var}} not found in {.arg data}.",
+        "i" = "Available columns: {.field {names(data)}}."
+      ),
+      class = "surveycore_error_design_var_missing"
+    )
+  }
+
+  fpc_col <- data[[fpc_var]]
+  n_na    <- sum(is.na(fpc_col))
+
+  if (n_na > 0L) {
+    cli::cli_abort(
+      c(
+        "x" = paste0(
+          "{.arg fpc} column {.field {fpc_var}} contains {n_na} ",
+          "NA value(s). FPC must be fully observed."
+        ),
+        "v" = paste0(
+          "Remove rows with missing FPC or set {.arg fpc = NULL} to ",
+          "omit the correction."
+        )
+      ),
+      class = "surveycore_error_fpc_na"
+    )
+  }
+
+  invisible(TRUE)
+}
+
+
+# ── .validate_repweights ───────────────────────────────────────────────────────
+
+# Validates that all columns in `repweights_vars` exist in `data` and are
+# numeric. Pass `repweights_vars = NULL` or `repweights_vars = character(0)`
+# to no-op.
+#' @noRd
+.validate_repweights <- function(repweights_vars, data) {
+  if (is.null(repweights_vars) || length(repweights_vars) == 0L) {
+    return(invisible(TRUE))
+  }
+
+  # Existence check
+  missing_vars <- setdiff(repweights_vars, names(data))
+  if (length(missing_vars) > 0L) {
+    cli::cli_abort(
+      c(
+        "x" = paste0(
+          "Replicate weight column(s) not found in {.arg data}: ",
+          "{.field {missing_vars}}."
+        )
+      ),
+      class = "surveycore_error_design_var_missing"
+    )
+  }
+
+  # Numeric check (first non-numeric column triggers the error)
+  for (rw in repweights_vars) {
+    rw_col <- data[[rw]]
+    if (!is.numeric(rw_col)) {
+      cli::cli_abort(
+        c(
+          "x" = paste0(
+            "Replicate weight column {.field {rw}} must be numeric, ",
+            "not {.cls {class(rw_col)}}."
+          )
+        ),
+        class = "surveycore_error_repweights_not_numeric"
+      )
+    }
+  }
+
+  invisible(TRUE)
+}
+
+
+# ── .validate_psu_strata ───────────────────────────────────────────────────────
+
+# Issues a warning if any PSU (first stage of `ids`) appears in more than one
+# stratum. Pass `ids = NULL` or `strata = NULL` to no-op. This check is skipped
+# when `nest = TRUE` (caller responsibility — this function does not take nest).
+#' @noRd
+.validate_psu_strata <- function(ids, strata, data) {
+  if (is.null(ids) || length(ids) == 0L || is.null(strata)) {
+    return(invisible(TRUE))
+  }
+
+  psu_col    <- as.character(data[[ids[[1L]]]])
+  strata_col <- as.character(data[[strata]])
+
+  psu_n_strata      <- tapply(strata_col, psu_col, function(s) length(unique(s)))
+  multi_strata_psus <- names(psu_n_strata)[psu_n_strata > 1L]
+
+  if (length(multi_strata_psus) > 0L) {
+    cli::cli_warn(
+      c(
+        "!" = paste0(
+          "Some PSUs appear in more than one stratum: ",
+          "{.val {head(multi_strata_psus, 5L)}}. ",
+          "If PSUs are nested within strata, set {.code nest = TRUE}."
+        )
+      ),
+      class = "surveycore_warning_psu_multi_strata"
+    )
+  }
+
+  invisible(TRUE)
+}
+
+
+# ── .validate_rscales ──────────────────────────────────────────────────────────
+
+# Validates that `rscales` has exactly `n_rep` elements, matching the number
+# of replicate weight columns. Pass `rscales = NULL` to no-op.
+#' @noRd
+.validate_rscales <- function(rscales, n_rep) {
+  if (is.null(rscales)) return(invisible(TRUE))
+
+  if (length(rscales) != n_rep) {
+    cli::cli_abort(
+      c(
+        "x" = paste0(
+          "Length of {.arg rscales} ({length(rscales)}) must equal ",
+          "number of replicate weights ({n_rep})."
+        )
+      ),
+      class = "surveycore_error_rscales_length"
+    )
+  }
+
+  invisible(TRUE)
+}
+
+
+# ── .update_design_var_names ───────────────────────────────────────────────────
+
+# Updates design variable name references in a `@variables` list according to
+# `rename_map`. Returns the updated list. Intended for use by rename methods,
+# which reconstruct the survey object atomically (new data + new variables in
+# a single constructor call) to avoid intermediate S7 validator failures.
+#
+# `variables`:  the `@variables` list from a survey design object.
+# `rename_map`: named character vector where names are old column names and
+#               values are the corresponding new names (e.g., c(old_wt = "weight")).
+#' @noRd
+.update_design_var_names <- function(variables, rename_map) {
+  vars <- variables
+
+  # Update scalar design variables (weights, strata, fpc)
+  for (slot in c("weights", "strata", "fpc")) {
+    if (!is.null(vars[[slot]]) && vars[[slot]] %in% names(rename_map)) {
+      vars[[slot]] <- rename_map[[vars[[slot]]]]
+    }
+  }
+
+  # Update ids (character vector, may have multiple stages)
+  if (!is.null(vars$ids)) {
+    matched           <- vars$ids %in% names(rename_map)
+    vars$ids[matched] <- rename_map[vars$ids[matched]]
+  }
+
+  # Update replicate weight column names (survey_replicate only)
+  if (!is.null(vars$repweights)) {
+    matched                  <- vars$repweights %in% names(rename_map)
+    vars$repweights[matched] <- rename_map[vars$repweights[matched]]
+  }
+
+  vars
+}
+
+
+# ── .rename_metadata_keys ──────────────────────────────────────────────────────
+
+# Renames keys (variable names) in all metadata list properties to stay in
+# sync after a column rename. Called alongside .update_design_var_names().
+#
+# `rename_map`: same named character vector as .update_design_var_names().
+#' @noRd
+.rename_metadata_keys <- function(metadata, rename_map) {
+  # Renames matched keys in a named list; leaves others unchanged.
+  .rename_list_keys <- function(lst, map) {
+    if (length(lst) == 0L || is.null(names(lst))) return(lst)
+    matched         <- names(lst) %in% names(map)
+    names(lst)[matched] <- map[names(lst)[matched]]
+    lst
+  }
+
+  metadata@variable_labels   <- .rename_list_keys(metadata@variable_labels, rename_map)
+  metadata@value_labels      <- .rename_list_keys(metadata@value_labels, rename_map)
+  metadata@question_prefaces <- .rename_list_keys(metadata@question_prefaces, rename_map)
+  metadata@notes             <- .rename_list_keys(metadata@notes, rename_map)
+  metadata@transformations   <- .rename_list_keys(metadata@transformations, rename_map)
+
+  metadata
+}

--- a/tests/testthat/test-validators.R
+++ b/tests/testthat/test-validators.R
@@ -1,0 +1,425 @@
+# tests/testthat/test-validators.R
+#
+# Tests for Layer 2 validator helpers in R/02-validators.R.
+#
+# Coverage (per plans/error-messages.md):
+#   Rows 10, 14, 17, 31, 32, 33, 34, 35, 37
+#
+# Testing approach (per .claude/rules/testing-standards.md):
+#   - Direct tests of internal helpers (constructors not yet implemented)
+#   - Happy path + error paths + edge cases per function
+#   - expect_error(class = ...) for all error cases
+#   - test_invariants() when creating/modifying survey objects
+
+
+# ── .validate_weights ──────────────────────────────────────────────────────────
+
+test_that(".validate_weights() returns TRUE for valid positive weights", {
+  df <- data.frame(x = 1:5, wt = c(1.0, 2.0, 1.5, 3.0, 0.8))
+  result <- .validate_weights("wt", df)
+  expect_true(result)
+})
+
+test_that(".validate_weights() accepts weights with NA values mixed in", {
+  # NAs are allowed — only non-NA values need to be positive
+  df <- data.frame(x = 1:4, wt = c(1.0, NA_real_, 2.0, NA_real_))
+  result <- .validate_weights("wt", df)
+  expect_true(result)
+})
+
+test_that(".validate_weights() errors when weight column not found in data", {
+  df <- data.frame(x = 1:3, other = 1:3)
+  expect_error(
+    .validate_weights("wt", df),
+    class = "surveycore_error_design_var_missing"
+  )
+})
+
+test_that(".validate_weights() errors when weight column is not numeric", {
+  df <- data.frame(x = 1:3, wt = c("a", "b", "c"))
+  expect_error(
+    .validate_weights("wt", df),
+    class = "surveycore_error_weights_not_numeric"
+  )
+})
+
+test_that(".validate_weights() errors when all weights are zero", {
+  df <- data.frame(x = 1:3, wt = c(0, 0, 0))
+  expect_error(
+    .validate_weights("wt", df),
+    class = "surveycore_error_weights_all_zero"
+  )
+})
+
+test_that(".validate_weights() errors when all weights are NA", {
+  df <- data.frame(x = 1:3, wt = c(NA_real_, NA_real_, NA_real_))
+  expect_error(
+    .validate_weights("wt", df),
+    class = "surveycore_error_weights_all_zero"
+  )
+})
+
+test_that(".validate_weights() errors when weights contain non-positive values", {
+  df <- data.frame(x = 1:4, wt = c(1.0, -0.5, 2.0, 0.0))
+  expect_error(
+    .validate_weights("wt", df),
+    class = "surveycore_error_weights_nonpositive"
+  )
+})
+
+test_that(".validate_weights() catches negative weights via nonpositive error", {
+  df <- data.frame(x = 1:3, wt = c(1.0, 1.0, -1.0))
+  expect_error(
+    .validate_weights("wt", df),
+    class = "surveycore_error_weights_nonpositive"
+  )
+})
+
+
+# ── .validate_design_vars ─────────────────────────────────────────────────────
+
+test_that(".validate_design_vars() returns TRUE for valid columns", {
+  df     <- data.frame(psu = 1:3, strata = c("a", "b", "c"), wt = 1:3)
+  result <- .validate_design_vars(c("psu", "strata"), df)
+  expect_true(result)
+})
+
+test_that(".validate_design_vars() returns TRUE for NULL vars", {
+  df     <- data.frame(x = 1:3)
+  result <- .validate_design_vars(NULL, df)
+  expect_true(result)
+})
+
+test_that(".validate_design_vars() returns TRUE for empty character vector", {
+  df     <- data.frame(x = 1:3)
+  result <- .validate_design_vars(character(0), df)
+  expect_true(result)
+})
+
+test_that(".validate_design_vars() errors when column not found", {
+  df <- data.frame(x = 1:3, strata = c("a", "b", "c"))
+  expect_error(
+    .validate_design_vars(c("psu", "strata"), df),
+    class = "surveycore_error_design_var_missing"
+  )
+})
+
+test_that(".validate_design_vars() errors when multiple columns not found", {
+  df <- data.frame(x = 1:3)
+  expect_error(
+    .validate_design_vars(c("psu", "strata", "fpc"), df),
+    class = "surveycore_error_design_var_missing"
+  )
+})
+
+test_that(".validate_design_vars() errors when column is a list-column", {
+  df      <- data.frame(x = 1:3)
+  df$psu  <- list(1, 2, 3)
+  expect_error(
+    .validate_design_vars("psu", df),
+    class = "surveycore_error_design_var_list"
+  )
+})
+
+test_that(".validate_design_vars() checks existence before list-column check", {
+  # A missing column should give design_var_missing, not design_var_list
+  df <- data.frame(x = 1:3)
+  expect_error(
+    .validate_design_vars("psu", df),
+    class = "surveycore_error_design_var_missing"
+  )
+})
+
+
+# ── .validate_fpc ─────────────────────────────────────────────────────────────
+
+test_that(".validate_fpc() returns TRUE for valid FPC column", {
+  df     <- data.frame(x = 1:3, fpc = c(1000L, 1000L, 1000L))
+  result <- .validate_fpc("fpc", df)
+  expect_true(result)
+})
+
+test_that(".validate_fpc() returns TRUE for NULL fpc_var", {
+  df     <- data.frame(x = 1:3)
+  result <- .validate_fpc(NULL, df)
+  expect_true(result)
+})
+
+test_that(".validate_fpc() errors when FPC column not found", {
+  df <- data.frame(x = 1:3)
+  expect_error(
+    .validate_fpc("fpc", df),
+    class = "surveycore_error_design_var_missing"
+  )
+})
+
+test_that(".validate_fpc() errors when FPC column contains NA", {
+  df <- data.frame(x = 1:3, fpc = c(1000L, NA_integer_, 1000L))
+  expect_error(
+    .validate_fpc("fpc", df),
+    class = "surveycore_error_fpc_na"
+  )
+})
+
+test_that(".validate_fpc() errors when all FPC values are NA", {
+  df <- data.frame(
+    x   = 1:3,
+    fpc = c(NA_integer_, NA_integer_, NA_integer_)
+  )
+  expect_error(
+    .validate_fpc("fpc", df),
+    class = "surveycore_error_fpc_na"
+  )
+})
+
+
+# ── .validate_repweights ───────────────────────────────────────────────────────
+
+test_that(".validate_repweights() returns TRUE for valid numeric repweights", {
+  df     <- make_survey_data(n = 100, n_psu = 10, design = "replicate", seed = 1L)
+  rw_cols <- paste0("repwt_", seq_len(5))
+  result  <- .validate_repweights(rw_cols, df)
+  expect_true(result)
+})
+
+test_that(".validate_repweights() returns TRUE for NULL repweights_vars", {
+  df     <- data.frame(x = 1:3)
+  result <- .validate_repweights(NULL, df)
+  expect_true(result)
+})
+
+test_that(".validate_repweights() returns TRUE for empty repweights_vars", {
+  df     <- data.frame(x = 1:3)
+  result <- .validate_repweights(character(0), df)
+  expect_true(result)
+})
+
+test_that(".validate_repweights() errors when repweight column not found", {
+  df <- data.frame(x = 1:3, repwt_1 = c(1.0, 1.1, 0.9))
+  expect_error(
+    .validate_repweights(c("repwt_1", "repwt_2"), df),
+    class = "surveycore_error_design_var_missing"
+  )
+})
+
+test_that(".validate_repweights() errors when repweight column is not numeric", {
+  df <- data.frame(
+    x      = 1:3,
+    repwt_1 = c("a", "b", "c"),
+    repwt_2 = c(1.0, 1.1, 0.9)
+  )
+  expect_error(
+    .validate_repweights(c("repwt_1", "repwt_2"), df),
+    class = "surveycore_error_repweights_not_numeric"
+  )
+})
+
+
+# ── .validate_psu_strata ───────────────────────────────────────────────────────
+
+test_that(".validate_psu_strata() returns TRUE when no PSU-stratum overlap", {
+  # Each PSU appears in exactly one stratum
+  df <- data.frame(
+    psu    = c("p1", "p1", "p2", "p2", "p3", "p3"),
+    strata = c("s1", "s1", "s1", "s1", "s2", "s2")
+  )
+  result <- .validate_psu_strata("psu", "strata", df)
+  expect_true(result)
+})
+
+test_that(".validate_psu_strata() returns TRUE for NULL ids", {
+  df     <- data.frame(psu = 1:3, strata = c("a", "b", "c"))
+  result <- .validate_psu_strata(NULL, "strata", df)
+  expect_true(result)
+})
+
+test_that(".validate_psu_strata() returns TRUE for NULL strata", {
+  df     <- data.frame(psu = 1:3, strata = c("a", "b", "c"))
+  result <- .validate_psu_strata("psu", NULL, df)
+  expect_true(result)
+})
+
+test_that(".validate_psu_strata() warns when PSU appears in multiple strata", {
+  # PSU "p1" appears in both "s1" and "s2"
+  df <- data.frame(
+    psu    = c("p1", "p1", "p2", "p2"),
+    strata = c("s1", "s2", "s1", "s1")
+  )
+  expect_warning(
+    .validate_psu_strata("psu", "strata", df),
+    class = "surveycore_warning_psu_multi_strata"
+  )
+})
+
+test_that(".validate_psu_strata() still returns TRUE after warning", {
+  df <- data.frame(
+    psu    = c("p1", "p1", "p2"),
+    strata = c("s1", "s2", "s1")
+  )
+  result <- suppressWarnings(
+    .validate_psu_strata("psu", "strata", df)
+  )
+  expect_true(result)
+})
+
+
+# ── .validate_rscales ─────────────────────────────────────────────────────────
+
+test_that(".validate_rscales() returns TRUE for correct-length rscales", {
+  result <- .validate_rscales(rep(1, 10), n_rep = 10L)
+  expect_true(result)
+})
+
+test_that(".validate_rscales() returns TRUE for NULL rscales", {
+  result <- .validate_rscales(NULL, n_rep = 10L)
+  expect_true(result)
+})
+
+test_that(".validate_rscales() errors when rscales length mismatches n_rep", {
+  expect_error(
+    .validate_rscales(rep(1, 5), n_rep = 10L),
+    class = "surveycore_error_rscales_length"
+  )
+})
+
+test_that(".validate_rscales() errors for length too long", {
+  expect_error(
+    .validate_rscales(rep(1, 15), n_rep = 10L),
+    class = "surveycore_error_rscales_length"
+  )
+})
+
+
+# ── .update_design_var_names ───────────────────────────────────────────────────
+#
+# These tests work on the @variables list directly (not on a full survey object)
+# because the rename operation requires atomic reconstruction: @data and
+# @variables must be consistent at the moment the S7 validator fires. The
+# helper returns an updated list; the rename method is responsible for
+# combining the new list with new @data in a fresh constructor call.
+
+test_that(".update_design_var_names() renames weights in a variables list", {
+  vars <- list(
+    ids           = NULL,
+    weights       = "old_wt",
+    strata        = NULL,
+    fpc           = NULL,
+    nest          = FALSE,
+    probs_provided = FALSE
+  )
+  result <- .update_design_var_names(vars, c(old_wt = "weight"))
+  expect_identical(result$weights, "weight")
+})
+
+test_that(".update_design_var_names() renames strata and fpc in a variables list", {
+  vars <- list(
+    ids           = NULL,
+    weights       = "wt",
+    strata        = "old_st",
+    fpc           = "old_fp",
+    nest          = FALSE,
+    probs_provided = FALSE
+  )
+  result <- .update_design_var_names(vars, c(old_st = "strata", old_fp = "fpc"))
+  expect_identical(result$strata, "strata")
+  expect_identical(result$fpc, "fpc")
+})
+
+test_that(".update_design_var_names() renames ids in a variables list", {
+  vars <- list(
+    ids           = c("old_psu", "old_ssu"),
+    weights       = "wt",
+    strata        = NULL,
+    fpc           = NULL,
+    nest          = FALSE,
+    probs_provided = FALSE
+  )
+  result <- .update_design_var_names(vars, c(old_psu = "psu"))
+  expect_identical(result$ids, c("psu", "old_ssu"))
+})
+
+test_that(".update_design_var_names() renames repweights in a variables list", {
+  vars <- list(
+    weights    = "wt",
+    repweights = c("repwt_1", "repwt_2", "repwt_3"),
+    type       = "BRR",
+    scale      = 1,
+    rscales    = NULL,
+    fpc        = NULL,
+    fpctype    = "fraction",
+    mse        = TRUE
+  )
+  result <- .update_design_var_names(vars, c(repwt_1 = "rep_1"))
+  expect_true("rep_1" %in% result$repweights)
+  expect_false("repwt_1" %in% result$repweights)
+  # Other repweights unchanged
+  expect_true("repwt_2" %in% result$repweights)
+})
+
+test_that(".update_design_var_names() leaves unmatched columns unchanged", {
+  vars <- list(
+    ids           = NULL,
+    weights       = "wt",
+    strata        = "stratum",
+    fpc           = NULL,
+    nest          = FALSE,
+    probs_provided = FALSE
+  )
+  # Rename a non-design column — nothing in @variables should change
+  result <- .update_design_var_names(vars, c(outcome_y = "y"))
+  expect_identical(result$weights, "wt")
+  expect_identical(result$strata, "stratum")
+})
+
+
+# ── .rename_metadata_keys ─────────────────────────────────────────────────────
+
+test_that(".rename_metadata_keys() renames variable_labels keys", {
+  m <- survey_metadata(
+    variable_labels = list(old_age = "Age in years", income = "Annual income")
+  )
+  m2 <- .rename_metadata_keys(m, c(old_age = "age"))
+  expect_true("age" %in% names(m2@variable_labels))
+  expect_false("old_age" %in% names(m2@variable_labels))
+  expect_identical(m2@variable_labels[["age"]], "Age in years")
+})
+
+test_that(".rename_metadata_keys() renames value_labels keys", {
+  m <- survey_metadata(
+    value_labels = list(old_sex = c(Male = 1L, Female = 2L))
+  )
+  m2 <- .rename_metadata_keys(m, c(old_sex = "sex"))
+  expect_true("sex" %in% names(m2@value_labels))
+  expect_false("old_sex" %in% names(m2@value_labels))
+})
+
+test_that(".rename_metadata_keys() renames keys in all metadata slots", {
+  m <- survey_metadata(
+    variable_labels   = list(old_y = "Outcome"),
+    value_labels      = list(old_y = c(No = 0L, Yes = 1L)),
+    question_prefaces = list(old_y = "For each item..."),
+    notes             = list(old_y = "Analyst note")
+  )
+  m2 <- .rename_metadata_keys(m, c(old_y = "y"))
+  expect_true("y" %in% names(m2@variable_labels))
+  expect_true("y" %in% names(m2@value_labels))
+  expect_true("y" %in% names(m2@question_prefaces))
+  expect_true("y" %in% names(m2@notes))
+})
+
+test_that(".rename_metadata_keys() leaves unmatched keys unchanged", {
+  m <- survey_metadata(
+    variable_labels = list(age = "Age in years", income = "Annual income")
+  )
+  m2 <- .rename_metadata_keys(m, c(age = "respondent_age"))
+  expect_true("respondent_age" %in% names(m2@variable_labels))
+  expect_true("income" %in% names(m2@variable_labels))
+  expect_false("age" %in% names(m2@variable_labels))
+})
+
+test_that(".rename_metadata_keys() handles empty metadata without error", {
+  m      <- survey_metadata()
+  result <- .rename_metadata_keys(m, c(x = "y"))
+  expect_true(S7::S7_inherits(result, survey_metadata))
+  expect_identical(length(result@variable_labels), 0L)
+})


### PR DESCRIPTION
## What

Implements all Layer 2 validator helpers in `R/02-validators.R` plus a comprehensive test suite (`tests/testthat/test-validators.R`). This is build step 4 in the Phase 0 sequence.

## Functions added

| Helper | Validates |
|--------|-----------|
| `.validate_weights()` | column existence, numeric, not all-zero/missing, all positive |
| `.validate_design_vars()` | all columns exist, no list-columns |
| `.validate_fpc()` | column existence, no NAs |
| `.validate_repweights()` | all columns exist, all numeric |
| `.validate_psu_strata()` | warns when PSU appears in > 1 stratum |
| `.validate_rscales()` | length matches number of replicate weights |
| `.update_design_var_names()` | updates `@variables` list after a column rename |
| `.rename_metadata_keys()` | updates metadata keys after a column rename |

**Design note:** `.update_design_var_names()` takes a `variables` list (not the full survey object) so rename methods can reconstruct the object atomically — avoiding intermediate S7 validator failures when `@data` and `@variables` would be briefly inconsistent.

## Checklist

- [x] Tests written and passing (`devtools::test()`) — 57 tests, 0 failures
- [x] R CMD check: 0 errors, 0 warnings (`devtools::check()`) — 2 pre-existing notes
- [x] Roxygen docs updated and `devtools::document()` run
- [x] `plans/error-messages.md` updated (if new errors/warnings added) — no new entries; uses existing classes
- [x] PR title is a valid Conventional Commit (`feat(scope): description`)