### PR TITLE
chore(cleanup): fix SRS dispatch test warnings and update stale Phase 0.5 comments

### DIFF
--- a/R/00-s7-classes.R
+++ b/R/00-s7-classes.R
@@ -99,8 +99,8 @@ survey_metadata <- S7::new_class(
 #'   \item{`variables`}{A named list of design specification (varies by
 #'     subclass).}
 #'   \item{`groups`}{Character vector of active grouping variables.
-#'     Always `character(0)` in Phase 0. Reserved for Phase 0.5
-#'     (`group_by()` support in surveytidy).}
+#'     Set by surveytidy's `group_by()`. Always `character(0)` in
+#'     standalone surveycore use.}
 #'   \item{`call`}{The language object capturing the construction call,
 #'     or `NULL`.}
 #' }
@@ -123,8 +123,8 @@ survey_base <- S7::new_class(
       S7::class_list,
       default = quote(list())
     ),
-    # RESERVED: Phase 0.5 — group_by() support in surveytidy.
-    # Always character(0) in Phase 0. Do NOT read or write in Phase 0 code.
+    # Set by surveytidy's group_by(). Always character(0) in standalone
+    # surveycore use. Do NOT read or write in surveycore code.
     groups   = S7::new_property(
       S7::class_character,
       default = quote(character(0))
@@ -147,8 +147,8 @@ survey_base <- S7::new_class(
 #'   [as_survey()].
 #' @param variables A named list of design specification (ids, weights,
 #'   strata, fpc, nest, probs_provided). Set automatically by [as_survey()].
-#' @param groups Reserved for Phase 0.5 (group_by support in surveytidy).
-#'   Always `character(0)` in Phase 0.
+#' @param groups Set by surveytidy's `group_by()`. Always `character(0)` in
+#'   standalone surveycore use.
 #' @param call Language object capturing the construction call.
 #'
 #' @section Design variables (`@variables`):
@@ -306,7 +306,8 @@ survey_taylor <- S7::new_class(
 #' @param variables A named list of design specification (weights,
 #'   repweights, type, scale, rscales, fpc, fpctype, mse). Set
 #'   automatically by [as_survey_rep()].
-#' @param groups Reserved for Phase 0.5. Always `character(0)` in Phase 0.
+#' @param groups Set by surveytidy's `group_by()`. Always `character(0)` in
+#'   standalone surveycore use.
 #' @param call Language object capturing the construction call.
 #'
 #' @section Design variables (`@variables`):
@@ -445,7 +446,8 @@ survey_replicate <- S7::new_class(
 #'   design when using [as_survey_twophase()].
 #' @param variables A named list of design specification (phase1, phase2,
 #'   subset, method). Set automatically by [as_survey_twophase()].
-#' @param groups Reserved for Phase 0.5. Always `character(0)` in Phase 0.
+#' @param groups Set by surveytidy's `group_by()`. Always `character(0)` in
+#'   standalone surveycore use.
 #' @param call Language object capturing the construction call.
 #'
 #' @section Design variables (`@variables`):
@@ -598,7 +600,8 @@ survey_twophase <- S7::new_class(
 #'   [as_survey()].
 #' @param variables A named list of design specification. Set automatically by
 #'   [as_survey()].
-#' @param groups Reserved for Phase 0.5. Always `character(0)` in Phase 0.
+#' @param groups Set by surveytidy's `group_by()`. Always `character(0)` in
+#'   standalone surveycore use.
 #' @param call Language object capturing the construction call.
 #'
 #' @section Design variables (`@variables`):
@@ -733,7 +736,8 @@ survey_srs <- S7::new_class(
 #'   or `NULL` if calibration was performed externally. Stores the
 #'   calibration targets, variables, and trimming parameters for
 #'   reproducibility and future bootstrap re-calibration. Default `NULL`.
-#' @param groups Reserved for Phase 0.5. Always `character(0)` in Phase 0.
+#' @param groups Set by surveytidy's `group_by()`. Always `character(0)` in
+#'   standalone surveycore use.
 #' @param call Language object capturing the construction call.
 #'
 #' @section Design variables (`@variables`):

--- a/R/04-methods-print.R
+++ b/R/04-methods-print.R
@@ -19,13 +19,13 @@
 # ── Internal helpers ────────────────────────────────────────────────────────
 
 # Return the subset of @data to display, converted to tibble for printing.
-# Phase 0: always all columns.
-# Phase 0.5: respects @variables$visible_vars set by select().
+# Respects @variables$visible_vars when set by surveytidy's select().
+# NULL (the surveycore default) → all columns shown.
 #' @noRd
 .data_for_print <- function(x) {
   visible <- x@variables[["visible_vars"]]
   data <- if (!is.null(visible)) {
-    x@data[, visible, drop = FALSE] # nocov — Phase 0.5 only
+    x@data[, visible, drop = FALSE] # nocov — only set by surveytidy
   } else {
     x@data
   }
@@ -33,12 +33,12 @@
 }
 
 # Print a note about design variables that are not in data_shown.
-# In Phase 0 this never fires (visible_vars is always NULL, so data_shown
-# contains all columns). Included for Phase 0.5 compatibility.
+# Only fires when surveytidy's select() has hidden design variables
+# (i.e., visible_vars is set). Never fires in standalone surveycore use.
 #' @noRd
 .print_hidden_note <- function(design_vars, data_shown) {
   hidden <- setdiff(design_vars, names(data_shown))
-  if (length(hidden) > 0L) { # nocov start — Phase 0.5 only
+  if (length(hidden) > 0L) { # nocov start — only set by surveytidy
     cli::cli_text("")
     cli::cli_bullets(c(
       "i" = "Design variables preserved but hidden: {.field {hidden}}.",

--- a/R/07-utils.R
+++ b/R/07-utils.R
@@ -68,7 +68,7 @@ SURVEYCORE_DOMAIN_COL <- "..surveycore_domain.."
 # Returns a character vector of selected column names, or NULL when expr is a
 # NULL quosure. Count validation is left to callers — error classes differ by
 # argument (weights, strata, fpc, etc.).
-# Used by constructors and Phase 0.5 dplyr verbs in surveytidy.
+# Used by constructors and by surveytidy dplyr verbs.
 #
 # @param expr  A quosure (from rlang::enquo()). NULL quosure → returns NULL.
 # @param data  A data.frame to evaluate the selection against.
@@ -189,7 +189,7 @@ SURVEYCORE_DOMAIN_COL <- "..surveycore_domain.."
 # Return a named list mapping slot names to column name(s).
 # Slots whose value is NULL are omitted from the result.
 # unlist()ing the result gives all design variable names.
-# Used by Phase 0.5 dplyr verbs (rename, select) for slot-level granularity
+# Used by surveytidy dplyr verbs (rename, select) for slot-level granularity
 # and by conversion methods to identify which role each column plays.
 #' @noRd
 .get_design_vars <- function(design) {

--- a/changelog/phase-0.75/chore-file-structure-cleanup.md
+++ b/changelog/phase-0.75/chore-file-structure-cleanup.md
@@ -1,0 +1,30 @@
+# chore(cleanup): fix test warnings and update stale Phase 0.5 comments
+
+**Date**: 2026-02-24
+**Branch**: chore/file-structure-cleanup
+**Phase**: Phase 0.75
+
+## Changes
+
+- Remove two dead tests and one dead test block that referenced removed behavior
+  in `test-conversion.R` and `test-methods-print.R`
+- Remove stale `# nocov` markers from `R/05-methods-conversion.R` that tagged
+  reachable branches as uncoverable
+- Fix 23 leaked SRS dispatch warnings in `test-constructors.R`: `as_survey()`
+  without ids/strata now dispatches to `survey_srs` and fires
+  `surveycore_warning_as_survey_srs_fallback`; tests not asserting on that
+  warning now wrap calls in `suppressWarnings()`
+- Update stale "Phase 0.5" references in R source files and test helpers to
+  reference "surveytidy" (the shipped package) instead of the planning-era label
+
+## Files Modified
+
+- `R/00-s7-classes.R` — replace Phase 0.5 `@groups` reserve comments with
+  accurate surveytidy references
+- `R/04-methods-print.R` — replace Phase 0.5 nocov labels with surveytidy
+  references
+- `R/07-utils.R` — replace two Phase 0.5 comments with surveytidy references
+- `tests/testthat/helper-test-data.R` — replace one Phase 0.5 comment with
+  surveytidy reference
+- `tests/testthat/test-constructors.R` — suppress 23 leaked SRS dispatch
+  warnings via three `suppressWarnings()` patterns

--- a/man/survey_base.Rd
+++ b/man/survey_base.Rd
@@ -27,8 +27,8 @@ use \code{\link[=as_survey]{as_survey()}}, \code{\link[=as_survey_rep]{as_survey
 \item{\code{variables}}{A named list of design specification (varies by
 subclass).}
 \item{\code{groups}}{Character vector of active grouping variables.
-Always \code{character(0)} in Phase 0. Reserved for Phase 0.5
-(\code{group_by()} support in surveytidy).}
+Set by surveytidy's \code{group_by()}. Always \code{character(0)} in
+standalone surveycore use.}
 \item{\code{call}}{The language object capturing the construction call,
 or \code{NULL}.}
 }

--- a/man/survey_calibrated.Rd
+++ b/man/survey_calibrated.Rd
@@ -23,7 +23,8 @@ survey_calibrated(
 \item{variables}{A named list of design specification (\code{weights},
 \code{probs_provided}). Set automatically by \code{\link[=as_survey_calibrated]{as_survey_calibrated()}}.}
 
-\item{groups}{Reserved for Phase 0.5. Always \code{character(0)} in Phase 0.}
+\item{groups}{Set by surveytidy's \code{group_by()}. Always \code{character(0)} in
+standalone surveycore use.}
 
 \item{call}{Language object capturing the construction call.}
 

--- a/man/survey_replicate.Rd
+++ b/man/survey_replicate.Rd
@@ -23,7 +23,8 @@ survey_replicate(
 repweights, type, scale, rscales, fpc, fpctype, mse). Set
 automatically by \code{\link[=as_survey_rep]{as_survey_rep()}}.}
 
-\item{groups}{Reserved for Phase 0.5. Always \code{character(0)} in Phase 0.}
+\item{groups}{Set by surveytidy's \code{group_by()}. Always \code{character(0)} in
+standalone surveycore use.}
 
 \item{call}{Language object capturing the construction call.}
 }

--- a/man/survey_srs.Rd
+++ b/man/survey_srs.Rd
@@ -22,7 +22,8 @@ over calling this constructor directly.}
 \item{variables}{A named list of design specification. Set automatically by
 \code{\link[=as_survey]{as_survey()}}.}
 
-\item{groups}{Reserved for Phase 0.5. Always \code{character(0)} in Phase 0.}
+\item{groups}{Set by surveytidy's \code{group_by()}. Always \code{character(0)} in
+standalone surveycore use.}
 
 \item{call}{Language object capturing the construction call.}
 }

--- a/man/survey_taylor.Rd
+++ b/man/survey_taylor.Rd
@@ -22,8 +22,8 @@ survey_taylor(
 \item{variables}{A named list of design specification (ids, weights,
 strata, fpc, nest, probs_provided). Set automatically by \code{\link[=as_survey]{as_survey()}}.}
 
-\item{groups}{Reserved for Phase 0.5 (group_by support in surveytidy).
-Always \code{character(0)} in Phase 0.}
+\item{groups}{Set by surveytidy's \code{group_by()}. Always \code{character(0)} in
+standalone surveycore use.}
 
 \item{call}{Language object capturing the construction call.}
 }

--- a/man/survey_twophase.Rd
+++ b/man/survey_twophase.Rd
@@ -23,7 +23,8 @@ design when using \code{\link[=as_survey_twophase]{as_survey_twophase()}}.}
 \item{variables}{A named list of design specification (phase1, phase2,
 subset, method). Set automatically by \code{\link[=as_survey_twophase]{as_survey_twophase()}}.}
 
-\item{groups}{Reserved for Phase 0.5. Always \code{character(0)} in Phase 0.}
+\item{groups}{Set by surveytidy's \code{group_by()}. Always \code{character(0)} in
+standalone surveycore use.}
 
 \item{call}{Language object capturing the construction call.}
 }

--- a/tests/testthat/helper-test-data.R
+++ b/tests/testthat/helper-test-data.R
@@ -183,7 +183,7 @@ test_invariants <- function(design) {
   }
 
   # All design types must have visible_vars in @variables (may be NULL).
-  # This is required for Phase 0.5 select() compatibility.
+  # Required for surveytidy's select() compatibility.
   if (!S7::S7_inherits(design, survey_calibrated)) {
     testthat::expect_true(
       "visible_vars" %in% names(design@variables),

--- a/tests/testthat/test-constructors.R
+++ b/tests/testthat/test-constructors.R
@@ -20,9 +20,11 @@
 
 test_that("as_survey() dispatches to survey_srs for SRS (no ids or strata)", {
   df <- make_survey_data(n = 100, seed = 1L)
-  expect_warning(
-    d <- as_survey(df),
-    class = "surveycore_warning_as_survey_srs_fallback"
+  suppressWarnings(
+    expect_warning(
+      d <- as_survey(df),
+      class = "surveycore_warning_as_survey_srs_fallback"
+    )
   )
   test_invariants(d)
   expect_true(S7::S7_inherits(d, survey_srs))
@@ -86,14 +88,14 @@ test_that("as_survey() creates survey_taylor for NHANES design (nest = TRUE)", {
 
 test_that("as_survey() stores call in @call", {
   df <- make_survey_data(n = 50, seed = 4L)
-  d  <- as_survey(df, weights = wt)
+  d  <- suppressWarnings(as_survey(df, weights = wt))
   expect_false(is.null(d@call))
   expect_true(is.call(d@call))
 })
 
 test_that("as_survey() extracts haven metadata when present", {
   df <- make_survey_data(n = 100, with_labels = TRUE, seed = 5L)
-  d  <- as_survey(df, weights = wt)
+  d  <- suppressWarnings(as_survey(df, weights = wt))
   test_invariants(d)
   expect_identical(d@metadata@variable_labels[["y1"]], "Outcome variable 1 (continuous)")
   expect_identical(d@metadata@value_labels[["y3"]], c("No" = 0L, "Yes" = 1L))
@@ -101,7 +103,7 @@ test_that("as_survey() extracts haven metadata when present", {
 
 test_that("as_survey() returns an empty metadata object when no haven attrs", {
   df <- make_survey_data(n = 50, seed = 6L)
-  d  <- as_survey(df, weights = wt)
+  d  <- suppressWarnings(as_survey(df, weights = wt))
   test_invariants(d)
   expect_identical(length(d@metadata@variable_labels), 0L)
 })
@@ -111,7 +113,7 @@ test_that("as_survey() returns an empty metadata object when no haven attrs", {
 
 test_that("as_survey() converts probs to weights (1/probs) stored as ..surveycore_wt..", {
   df      <- data.frame(y = 1:5, prob = rep(0.2, 5))
-  d       <- as_survey(df, probs = prob)
+  d       <- suppressWarnings(as_survey(df, probs = prob))
   test_invariants(d)
   expect_identical(d@variables$weights, surveycore:::.SURVEYCORE_WT_COL)
   expect_true(d@variables$probs_provided)
@@ -139,7 +141,7 @@ test_that("as_survey() uses weights when both probs and weights are consistent",
 
 test_that("as_survey() stores fpc column name in @variables", {
   df <- make_survey_data(n = 100, seed = 7L)
-  d  <- as_survey(df, weights = wt, fpc = fpc)
+  d  <- suppressWarnings(as_survey(df, weights = wt, fpc = fpc))
   test_invariants(d)
   expect_identical(d@variables$fpc, "fpc")
 })
@@ -194,9 +196,11 @@ test_that("as_survey() errors when data has duplicate column names [row 3]", {
 # Row 4: data has 1 row (warning, not error)
 test_that("as_survey() warns when data has 1 row [row 4]", {
   single_row <- data.frame(x = 42, w = 1)
-  expect_warning(
-    as_survey(single_row, weights = w),
-    class = "surveycore_warning_single_row"
+  suppressWarnings(
+    expect_warning(
+      as_survey(single_row, weights = w),
+      class = "surveycore_warning_single_row"
+    )
   )
 })
 
@@ -228,9 +232,11 @@ test_that("as_survey() errors when probs and weights are inconsistent [row 5]", 
 # Row 7: SRS warning (no weights/probs/ids)
 test_that("as_survey() warns for SRS (no weights, probs, or ids) [row 7]", {
   df <- data.frame(y = 1:10, x = rnorm(10))
-  expect_warning(
-    as_survey(df),
-    class = "surveycore_warning_srs_no_weights"
+  suppressWarnings(
+    expect_warning(
+      as_survey(df),
+      class = "surveycore_warning_srs_no_weights"
+    )
   )
 })
 
@@ -269,7 +275,7 @@ test_that("as_survey() creates equal weights (..surveycore_wt..) for SRS [row 7]
 test_that("as_survey() errors when weights helper matches no columns [row 8]", {
   df <- data.frame(y = 1:5, wt = 1:5)
   expect_error(
-    as_survey(df, weights = starts_with("zzz")),
+    suppressWarnings(as_survey(df, weights = starts_with("zzz"))),
     class = "surveycore_error_weights_not_found"
   )
   expect_snapshot(
@@ -282,7 +288,7 @@ test_that("as_survey() errors when weights helper matches no columns [row 8]", {
 test_that("as_survey() errors when weights expression selects multiple columns [row 9]", {
   df <- data.frame(y = 1:5, wt1 = 1:5, wt2 = 1:5)
   expect_error(
-    as_survey(df, weights = starts_with("wt")),
+    suppressWarnings(as_survey(df, weights = starts_with("wt"))),
     class = "surveycore_error_weights_multiple"
   )
   expect_snapshot(
@@ -295,7 +301,7 @@ test_that("as_survey() errors when weights expression selects multiple columns [
 test_that("as_survey() errors when all weights are zero [row 10]", {
   df <- data.frame(x = 1:5, wt = c(0, 0, 0, 0, 0))
   expect_error(
-    as_survey(df, weights = wt),
+    suppressWarnings(as_survey(df, weights = wt)),
     class = "surveycore_error_weights_all_zero"
   )
 })
@@ -303,7 +309,7 @@ test_that("as_survey() errors when all weights are zero [row 10]", {
 test_that("as_survey() errors when all weights are NA [row 10]", {
   df <- data.frame(x = 1:5, wt = rep(NA_real_, 5))
   expect_error(
-    as_survey(df, weights = wt),
+    suppressWarnings(as_survey(df, weights = wt)),
     class = "surveycore_error_weights_all_zero"
   )
 })
@@ -339,7 +345,7 @@ test_that("as_survey() errors when fpc expression selects multiple columns [row 
     fpc2 = rep(2000L, 5)
   )
   expect_error(
-    as_survey(df, weights = wt, fpc = starts_with("fpc")),
+    suppressWarnings(as_survey(df, weights = wt, fpc = starts_with("fpc"))),
     class = "surveycore_error_fpc_multiple"
   )
   expect_snapshot(
@@ -356,7 +362,7 @@ test_that("as_survey() errors when fpc column has NA values [row 14]", {
     fpc = c(1000L, NA_integer_, 1000L, 1000L, 1000L)
   )
   expect_error(
-    as_survey(df, weights = wt, fpc = fpc),
+    suppressWarnings(as_survey(df, weights = wt, fpc = fpc)),
     class = "surveycore_error_fpc_na"
   )
   expect_snapshot(error = TRUE, as_survey(df, weights = wt, fpc = fpc))
@@ -380,7 +386,7 @@ test_that("as_survey() errors when nest = TRUE and strata is NULL [row 15]", {
 
 test_that("as_survey() handles weights with NA values mixed in (valid)", {
   df <- data.frame(x = 1:5, wt = c(1.0, NA_real_, 2.0, 1.5, NA_real_))
-  d  <- as_survey(df, weights = wt)
+  d  <- suppressWarnings(as_survey(df, weights = wt))
   test_invariants(d)
   expect_identical(d@variables$weights, "wt")
 })
@@ -395,14 +401,14 @@ test_that("as_survey() with tibble input (inherits data.frame)", {
 
 test_that("as_survey() populates all expected @variables keys", {
   df  <- make_survey_data(n = 100, seed = 9L)
-  d   <- as_survey(df, weights = wt)
+  d   <- suppressWarnings(as_survey(df, weights = wt))
   expected_keys <- c("ids", "weights", "strata", "fpc", "nest", "probs_provided")
   expect_true(all(expected_keys %in% names(d@variables)))
 })
 
 test_that("as_survey() sets NULL for unspecified design vars", {
   df <- data.frame(x = 1:5, wt = rep(1, 5))
-  d  <- as_survey(df, weights = wt)
+  d  <- suppressWarnings(as_survey(df, weights = wt))
   expect_null(d@variables$ids)
   expect_null(d@variables$strata)
   expect_null(d@variables$fpc)
@@ -439,7 +445,7 @@ test_that("as_survey() does NOT warn for PSU in multiple strata when nest = TRUE
 
 test_that("as_survey() accepts bare name for weights", {
   df <- data.frame(y = 1:5, weight_col = rep(1, 5))
-  d  <- as_survey(df, weights = weight_col)
+  d  <- suppressWarnings(as_survey(df, weights = weight_col))
   test_invariants(d)
   expect_identical(d@variables$weights, "weight_col")
 })
@@ -471,7 +477,7 @@ test_that("as_survey() accepts single bare name for ids", {
 
 test_that("as_survey() ids = NULL means SRS (no cluster)", {
   df <- data.frame(y = 1:10, wt = rep(1, 10))
-  d  <- as_survey(df, weights = wt)
+  d  <- suppressWarnings(as_survey(df, weights = wt))
   expect_null(d@variables$ids)
 })
 
@@ -1248,7 +1254,7 @@ test_that("as_survey_twophase() accepts bare name for ids2", {
 test_that("as_survey() errors when probs expression matches no columns", {
   df <- data.frame(x = 1:5, wt = 1:5)
   expect_error(
-    as_survey(df, probs = tidyselect::starts_with("nonexistent_xyz")),
+    suppressWarnings(as_survey(df, probs = tidyselect::starts_with("nonexistent_xyz"))),
     class = "surveycore_error_weights_not_found"
   )
 })
@@ -1256,7 +1262,7 @@ test_that("as_survey() errors when probs expression matches no columns", {
 test_that("as_survey() errors when probs expression selects multiple columns", {
   df <- data.frame(x = 1:5, prob1 = rep(0.1, 5), prob2 = rep(0.2, 5))
   expect_error(
-    as_survey(df, probs = starts_with("prob")),
+    suppressWarnings(as_survey(df, probs = starts_with("prob"))),
     class = "surveycore_error_weights_multiple"
   )
 })
@@ -1339,7 +1345,7 @@ test_that("as_survey() errors when strata expression matches no columns", {
 test_that("as_survey() errors when fpc expression matches no columns", {
   df <- data.frame(x = 1:10, wt = rep(1, 10))
   expect_error(
-    as_survey(df, weights = wt, fpc = tidyselect::starts_with("nonexistent_xyz")),
+    suppressWarnings(as_survey(df, weights = wt, fpc = tidyselect::starts_with("nonexistent_xyz"))),
     class = "surveycore_error_fpc_not_found"
   )
 })


### PR DESCRIPTION
## What

Two cleanup items to close out remaining noise from the `survey_srs` dispatch work:

1. **23 test warnings fixed** — `as_survey()` without `ids`/`strata` now dispatches
   to `survey_srs` and fires `surveycore_warning_as_survey_srs_fallback`. Tests that
   don't assert on this warning now wrap calls in `suppressWarnings()`. Three patterns
   applied: (a) happy-path assignment, (b) `expect_error()` wrappers, (c)
   `suppressWarnings(expect_warning(...))` for tests with a secondary warning.
   Snapshot tests left unchanged — they correctly document both warning + error.

2. **Stale "Phase 0.5" comments updated** — Phase 0.5 shipped as the separate
   `surveytidy` package. All source-level references updated to name `surveytidy`
   directly (in `R/00-s7-classes.R`, `R/04-methods-print.R`, `R/07-utils.R`,
   `tests/testthat/helper-test-data.R`). Generated `man/` files updated to match.

## Checklist

- [x] Tests written and passing (`devtools::test()`) — FAIL 0 | WARN 0 | SKIP 0 | PASS 2766
- [x] R CMD check: 0 errors, 0 warnings, 1 pre-approved note (`devtools::check()`)
- [x] Roxygen docs updated and `devtools::document()` run (man/ files staged)
- [x] `plans/error-messages.md` updated — N/A (no new error classes)
- [x] PR title is a valid Conventional Commit