### PR TITLE
feat(constructors): export as_survey_calibrated() with print/summary and variance dispatch fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Suggests:
     srvyr (>= 1.0),
     haven (>= 2.5.0),
     dplyr (>= 1.1.0),
+    lifecycle (>= 1.0.0),
     covr,
     knitr,
     rmarkdown

--- a/R/03-constructors.R
+++ b/R/03-constructors.R
@@ -979,6 +979,8 @@ as_survey_twophase <- function(
 
 #' Create a Calibrated / Non-Probability Survey Design
 #'
+#' `r lifecycle::badge("experimental")`
+#'
 #' Creates a survey design object for non-probability samples and post-hoc
 #' calibrated designs (e.g., raked online panels, post-stratified samples).
 #' Accepts pre-computed calibration weights and optionally stores calibration
@@ -1042,7 +1044,6 @@ as_survey_twophase <- function(
 #'   [as_survey_rep()] for replicate-weight designs
 #'
 #' @family constructors
-#' @keywords internal
 #' @export
 as_survey_calibrated <- function(
   data,

--- a/R/04-methods-print.R
+++ b/R/04-methods-print.R
@@ -419,6 +419,124 @@ S7::method(print, survey_twophase) <- function(
 }
 
 
+# ── print.survey_calibrated ───────────────────────────────────────────────
+
+# Print a Calibrated / Non-Probability Survey Design
+#
+# @param x A survey_calibrated object.
+# @param n Maximum number of data rows to print. Default 10L.
+# @param design_info Show design specification section?
+# @param weights_info Show weight distribution statistics?
+# @param metadata_info Show metadata summary?
+# @param full If TRUE, show all sections.
+# @param ... Passed to tibble print.
+# @return x, invisibly.
+# Class defined in R/00-s7-classes.R
+S7::method(print, survey_calibrated) <- function(
+  x,
+  n             = 10L,
+  design_info   = FALSE,
+  weights_info  = FALSE,
+  metadata_info = FALSE,
+  full          = FALSE,
+  ...
+) {
+  if (full) {
+    design_info <- weights_info <- metadata_info <- TRUE
+  }
+
+  # ── Header ────────────────────────────────────────────────────────────────
+  cli::cli_h1("Survey Design")
+  cli::cli_text("{.cls survey_calibrated} (calibrated / non-probability) [experimental]")
+  cli::cli_text("Sample size: {.val {nrow(x@data)}}")
+
+  if (length(x@groups) > 0L) {
+    cli::cli_text("Groups: {.field {x@groups}}")
+  }
+
+  if (weights_info) {
+    wts        <- x@data[[x@variables$weights]]
+    weighted_n <- round(sum(wts, na.rm = TRUE))
+    cli::cli_text("Weighted N: {.val {weighted_n}}")
+  }
+
+  # ── Design specification ──────────────────────────────────────────────────
+  if (design_info) {
+    cli::cli_text("")
+    cli::cli_h2("Design specification")
+
+    wts_var <- x@variables$weights
+    cli::cli_bullets(c("*" = "Weights: {.field {wts_var}}"))
+
+    cal_label <- if (!is.null(x@calibration)) "stored" else "none stored"
+    cli::cli_bullets(c("*" = "Calibration provenance: {cal_label}"))
+
+    cli::cli_text("")
+    cli::cli_text("Design variables: {.field {wts_var}}")
+  }
+
+  # ── Weight distribution ───────────────────────────────────────────────────
+  if (weights_info) {
+    wts <- x@data[[x@variables$weights]]
+    cli::cli_text("")
+    cli::cli_h2("Weight distribution")
+    .print_weight_distribution(wts)
+  }
+
+  # ── Metadata ──────────────────────────────────────────────────────────────
+  if (metadata_info) {
+    n_labeled <- length(x@metadata@variable_labels)
+    cli::cli_text("")
+    cli::cli_h2("Metadata")
+    cli::cli_text("{n_labeled} variable(s) labeled")
+  }
+
+  # ── Data ──────────────────────────────────────────────────────────────────
+  cli::cli_text("")
+  data_shown <- .data_for_print(x)
+  print(data_shown, n = n, ...)
+
+  .print_hidden_note(x@variables$weights, data_shown)
+
+  invisible(x)
+}
+
+
+# ── summary.survey_calibrated ─────────────────────────────────────────────
+
+# Summarise a Calibrated / Non-Probability Survey Design
+# @param object A survey_calibrated object.
+# @return object, invisibly.
+# Class defined in R/00-s7-classes.R
+S7::method(summary, survey_calibrated) <- function(object, ...) {
+  x <- object
+
+  cli::cli_h1("Survey Design Summary")
+  cli::cli_text("Type: calibrated / non-probability [experimental]")
+  cli::cli_text("Sample size: {.val {nrow(x@data)}}")
+
+  wts_var    <- x@variables$weights
+  wts        <- x@data[[wts_var]]
+  weighted_n <- round(sum(wts, na.rm = TRUE))
+  cli::cli_text("Weighted N: {.val {weighted_n}}")
+
+  cli::cli_text("")
+  cli::cli_h2("Design")
+  cli::cli_text("Weights: {.field {wts_var}}")
+  .print_weight_distribution(wts)
+
+  cal_label <- if (!is.null(x@calibration)) "stored" else "none stored"
+  cli::cli_text("Calibration provenance: {cal_label}")
+
+  cli::cli_text("")
+  n_labeled <- length(x@metadata@variable_labels)
+  n_total   <- ncol(x@data)
+  cli::cli_text("Metadata: {n_labeled} of {n_total} variable(s) labeled")
+
+  invisible(x)
+}
+
+
 # ── summary.survey_taylor ──────────────────────────────────────────────────
 
 # Summarise a Taylor Series Survey Design

--- a/R/06-variance-estimation.R
+++ b/R/06-variance-estimation.R
@@ -498,10 +498,12 @@ get_means <- function(design, var, na.rm = TRUE) {
     )
   }
 
-  result <- if (S7::S7_inherits(design, survey_taylor)) {
-    .taylor_mean(design, var_name, na.rm = na.rm)
-  } else {
+  # survey_replicate → replicate variance
+  # survey_taylor and survey_calibrated → Taylor/SRS variance
+  result <- if (S7::S7_inherits(design, survey_replicate)) {
     .replicate_mean(design, var_name, na.rm = na.rm)
+  } else {
+    .taylor_mean(design, var_name, na.rm = na.rm)
   }
   list(variable = var_name, mean = result$mean, se = result$se)
 }
@@ -575,10 +577,12 @@ get_totals <- function(design, var, na.rm = TRUE) {
     )
   }
 
-  result <- if (S7::S7_inherits(design, survey_taylor)) {
-    .taylor_total(design, var_name, na.rm = na.rm)
-  } else {
+  # survey_replicate → replicate variance
+  # survey_taylor and survey_calibrated → Taylor/SRS variance
+  result <- if (S7::S7_inherits(design, survey_replicate)) {
     .replicate_total(design, var_name, na.rm = na.rm)
+  } else {
+    .taylor_total(design, var_name, na.rm = na.rm)
   }
   list(variable = var_name, total = result$total, se = result$se)
 }

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -40,6 +40,7 @@ reference:
       - as_survey
       - as_survey_rep
       - as_survey_twophase
+      - as_survey_calibrated
       - update_design
 
   - title: "Estimation"
@@ -90,6 +91,7 @@ reference:
       - survey_taylor
       - survey_replicate
       - survey_twophase
+      - survey_calibrated
       - survey_metadata
 
   - title: "Utilities"

--- a/man/as_survey_calibrated.Rd
+++ b/man/as_survey_calibrated.Rd
@@ -27,6 +27,9 @@ be formally specified in Phase 2.5.}
 A \code{survey_calibrated} object.
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+}
+\details{
 Creates a survey design object for non-probability samples and post-hoc
 calibrated designs (e.g., raked online panels, post-stratified samples).
 Accepts pre-computed calibration weights and optionally stores calibration
@@ -91,4 +94,3 @@ Other constructors:
 \code{\link{survey_twophase}()}
 }
 \concept{constructors}
