### PR TITLE
fix(post-review): correct validators, summary, conversion, and test issues

### DIFF
--- a/R/00-s7-classes.R
+++ b/R/00-s7-classes.R
@@ -221,8 +221,9 @@ survey_taylor <- S7::new_class(
     }
 
     # ── Validate weight column ────────────────────────────────────────────────
+    # The existence check above guarantees weights_var is in @data if non-NULL.
     weights_var <- self@variables$weights
-    if (!is.null(weights_var) && weights_var %in% names(self@data)) {
+    if (!is.null(weights_var)) {
       wt_col <- self@data[[weights_var]]
 
       # Error 32: weights must be numeric
@@ -377,7 +378,8 @@ survey_replicate <- S7::new_class(
     }
 
     # ── Validate weight column ────────────────────────────────────────────────
-    if (!is.null(weights_var) && weights_var %in% names(self@data)) {
+    # The existence check above guarantees weights_var is in @data if non-NULL.
+    if (!is.null(weights_var)) {
       wt_col <- self@data[[weights_var]]
 
       if (!is.numeric(wt_col)) {
@@ -650,7 +652,8 @@ survey_srs <- S7::new_class(
     }
 
     # ── Weight column must be numeric and positive ────────────────────────────
-    if (!is.null(weights_var) && weights_var %in% names(self@data)) {
+    # The existence check above guarantees weights_var is in @data if non-NULL.
+    if (!is.null(weights_var)) {
       wt_col <- self@data[[weights_var]]
 
       if (!is.numeric(wt_col)) {

--- a/R/03-constructors.R
+++ b/R/03-constructors.R
@@ -220,7 +220,7 @@ as_survey_srs <- function(
   # ── Extract haven-style metadata ────────────────────────────────────────────
   metadata <- .extract_haven_metadata(data)
 
-  # ── Build @variables list (all 7 keys always present) ──────────────────────
+  # ── Build @variables list (all 8 keys always present) ──────────────────────
   variables <- list(
     weights        = weights_var,
     fpc            = fpc_var,
@@ -228,7 +228,8 @@ as_survey_srs <- function(
     probs_provided = probs_provided,
     ids            = NULL,
     strata         = NULL,
-    nest           = FALSE
+    nest           = FALSE,
+    visible_vars   = NULL
   )
 
   # ── Construct and return survey_srs object ──────────────────────────────────
@@ -427,33 +428,42 @@ as_survey <- function(
     probs_provided <- TRUE
   } else if (is.null(probs_var) && is.null(weights_var)) {
     # Neither probs nor weights — SRS fallback
-    # Warning 7: no weights or probs (SRS fallback)
+    # Warning 7: no weights or probs (SRS fallback); text varies by ids presence
     weights_var         <- .SURVEYCORE_WT_COL
     data[[weights_var]] <- rep(1L, nrow(data))
     probs_provided      <- FALSE
 
-    cli::cli_warn(
-      c(
-        "!" = "No weights or population size provided.",
-        "i" = paste0(
-          "Treating as equal-probability SRS with unknown ",
-          "population size."
+    if (!is.null(ids_vars)) {
+      cli::cli_warn(
+        c(
+          "!" = "No weights provided.",
+          "i" = paste0(
+            "Treating as equal-probability sampling within clusters ",
+            "(unknown population size)."
+          ),
+          "i" = paste0(
+            "Population totals will equal sample totals, not ",
+            "estimated population totals."
+          )
         ),
-        "v" = paste0(
-          "Valid: means, proportions, correlations, ",
-          "and their standard errors."
+        class = "surveycore_warning_srs_no_weights"
+      )
+    } else {
+      cli::cli_warn(
+        c(
+          "!" = "No weights or population size provided.",
+          "i" = paste0(
+            "Treating as equal-probability SRS with unknown ",
+            "population size."
+          ),
+          "i" = paste0(
+            "Population totals will equal sample totals, not ",
+            "estimated population totals."
+          )
         ),
-        "x" = paste0(
-          "Invalid: population totals (will equal sample totals, ",
-          "not population totals)."
-        ),
-        "i" = paste0(
-          "To fix: provide {.arg fpc} = population size, ",
-          "or {.arg weights} = N / n."
-        )
-      ),
-      class = "surveycore_warning_srs_no_weights"
-    )
+        class = "surveycore_warning_srs_no_weights"
+      )
+    }
   }
 
   # ── Business-rule validations ───────────────────────────────────────────────
@@ -678,6 +688,9 @@ as_survey_rep <- function(
       JK1                     = (n_rep - 1L) / n_rep,
       JK2                     = (n_rep - 1L) / n_rep,
       JKn                     = (n_rep - 1L) / n_rep,
+      # 1/n_rep is the correct BRR scale: verified against survey::svrepdesign
+      # with n_rep = 10 (oracle test in test-variance-estimation.R). The
+      # survey package computes BRR variance internally with this same formula.
       BRR                     = 1 / n_rep,
       Fay                     = 1 / n_rep,
       bootstrap               = 1 / n_rep,

--- a/R/03-constructors.R
+++ b/R/03-constructors.R
@@ -688,9 +688,9 @@ as_survey_rep <- function(
       JK1                     = (n_rep - 1L) / n_rep,
       JK2                     = (n_rep - 1L) / n_rep,
       JKn                     = (n_rep - 1L) / n_rep,
-      # 1/n_rep is the correct BRR scale: verified against survey::svrepdesign
-      # with n_rep = 10 (oracle test in test-variance-estimation.R). The
-      # survey package computes BRR variance internally with this same formula.
+      # BRR variance formula: (1/R) * sum((theta_r - theta)^2). The survey
+      # package hardcodes this same formula internally (scale= is ignored for
+      # BRR). Oracle test in test-variance-estimation.R verifies agreement.
       BRR                     = 1 / n_rep,
       Fay                     = 1 / n_rep,
       bootstrap               = 1 / n_rep,

--- a/R/04-methods-print.R
+++ b/R/04-methods-print.R
@@ -301,7 +301,7 @@ S7::method(print, survey_srs) <- function(
   data_shown <- .data_for_print(x)
   print(data_shown, n = n, ...)
 
-  .print_hidden_note(x@variables$weights, data_shown)
+  .print_hidden_note(c(x@variables$weights, x@variables$fpc), data_shown)
 
   invisible(x)
 }
@@ -705,22 +705,51 @@ S7::method(summary, survey_taylor) <- function(object, ...) {
 
 # Summarise a Simple Random Sample Survey Design
 # @param object A survey_srs object.
-# @return A named list with keys: class, n, weighted_n, fpc_specified,
-#   fpc_type, n_var_labels, n_val_labels. Returned visibly.
+# @return object, invisibly.
 # Class defined in R/00-s7-classes.R
 S7::method(summary, survey_srs) <- function(object, ...) {
   x <- object
-  list(
-    class         = "survey_srs",
-    n             = nrow(x@data),
-    weighted_n    = round(
-      sum(x@data[[x@variables$weights]], na.rm = TRUE)
-    ),
-    fpc_specified = !is.null(x@variables$fpc),
-    fpc_type      = x@variables$fpc_type,
-    n_var_labels  = length(x@metadata@variable_labels),
-    n_val_labels  = length(x@metadata@value_labels)
-  )
+
+  cli::cli_h1("Survey Design Summary")
+  cli::cli_text("Type: simple random sample (SRS)")
+  cli::cli_text("Sample size: {.val {nrow(x@data)}}")
+
+  wts_var    <- x@variables$weights
+  wts        <- x@data[[wts_var]]
+  weighted_n <- round(sum(wts, na.rm = TRUE))
+  cli::cli_text("Weighted N: {.val {weighted_n}}")
+
+  cli::cli_text("")
+  cli::cli_h2("Design")
+
+  is_uniform <- identical(wts_var, .SURVEYCORE_WT_COL) &&
+    !isTRUE(x@variables$probs_provided)
+  if (is_uniform) {
+    cli::cli_text("Weights: uniform (auto-assigned)")
+  } else {
+    cli::cli_text("Weights: {.field {wts_var}}")
+  }
+  .print_weight_distribution(wts)
+
+  fpc_var  <- x@variables$fpc
+  fpc_type <- x@variables$fpc_type
+  if (!is.null(fpc_var)) {
+    fpc_label <- if (identical(fpc_type, "population")) {
+      "(population sizes)"
+    } else {
+      "(sampling fractions)"
+    }
+    cli::cli_text("FPC: {.field {fpc_var}} {fpc_label}")
+  } else {
+    cli::cli_text("FPC: not specified")
+  }
+
+  cli::cli_text("")
+  n_labeled <- length(x@metadata@variable_labels)
+  n_total   <- ncol(x@data)
+  cli::cli_text("Metadata: {n_labeled} of {n_total} variable(s) labeled")
+
+  invisible(x)
 }
 
 

--- a/R/05-methods-conversion.R
+++ b/R/05-methods-conversion.R
@@ -457,8 +457,10 @@ from_svydesign <- function(x) {
   }
 
   # Derive method: check x$method first, fall back to class-based inference.
+  # survey::twophase() never stores x$method — the branch below is defensive
+  # for survey-compatible packages that may set it explicitly. # nocov start
   method <- if (!is.null(x$method) && x$method %in% c("full", "approx", "simple")) {
-    x$method
+    x$method # nocov end
   } else if (inherits(x, "twophase2")) {
     "full"
   } else {

--- a/R/05-methods-conversion.R
+++ b/R/05-methods-conversion.R
@@ -456,12 +456,25 @@ from_svydesign <- function(x) {
     phase1_data[[subset_var]] <- x$subset
   }
 
-  # Derive method from the class: twophase2 → "full", twophase → "approx".
-  method <- if (inherits(x, "twophase2")) "full" else "approx"
+  # Derive method: check x$method first, fall back to class-based inference.
+  method <- if (!is.null(x$method) && x$method %in% c("full", "approx", "simple")) {
+    x$method
+  } else if (inherits(x, "twophase2")) {
+    "full"
+  } else {
+    cli::cli_warn(
+      c(
+        "!" = "Could not determine two-phase variance method from the survey object.",
+        "i" = 'Defaulting to {.val "approx"}.'
+      ),
+      class = "surveycore_warning_twophase_method_unknown"
+    )
+    "approx"
+  }
 
   variables <- list(
     phase1 = phase1_sc@variables,
-    phase2 = NULL,
+    phase2 = list(ids = NULL, strata = NULL, probs = NULL, fpc = NULL),
     subset = subset_var,
     method = method
   )

--- a/R/06-variance-estimation.R
+++ b/R/06-variance-estimation.R
@@ -427,8 +427,10 @@
 # survey::svymean(~y1, svydesign(ids=~1, weights=~weight, data=df))
 # surveycore .srs_mean result: agrees at tolerance 1e-10 for point, 1e-8 for SE.
 # Non-uniform weights work because SRS weights are proportional to N/n,
-# so the weighted and unweighted sample variances are identical per classical
-# theory. Agreement confirmed before oracle tests were written.
+# so the weighted and unweighted sample variances are approximately equal for
+# near-proportional weights. The oracle test tolerance of 1e-8 for SE
+# accommodates this approximation. Agreement confirmed before oracle tests
+# were written.
 
 # @param design  A survey_srs object.
 # @param var_name Character. Name of the variable column.

--- a/R/07-utils.R
+++ b/R/07-utils.R
@@ -174,7 +174,7 @@ SURVEYCORE_DOMAIN_COL <- "..surveycore_domain.."
     p2_cols <- if (!is.null(p2)) {
       unlist(p2[!vapply(p2, is.null, logical(1L))], use.names = FALSE)
     } else {
-      character(0L) # nocov — p2 is always initialized as a list by as_survey_twophase()
+      character(0L) # nocov — p2 is always a list (as_survey_twophase() and .from_svydesign_twophase() both initialize it)
     }
     unique(c(
       p1$ids, p1$weights, p1$strata, p1$fpc,

--- a/plans/error-messages.md
+++ b/plans/error-messages.md
@@ -91,6 +91,7 @@ against the messages defined here.
 | 59 | `as_survey_srs()` | `fpc` population size < sample size | ERROR | `surveycore_error_fpc_below_sample` | `"{.arg fpc} column {.field {fpc_var}} has {n_bad} value(s) smaller than the sample size ({n}). Population size cannot be smaller than the number of sampled units."` |
 | 60 | `as_survey()` | No `ids` or `strata` — dispatching to `survey_srs` | WARN | `surveycore_warning_as_survey_srs_fallback` | `c("!" = "No {.arg ids} or {.arg strata} specified.", "i" = "Creating a {.cls survey_srs} design (equal-probability SRS).", "v" = "Use {.fn as_survey_srs} to create SRS designs without this warning.")` |
 | 61 | `as_survey_srs()` | No `weights` provided — auto-assigning uniform weights | WARN | `surveycore_warning_srs_no_weights` | `"No {.arg weights} provided to {.fn as_survey_srs}. Assigning uniform weights ({.code ..surveycore_wt.. = 1}). Population size unknown — total estimates will use {.code \u03a3w_i = n} as the estimated N."` |
+| 62 | `from_svydesign()` (twophase) | Could not determine two-phase variance method | WARN | `surveycore_warning_twophase_method_unknown` | `"Could not determine two-phase variance method from the survey object. Defaulting to {.val \"approx\"}."` |
 
 ---
 

--- a/tests/testthat/_snaps/methods-print.md
+++ b/tests/testthat/_snaps/methods-print.md
@@ -413,3 +413,25 @@
       4     4     2
       5     5     2
 
+# summary.survey_srs output matches snapshot
+
+    Code
+      summary(d)
+    Message
+      
+      -- Survey Design Summary -------------------------------------------------------
+      Type: simple random sample (SRS)
+      Sample size: 10
+      Weighted N: 20
+      
+      
+      -- Design --
+      
+      Weights: wt
+      * Range: 2 – 2
+      * Mean: 2
+      * CV: 0
+      FPC: not specified
+      
+      Metadata: 0 of 2 variable(s) labeled
+

--- a/tests/testthat/helper-test-data.R
+++ b/tests/testthat/helper-test-data.R
@@ -176,10 +176,19 @@ make_survey_data <- function(
 #' @keywords internal
 test_invariants <- function(design) {
 
-  # survey_srs has an additional @variables key (fpc_type) — check it here
+  # survey_srs has additional @variables keys (fpc_type, visible_vars) — check here
   # before the general invariants run.
   if (S7::S7_inherits(design, survey_srs)) {
     testthat::expect_true("fpc_type" %in% names(design@variables))
+  }
+
+  # All design types must have visible_vars in @variables (may be NULL).
+  # This is required for Phase 0.5 select() compatibility.
+  if (!S7::S7_inherits(design, survey_calibrated)) {
+    testthat::expect_true(
+      "visible_vars" %in% names(design@variables),
+      label = "@variables has 'visible_vars' key"
+    )
   }
 
   # survey_calibrated has a different @variables structure — handle separately

--- a/tests/testthat/test-constructors.R
+++ b/tests/testthat/test-constructors.R
@@ -246,6 +246,18 @@ test_that("as_survey() warns with cluster message when ids given but no weights 
   )
 })
 
+test_that("as_survey() warns with SRS message when strata given but no ids and no weights [row 7]", {
+  df <- data.frame(st = rep(c("A", "B"), 5), y = 1:10, wt = rep(1, 10))
+  expect_warning(
+    as_survey(df, strata = st),
+    class = "surveycore_warning_srs_no_weights"
+  )
+  expect_warning(
+    as_survey(df, strata = st),
+    regexp = "No weights or population size provided"
+  )
+})
+
 test_that("as_survey() creates equal weights (..surveycore_wt..) for SRS [row 7]", {
   df <- data.frame(y = 1:10)
   d  <- suppressWarnings(as_survey(df))

--- a/tests/testthat/test-constructors.R
+++ b/tests/testthat/test-constructors.R
@@ -234,6 +234,18 @@ test_that("as_survey() warns for SRS (no weights, probs, or ids) [row 7]", {
   )
 })
 
+test_that("as_survey() warns with cluster message when ids given but no weights [row 7]", {
+  df <- data.frame(psu = rep(1:5, 2), y = 1:10)
+  expect_warning(
+    as_survey(df, ids = psu),
+    class = "surveycore_warning_srs_no_weights"
+  )
+  expect_warning(
+    as_survey(df, ids = psu),
+    regexp = "equal-probability sampling within clusters"
+  )
+})
+
 test_that("as_survey() creates equal weights (..surveycore_wt..) for SRS [row 7]", {
   df <- data.frame(y = 1:10)
   d  <- suppressWarnings(as_survey(df))

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -47,6 +47,10 @@
 #    26. svymean round-trip for replicate design [numerical]
 #   from_svydesign() — error on non-survey input
 #    27. rejects plain data.frame
+#   as_svydesign() — survey_taylor with no ids uses ids = ~1
+#    37. as_svydesign(survey_taylor) with ids = NULL produces ids = ~1
+#   from_svydesign() — twophase method unknown fallback warning
+#    38. warns when twophase x$method is unrecognised
 #   from_tbl_svy() — happy path
 #    28. tbl_svy → survey_taylor
 #   from_tbl_svy() — error on non-tbl_svy input
@@ -612,4 +616,46 @@ test_that("from_svydesign() replicate result has visible_vars key in @variables"
                               type = "BRR", combined.weights = TRUE)
   d   <- from_svydesign(sv)
   expect_true("visible_vars" %in% names(d@variables))
+})
+
+
+# 37. as_svydesign() for survey_taylor with ids = NULL uses ids = ~1 (line 111)
+test_that("as_svydesign() uses ids = ~1 when survey_taylor has ids = NULL", {
+  skip_if_not_installed("survey")
+  df <- make_survey_data(n = 30L, n_psu = 10L, n_strata = 2L, seed = 42L)
+  # Stratified design with no cluster ids — ids = NULL in @variables
+  d  <- as_survey(df, weights = wt, strata = strata)
+  test_invariants(d)
+  expect_null(d@variables$ids)
+  sv <- as_svydesign(d)
+  expect_true(inherits(sv, "survey.design"))
+})
+
+
+# 38. from_svydesign() warns when twophase x$method is unrecognised (lines 465-472)
+test_that("from_svydesign() warns surveycore_warning_twophase_method_unknown for unknown method", {
+  skip_if_not_installed("survey")
+  set.seed(42)
+  n   <- 30L
+  df  <- data.frame(x = rnorm(n), wt = rep(1, n))
+  sub <- sample(c(TRUE, FALSE), n, replace = TRUE, prob = c(0.6, 0.4))
+  # method = "approx" creates a plain "twophase" object (not "twophase2"), so
+  # the class-based fallback does not fire and only x$method controls dispatch.
+  sv  <- survey::twophase(
+    id     = list(~1, ~1),
+    strata = list(NULL, NULL),
+    probs  = list(NULL, NULL),
+    data   = df,
+    subset = sub,
+    method = "approx"
+  )
+  # Replace method with an unrecognised value to trigger the fallback warning.
+  sv$method <- "nonexistent_method"
+
+  expect_warning(
+    d <- from_svydesign(sv),
+    class = "surveycore_warning_twophase_method_unknown"
+  )
+  expect_true(S7::S7_inherits(d, survey_twophase))
+  expect_identical(d@variables$method, "approx")
 })

--- a/tests/testthat/test-methods-print.R
+++ b/tests/testthat/test-methods-print.R
@@ -27,8 +27,9 @@
 #  21. print.survey_srs — full = TRUE (snapshot)
 #  22. print.survey_srs — uniform auto-weights label
 #  23. print.survey_srs — invisible return
-#  24. summary.survey_srs — keys and types
-#  25. summary.survey_srs — fpc_specified / fpc_type
+#  24. summary.survey_srs — output and invisible return
+#  25. summary.survey_srs — FPC info in output
+#  26. summary.survey_srs — output (snapshot)
 #
 # Note: cli output (cli_h1/h2/text/bullets) goes to message(), not stdout.
 # Use capture.output(type = "message") to capture cli output in tests.
@@ -60,7 +61,8 @@ make_srs_design <- function(seed = 42L) {
       strata         = NULL,
       fpc            = NULL,
       nest           = FALSE,
-      probs_provided = FALSE
+      probs_provided = FALSE,
+      visible_vars   = NULL
     )
   )
 }
@@ -417,41 +419,56 @@ test_that("print.survey_srs returns object invisibly", {
 })
 
 
-# ── 24. summary.survey_srs — keys and types ──────────────────────────────────
+# ── 24. summary.survey_srs — output and invisible return ─────────────────────
 
-test_that("summary.survey_srs returns a list with correct keys", {
-  d   <- as_survey_srs(data.frame(y = 1:10, wt = rep(2, 10)), weights = wt)
+test_that("summary.survey_srs shows type, size, weights, FPC, and metadata sections", {
+  d <- as_survey_srs(data.frame(y = 1:10, wt = rep(2, 10)), weights = wt)
   test_invariants(d)
-  s   <- summary(d)
-  expected_keys <- c("class", "n", "weighted_n", "fpc_specified",
-                     "fpc_type", "n_var_labels", "n_val_labels")
-  expect_true(all(expected_keys %in% names(s)))
-  expect_identical(s$class,      "survey_srs")
-  expect_identical(s$n,          10L)
-  expect_equal(s$weighted_n,    20)   # 10 rows × weight 2; round() returns double
-  expect_false(s$fpc_specified)
-  expect_null(s$fpc_type)
-  expect_identical(s$n_var_labels, 0L)
-  expect_identical(s$n_val_labels, 0L)
+  withr::local_options(list(width = 80L, cli.width = 80L))
+  out <- capture.output(summary(d), type = "message")
+  expect_true(any(grepl("simple random sample", out, ignore.case = TRUE)))
+  expect_true(any(grepl("Sample size", out)))
+  expect_true(any(grepl("Weighted N", out)))
+  expect_true(any(grepl("FPC", out)))
+  expect_true(any(grepl("Metadata", out)))
+})
+
+test_that("summary.survey_srs returns object invisibly", {
+  d <- as_survey_srs(data.frame(y = 1:10, wt = rep(2, 10)), weights = wt)
+  test_invariants(d)
+  result <- suppressMessages(summary(d))
+  expect_identical(result, d)
 })
 
 
-# ── 25. summary.survey_srs — fpc_specified / fpc_type ────────────────────────
+# ── 25. summary.survey_srs — FPC info in output ───────────────────────────────
 
-test_that("summary.survey_srs reflects population FPC correctly", {
+test_that("summary.survey_srs reflects population FPC in output", {
   df <- data.frame(y = 1:5, wt = rep(1, 5), pop = rep(100L, 5))
   d  <- as_survey_srs(df, weights = wt, fpc = pop)
   test_invariants(d)
-  s  <- summary(d)
-  expect_true(s$fpc_specified)
-  expect_identical(s$fpc_type, "population")
+  withr::local_options(list(width = 80L, cli.width = 80L))
+  out <- capture.output(summary(d), type = "message")
+  expect_true(any(grepl("pop", out)))
+  expect_true(any(grepl("population sizes", out)))
 })
 
-test_that("summary.survey_srs reflects fraction FPC correctly", {
+test_that("summary.survey_srs reflects fraction FPC in output", {
   df <- data.frame(y = 1:5, wt = rep(1, 5), frac = rep(0.1, 5))
   d  <- as_survey_srs(df, weights = wt, fpc = frac)
   test_invariants(d)
-  s  <- summary(d)
-  expect_true(s$fpc_specified)
-  expect_identical(s$fpc_type, "fraction")
+  withr::local_options(list(width = 80L, cli.width = 80L))
+  out <- capture.output(summary(d), type = "message")
+  expect_true(any(grepl("frac", out)))
+  expect_true(any(grepl("sampling fractions", out)))
+})
+
+
+# ── 26. summary.survey_srs — output (snapshot) ───────────────────────────────
+
+test_that("summary.survey_srs output matches snapshot", {
+  d <- as_survey_srs(data.frame(y = 1:10, wt = rep(2, 10)), weights = wt)
+  test_invariants(d)
+  withr::local_options(list(width = 80L, cli.width = 80L))
+  expect_snapshot(summary(d))
 })

--- a/tests/testthat/test-methods-print.R
+++ b/tests/testthat/test-methods-print.R
@@ -30,6 +30,7 @@
 #  24. summary.survey_srs — output and invisible return
 #  25. summary.survey_srs — FPC info in output
 #  26. summary.survey_srs — output (snapshot)
+#  27. print.survey_srs — probs_provided label in design_info
 #
 # Note: cli output (cli_h1/h2/text/bullets) goes to message(), not stdout.
 # Use capture.output(type = "message") to capture cli output in tests.
@@ -471,4 +472,16 @@ test_that("summary.survey_srs output matches snapshot", {
   test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
   expect_snapshot(summary(d))
+})
+
+
+# ── 27. print.survey_srs — probs_provided label ──────────────────────────────
+
+test_that("print.survey_srs shows '(from sampling probabilities)' when probs_provided", {
+  df <- data.frame(y = 1:10, p = rep(0.1, 10))
+  d  <- as_survey_srs(df, probs = p)
+  test_invariants(d)
+  withr::local_options(list(width = 80L, cli.width = 80L))
+  out <- capture.output(print(d, design_info = TRUE), type = "message")
+  expect_true(any(grepl("from sampling probabilities", out)))
 })

--- a/tests/testthat/test-s7-classes.R
+++ b/tests/testthat/test-s7-classes.R
@@ -25,7 +25,8 @@
     strata         = strata,
     fpc            = fpc,
     nest           = nest,
-    probs_provided = probs_provided
+    probs_provided = probs_provided,
+    visible_vars   = NULL
   )
 }
 
@@ -41,19 +42,21 @@
   mse         = TRUE
 ) {
   list(
-    weights    = weights,
-    repweights = repweights,
-    type       = type,
-    scale      = scale,
-    rscales    = rscales,
-    fpc        = fpc,
-    fpctype    = fpctype,
-    mse        = mse
+    weights      = weights,
+    repweights   = repweights,
+    type         = type,
+    scale        = scale,
+    rscales      = rscales,
+    fpc          = fpc,
+    fpctype      = fpctype,
+    mse          = mse,
+    visible_vars = NULL
   )
 }
 
 # A small valid data frame for survey_taylor tests.
-.df10 <- function() {
+.df10 <- function(seed = 42L) {
+  set.seed(seed)
   data.frame(
     psu    = paste0("psu_", rep(1:5, 2)),
     strata = paste0("s", rep(1:2, each = 5)),
@@ -65,7 +68,8 @@
 }
 
 # A small valid data frame for survey_replicate tests.
-.df_rep <- function(R = 4L) {
+.df_rep <- function(R = 4L, seed = 42L) {
+  set.seed(seed)
   df <- data.frame(
     wt = runif(20, 0.5, 2),
     y  = rnorm(20),
@@ -457,10 +461,11 @@ test_that("survey_twophase() creates valid object with minimal spec", {
   d <- survey_twophase(
     data      = df,
     variables = list(
-      phase1 = .taylor_vars(weights = "wt", ids = "psu"),
-      phase2 = list(ids = NULL, strata = NULL, probs = NULL, fpc = NULL),
-      subset = "ph2",
-      method = "full"
+      phase1       = .taylor_vars(weights = "wt", ids = "psu"),
+      phase2       = list(ids = NULL, strata = NULL, probs = NULL, fpc = NULL),
+      subset       = "ph2",
+      method       = "full",
+      visible_vars = NULL
     )
   )
   test_invariants(d)
@@ -480,15 +485,16 @@ test_that("survey_twophase() creates valid object with phase2 strata col", {
   d <- survey_twophase(
     data      = df,
     variables = list(
-      phase1 = .taylor_vars(weights = "wt"),
-      phase2 = list(
+      phase1       = .taylor_vars(weights = "wt"),
+      phase2       = list(
         ids    = NULL,
         strata = "ph2_str",
         probs  = NULL,
         fpc    = NULL
       ),
-      subset = "ph2",
-      method = "approx"
+      subset       = "ph2",
+      method       = "approx",
+      visible_vars = NULL
     )
   )
   test_invariants(d)
@@ -620,7 +626,8 @@ test_that("survey_twophase validator: warning 26 — phase2 col all-NA in ph2", 
     probs_provided = probs_provided,
     ids            = ids,
     strata         = strata,
-    nest           = nest
+    nest           = nest,
+    visible_vars   = NULL
   )
 }
 
@@ -672,15 +679,18 @@ test_that("survey_srs validator: FPC column absent from @data fires error", {
   )
 })
 
-# Row 5 — all 7 @variables keys present after construction
-test_that("survey_srs: all 7 @variables keys present after construction", {
+# Row 5 — all 8 @variables keys present after construction
+test_that("survey_srs: all 8 @variables keys present after construction", {
   df <- data.frame(y = 1:5, wt = rep(1, 5))
   d  <- survey_srs(
     data      = df,
     variables = .srs_vars(weights = "wt")
   )
   test_invariants(d)
-  keys <- c("weights", "fpc", "fpc_type", "probs_provided", "ids", "strata", "nest")
+  keys <- c(
+    "weights", "fpc", "fpc_type", "probs_provided",
+    "ids", "strata", "nest", "visible_vars"
+  )
   expect_true(all(keys %in% names(d@variables)))
 })
 

--- a/tests/testthat/test-variance-estimation.R
+++ b/tests/testthat/test-variance-estimation.R
@@ -470,13 +470,12 @@ test_that("get_means() BRR scale formula 1/n_rep is correct for n_rep != 4", {
   n_rep      <- length(repwt_cols)  # should be 10 (n_psu / 2)
 
   sc <- as_survey_rep(d, weights = wt, repweights = all_of(repwt_cols), type = "BRR")
-  # survey package default scale for BRR is 1/4 when not specified.
-  # Pass scale = 1/n_rep explicitly to match surveycore behaviour.
+  # survey hardcodes scale = 1/R for BRR internally; the scale= argument is
+  # ignored. Both packages independently compute (1/n_rep) * sum((theta_r - theta)^2).
   sv <- survey::svrepdesign(
     weights    = d$wt,
     repweights = d[, repwt_cols],
     type       = "BRR",
-    scale      = 1 / n_rep,
     mse        = TRUE,
     data       = d
   )

--- a/tests/testthat/test-variance-estimation.R
+++ b/tests/testthat/test-variance-estimation.R
@@ -458,6 +458,36 @@ test_that("get_means() and get_totals() work for survey_replicate (return struct
   expect_gte(t$se, 0)
 })
 
+test_that("get_means() BRR scale formula 1/n_rep is correct for n_rep != 4", {
+  # Verifies that scale = 1/n_rep (not 1/4) is the correct BRR formula.
+  # With n_psu = 20, n_rep = 10 (half-samples from 20 PSUs).
+  # If 1/n_rep is correct, surveycore and survey::svrepdesign agree at 1e-8.
+  skip_if_not_installed("survey")
+
+  d <- make_survey_data(n = 200, n_psu = 20, n_strata = 4,
+                        design = "replicate", type = "brr", seed = 99)
+  repwt_cols <- grep("^repwt_", names(d), value = TRUE)
+  n_rep      <- length(repwt_cols)  # should be 10 (n_psu / 2)
+
+  sc <- as_survey_rep(d, weights = wt, repweights = all_of(repwt_cols), type = "BRR")
+  # survey package default scale for BRR is 1/4 when not specified.
+  # Pass scale = 1/n_rep explicitly to match surveycore behaviour.
+  sv <- survey::svrepdesign(
+    weights    = d$wt,
+    repweights = d[, repwt_cols],
+    type       = "BRR",
+    scale      = 1 / n_rep,
+    mse        = TRUE,
+    data       = d
+  )
+
+  sc_mean <- get_means(sc, y1)
+  sv_mean <- survey::svymean(~y1, sv, na.rm = TRUE)
+
+  expect_equal(sc_mean$mean, coef(sv_mean)[["y1"]], tolerance = 1e-10)
+  expect_equal(sc_mean$se,   as.numeric(survey::SE(sv_mean)), tolerance = 1e-8)
+})
+
 
 # ---------------------------------------------------------------------------
 # Block 11: Error paths — non-survey inputs to get_means()/get_totals()


### PR DESCRIPTION
## What

Post-review corrections to the `survey_srs` PR: validator guard simplification, `summary.survey_srs` rewrite, `from_svydesign()` bug fixes, and test coverage gaps filled.

## Changes

**Validators (`R/00-s7-classes.R`)**
- Remove redundant `weights_var %in% names(self@data)` guard in `survey_taylor`, `survey_replicate`, and `survey_srs` validators — the existence check immediately above already guarantees the column is present

**Constructors (`R/03-constructors.R`)**
- Add `visible_vars = NULL` to `@variables` in all constructors (required for Phase 0.5 `select()` compatibility)
- Context-sensitive SRS fallback warning: emit a cluster-specific message when `ids` are present but no weights are supplied
- Correct BRR scale formula comment: survey hardcodes `1/R` internally; `scale=` is not used

**Print methods (`R/04-methods-print.R`)**
- Fix `print.survey_srs` to include `fpc` alongside `weights` in `.print_hidden_note()`
- Rewrite `summary.survey_srs` to use cli output (matching `summary.survey_taylor` / `_replicate` / `_twophase`) and return `invisible(x)` instead of a named list

**Conversion (`R/05-methods-conversion.R`)**
- `from_svydesign()` twophase: check `x$method` before falling back to class-based inference; emit a typed warning when method cannot be determined
- Initialize `phase2` as `list(ids, strata, probs, fpc)` instead of `NULL`

**Variance comment (`R/06-variance-estimation.R`)**
- Correct SRS mean comment: "are identical" → "are approximately equal for near-proportional weights"

**Tests**
- Add `visible_vars = NULL` to all `@variables` fixtures in `test-s7-classes.R`
- Add `seed` parameter to `.df10()` and `.df_rep()` helpers for reproducibility
- Rewrite `summary.survey_srs` tests to match new cli output; add snapshot (test 26)
- Add test for cluster-with-no-weights warning path
- Add BRR oracle test verifying `scale = 1/n_rep` for `n_rep != 4`; fix dead `scale=` argument in `survey::svrepdesign()` call

## Checklist

- [x] Tests written and passing (`devtools::test()`)
- [x] R CMD check: 0 errors, 0 warnings (`devtools::check()`)
- [x] Roxygen docs updated and `devtools::document()` run
- [x] `plans/error-messages.md` updated (new warning class `surveycore_warning_twophase_method_unknown`)
- [ ] `VENDORED.md` updated (if variance code vendored in this PR) — N/A
- [x] PR title is a valid Conventional Commit (`feat(scope): description`)