-\keyword{internal}

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -215,3 +215,52 @@
       Error in `as_survey_twophase()`:
       x `subset` column all_true must contain both TRUE and FALSE values. Found 200 TRUE out of 200 rows.
 
+# as_survey_calibrated() rejects non-data-frame input
+
+    Code
+      as_survey_calibrated(list(y = 1:10, w = rep(1, 10)), weights = w)
+    Condition
+      Error in `as_survey_calibrated()`:
+      x `data` must be a data frame, not <list>
+
+# as_survey_calibrated() rejects empty data
+
+    Code
+      as_survey_calibrated(empty, weights = w)
+    Condition
+      Error in `as_survey_calibrated()`:
+      x `data` must have at least one row
+
+# as_survey_calibrated() rejects duplicate column names
+
+    Code
+      as_survey_calibrated(df, weights = w)
+    Condition
+      Error in `as_survey_calibrated()`:
+      x Column names in `data` must be unique. Duplicates: w
+
+# as_survey_calibrated() rejects missing weights argument
+
+    Code
+      as_survey_calibrated(df)
+    Condition
+      Error in `as_survey_calibrated()`:
+      x `weights` is required for `as_survey_calibrated()`.
+      i Supply the column name of your calibration weight variable (e.g., `weights = cal_wt`).
+
+# as_survey_calibrated() rejects weights selecting multiple columns
+
+    Code
+      as_survey_calibrated(df, weights = c(w1, w2))
+    Condition
+      Error in `as_survey_calibrated()`:
+      x `weights` must select exactly 1 column, not 2
+
+# as_survey_calibrated() rejects non-positive weights
+
+    Code
+      as_survey_calibrated(df, weights = w)
+    Condition
+      Error in `.validate_weights()`:
+      x Weight column w has 1 non-positive value(s). All non-NA weights must be > 0.
+

--- a/tests/testthat/helper-test-data.R
+++ b/tests/testthat/helper-test-data.R
@@ -164,16 +164,62 @@ make_survey_data <- function(
 # test_invariants()
 # ------------------------------------------------------------------------------
 
-#' Assert all 5 formal invariants on a survey object
+#' Assert all formal invariants on a survey object
 #'
 #' Call this at the start of EVERY test_that() block that creates or modifies
 #' a survey object. Checks all invariants from formal spec Section I.
 #'
-#' @param design A survey_taylor, survey_replicate, or survey_twophase object.
+#' @param design A survey_taylor, survey_replicate, survey_twophase, or
+#'   survey_calibrated object.
 #' @return Returns design invisibly on success. Throws testthat failure on any
 #'   violated invariant.
 #' @keywords internal
 test_invariants <- function(design) {
+
+  # survey_calibrated has a different @variables structure — handle separately
+  if (S7::S7_inherits(design, survey_calibrated)) {
+    testthat::expect_true(is.data.frame(design@data))
+    testthat::expect_false(is.null(design@data))
+    testthat::expect_gte(nrow(design@data), 1L)
+    testthat::expect_false(
+      anyDuplicated(names(design@data)) > 0L,
+      label = "@data has no duplicate column names"
+    )
+
+    testthat::expect_true(
+      "weights" %in% names(design@variables),
+      label = "@variables has 'weights' key"
+    )
+    testthat::expect_true(
+      "probs_provided" %in% names(design@variables),
+      label = "@variables has 'probs_provided' key"
+    )
+
+    wt_var <- design@variables$weights
+    if (!is.null(wt_var)) {
+      testthat::expect_true(
+        wt_var %in% names(design@data),
+        label = paste0("weight column '", wt_var, "' present in @data")
+      )
+      wt_col <- design@data[[wt_var]]
+      testthat::expect_true(is.numeric(wt_col), label = "weight column is numeric")
+      testthat::expect_true(
+        all(wt_col[!is.na(wt_col)] > 0),
+        label = "weight column has all positive values"
+      )
+    }
+
+    testthat::expect_true(S7::S7_inherits(design@metadata, survey_metadata))
+    meta_vars <- names(design@metadata@variable_labels)
+    if (length(meta_vars) > 0L) {
+      testthat::expect_true(
+        all(meta_vars %in% names(design@data)),
+        label = "all metadata-labelled vars present in @data"
+      )
+    }
+
+    return(invisible(design))
+  }
   # Invariant 1: @data is a non-NULL data.frame with >= 1 row, no duplicate names
   testthat::expect_true(is.data.frame(design@data))
   testthat::expect_false(is.null(design@data))

--- a/tests/testthat/test-constructors.R
+++ b/tests/testthat/test-constructors.R
@@ -1293,3 +1293,186 @@ test_that("as_survey_rep() validates fpc column for NAs", {
     class = "surveycore_error_fpc_na"
   )
 })
+
+
+# ==============================================================================
+# as_survey_calibrated() tests
+# ==============================================================================
+
+# ── Happy paths ────────────────────────────────────────────────────────────────
+
+test_that("as_survey_calibrated() creates a survey_calibrated object", {
+  df <- data.frame(y = rnorm(100), cal_wt = runif(100, 0.5, 2))
+  d  <- as_survey_calibrated(df, weights = cal_wt)
+  test_invariants(d)
+  expect_true(S7::S7_inherits(d, survey_calibrated))
+  expect_equal(d@variables$weights, "cal_wt")
+})
+
+test_that("as_survey_calibrated() stores calibration provenance object", {
+  df  <- data.frame(y = rnorm(50), w = runif(50, 1, 3))
+  cal <- list(targets = list(age = c(0.3, 0.4, 0.3)), method = "raking")
+  d   <- as_survey_calibrated(df, weights = w, calibration = cal)
+  test_invariants(d)
+  expect_identical(d@calibration, cal)
+})
+
+test_that("as_survey_calibrated() calibration is NULL when not supplied", {
+  df <- data.frame(y = 1:20, w = rep(1, 20))
+  d  <- as_survey_calibrated(df, weights = w)
+  test_invariants(d)
+  expect_null(d@calibration)
+})
+
+test_that("as_survey_calibrated() extracts haven variable labels", {
+  df    <- data.frame(y = 1:50, w = rep(1, 50))
+  attr(df$y, "label") <- "Outcome variable"
+  d     <- as_survey_calibrated(df, weights = w)
+  test_invariants(d)
+  expect_equal(d@metadata@variable_labels[["y"]], "Outcome variable")
+})
+
+test_that("as_survey_calibrated() is a subclass of survey_base", {
+  df <- data.frame(y = 1:30, w = rep(1.5, 30))
+  d  <- as_survey_calibrated(df, weights = w)
+  test_invariants(d)
+  expect_true(S7::S7_inherits(d, survey_base))
+})
+
+# ── @variables structure ───────────────────────────────────────────────────────
+
+test_that("as_survey_calibrated() @variables has weights and probs_provided keys", {
+  df <- data.frame(y = 1:10, w = rep(2, 10))
+  d  <- as_survey_calibrated(df, weights = w)
+  expect_true("weights"        %in% names(d@variables))
+  expect_true("probs_provided" %in% names(d@variables))
+})
+
+test_that("as_survey_calibrated() @variables$probs_provided is always FALSE", {
+  df <- data.frame(y = 1:10, w = rep(2, 10))
+  d  <- as_survey_calibrated(df, weights = w)
+  expect_false(d@variables$probs_provided)
+})
+
+# ── Error paths ────────────────────────────────────────────────────────────────
+
+test_that("as_survey_calibrated() rejects non-data-frame input", {
+  expect_error(
+    as_survey_calibrated(list(y = 1:10, w = rep(1, 10)), weights = w),
+    class = "surveycore_error_not_data_frame"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey_calibrated(list(y = 1:10, w = rep(1, 10)), weights = w)
+  )
+})
+
+test_that("as_survey_calibrated() rejects empty data", {
+  empty <- data.frame(y = numeric(0), w = numeric(0))
+  expect_error(
+    as_survey_calibrated(empty, weights = w),
+    class = "surveycore_error_empty_data"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey_calibrated(empty, weights = w)
+  )
+})
+
+test_that("as_survey_calibrated() rejects duplicate column names", {
+  df <- data.frame(y = 1:5, w = rep(1, 5), w = rep(2, 5), check.names = FALSE)
+  expect_error(
+    as_survey_calibrated(df, weights = w),
+    class = "surveycore_error_duplicate_names"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey_calibrated(df, weights = w)
+  )
+})
+
+test_that("as_survey_calibrated() rejects missing weights argument", {
+  df <- data.frame(y = 1:10, w = rep(1, 10))
+  expect_error(
+    as_survey_calibrated(df),
+    class = "surveycore_error_weights_missing"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey_calibrated(df)
+  )
+})
+
+test_that("as_survey_calibrated() rejects weights selecting multiple columns", {
+  df <- data.frame(y = 1:10, w1 = rep(1, 10), w2 = rep(1, 10))
+  expect_error(
+    as_survey_calibrated(df, weights = c(w1, w2)),
+    class = "surveycore_error_weights_multiple"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey_calibrated(df, weights = c(w1, w2))
+  )
+})
+
+test_that("as_survey_calibrated() rejects non-positive weights", {
+  df <- data.frame(y = 1:5, w = c(1, 0, 1, 1, 1))
+  expect_error(
+    as_survey_calibrated(df, weights = w),
+    class = "surveycore_error_weights_nonpositive"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey_calibrated(df, weights = w)
+  )
+})
+
+# ── Warning paths ──────────────────────────────────────────────────────────────
+
+test_that("as_survey_calibrated() warns for single-row data", {
+  df <- data.frame(y = 1, w = 1)
+  expect_warning(
+    result <- as_survey_calibrated(df, weights = w),
+    class = "surveycore_warning_single_row"
+  )
+  expect_true(S7::S7_inherits(result, survey_calibrated))
+})
+
+# ── Estimation ─────────────────────────────────────────────────────────────────
+
+test_that("get_means() returns SRS-based estimate for survey_calibrated", {
+  df <- data.frame(y = c(1, 2, 3, 4, 5), w = c(2, 1, 2, 1, 2))
+  d  <- as_survey_calibrated(df, weights = w)
+  result <- get_means(d, y)
+  expect_equal(result$variable, "y")
+  expect_true(is.numeric(result$mean))
+  expect_true(is.numeric(result$se))
+  expect_true(result$se >= 0)
+})
+
+test_that("get_totals() returns SRS-based estimate for survey_calibrated", {
+  df <- data.frame(y = c(1, 2, 3, 4, 5), w = c(2, 1, 2, 1, 2))
+  d  <- as_survey_calibrated(df, weights = w)
+  result <- get_totals(d, y)
+  expect_equal(result$variable, "y")
+  expect_true(is.numeric(result$total))
+  expect_true(is.numeric(result$se))
+})
+
+# ── Print ──────────────────────────────────────────────────────────────────────
+
+test_that("print() works for survey_calibrated and returns x invisibly", {
+  df  <- data.frame(y = 1:10, w = rep(1, 10))
+  d   <- as_survey_calibrated(df, weights = w)
+  out <- withVisible(print(d))
+  expect_false(out$visible)
+  expect_true(S7::S7_inherits(out$value, survey_calibrated))
+})
+
+test_that("summary() works for survey_calibrated and returns x invisibly", {
+  df  <- data.frame(y = 1:10, w = rep(1, 10))
+  d   <- as_survey_calibrated(df, weights = w)
+  out <- withVisible(summary(d))
+  expect_false(out$visible)
+  expect_true(S7::S7_inherits(out$value, survey_calibrated))
+})


### PR DESCRIPTION
## What

Promotes `as_survey_calibrated()` from internal skeleton to a public experimental API, adds `print()` and `summary()` S7 methods, fixes a variance dispatch crash, and adds 16 test blocks covering the full constructor contract.

## Changes

- **DESCRIPTION**: add `lifecycle (>= 1.0.0)` to `Suggests`
- **R/03-constructors.R**: remove `@keywords internal`; add `lifecycle::badge("experimental")` to the description block
- **R/04-methods-print.R**: add `S7::method(print, survey_calibrated)` and `S7::method(summary, survey_calibrated)` — mirrors the pattern used by the other three design types
- **R/06-variance-estimation.R**: fix dispatch in `get_means()` and `get_totals()` — previous logic branched on `S7_inherits(design, survey_taylor)` and fell through to `.replicate_mean()`/`.replicate_total()` for `survey_calibrated`, crashing on missing `repweights`; new logic branches on `survey_replicate` (positive case) so `survey_calibrated` and `survey_taylor` both reach the Taylor/SRS path
- **_pkgdown.yml**: add `as_survey_calibrated` to constructors section; add `survey_calibrated` to S7 class objects section
- **tests/testthat/helper-test-data.R**: extend `test_invariants()` with a `survey_calibrated` branch that validates the reduced `@variables` structure (`weights` + `probs_provided` only)
- **tests/testthat/test-constructors.R**: 16 new `test_that()` blocks — happy paths, `@variables` structure, error paths (6 error classes), single-row warning, estimation via `get_means()`/`get_totals()`, and `print()`/`summary()` return-value contracts

## Checklist

- [x] Tests written and passing (`devtools::test()`) — 2149/2149
- [x] R CMD check: 0 errors, 0 warnings (`devtools::check()`)
- [x] Roxygen docs updated and `devtools::document()` run
- [x] `plans/error-messages.md` updated (if new errors/warnings added) — no new error classes; existing classes reused
- [x] PR title is a valid Conventional Commit (`feat(scope): description`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)