### PR TITLE
fix(constructors): tighten as_survey_twophase() NA and method validation

### DIFF
--- a/R/03-constructors.R
+++ b/R/03-constructors.R
@@ -899,22 +899,25 @@ as_survey_twophase <- function(
 
   subset_vals <- data[[subset_var]]
 
-  # Warning: NAs in subset column mean some rows have unknown Phase 2
-  # membership — flag this so users are not surprised by downstream behavior.
+  # Error: NAs in subset column — phase 2 membership must be fully observed.
   n_na <- sum(is.na(subset_vals))
   if (n_na > 0L) {
-    cli::cli_warn(
+    cli::cli_abort(
       c(
-        "!" = paste0(
+        "x" = paste0(
           "{.arg subset} column {.field {subset_var}} contains {n_na} ",
           "NA value(s)."
         ),
         "i" = paste0(
-          "Rows with NA are excluded from Phase 2. ",
-          "This may affect variance estimation."
+          "The phase 2 membership indicator must be fully observed ",
+          "for all phase 1 units."
+        ),
+        "v" = paste0(
+          "Remove rows with missing {.arg subset} values before calling ",
+          "{.fn as_survey_twophase}."
         )
       ),
-      class = "surveycore_warning_subset_na"
+      class = "surveycore_error_subset_na"
     )
   }
 
@@ -973,24 +976,6 @@ as_survey_twophase <- function(
         )
       ),
       class = "surveycore_warning_simple_clustered"
-    )
-  }
-
-  # ── Warning 25: method = "full" with no Phase 2 design info ─────────────────
-
-  no_phase2_info <- is.null(ids2_vars) && is.null(strata2_var) &&
-                    is.null(probs2_var) && is.null(fpc2_var)
-  if (method == "full" && no_phase2_info) {
-    cli::cli_warn(
-      c(
-        "!" = paste0(
-          'No Phase 2 design information provided with ',
-          '{.code method = "full"}. ',
-          "Phase 2 selection treated as simple random subsampling within ",
-          "Phase 1 strata."
-        )
-      ),
-      class = "surveycore_warning_full_no_phase2"
     )
   }
 

--- a/changelog/phase-0.75/twophase-constructor-na.md
+++ b/changelog/phase-0.75/twophase-constructor-na.md
@@ -1,0 +1,28 @@
+# fix(constructors): tighten as_survey_twophase() NA and method validation
+
+**Date**: 2026-02-24
+**Branch**: feature/twophase-constructor-na
+**Phase**: Phase 0.75
+
+## Changes
+
+- Change Warning 23b (NA in `subset` column) from a `cli_warn()` to a hard `cli_abort()` with class `surveycore_error_subset_na`; the phase 2 membership indicator must be fully observed for all phase 1 units
+- Remove Warning 25 (`method = "full"` with no Phase 2 design info) entirely from `as_survey_twophase()`; this check is deferred to estimation time in PR 3
+- Rename the `phase2_ind` column produced by `make_survey_data(design = "twophase")` to `subset` throughout all test files and the test data generator
+- Update `make_all_designs()` to use `method = "approx"` and remove `suppressWarnings()` wrapper (no longer needed)
+- Update `plans/error-messages.md`: replace row 23b (warning) with the new hard error; remove row 25
+
+## Files Modified
+
+- `R/03-constructors.R` — replace `cli_warn` with `cli_abort` for NA subset check; remove Warning 25 block
+- `tests/testthat/helper-test-data.R` — rename `phase2_ind` → `subset` in `make_survey_data()`; update `make_all_designs()` to use `method = "approx"` without `suppressWarnings()`
+- `tests/testthat/test-constructors.R` — rename all `phase2_ind` references to `subset`; replace Row 23b warning test with dual-pattern error test; delete Row 25 test blocks; update degenerate-with-NA test
+- `tests/testthat/test-conversion.R` — rename `phase2_ind` → `subset`; remove stale `suppressWarnings()` wrappers
+- `tests/testthat/test-methods-print.R` — rename `phase2_ind` → `subset`; remove `suppressWarnings()` wrapper
+- `tests/testthat/test-update-design.R` — rename `phase2_ind` → `subset`; remove `suppressWarnings()` wrapper
+- `tests/testthat/test-utils.R` — rename `phase2_ind` → `subset` including string literal in `expect_true()`
+- `tests/testthat/test-variance-dispatch.R` — update "not yet implemented" blocks to use `subset = subset, method = "approx"`
+- `tests/testthat/_snaps/constructors.md` — remove stale snapshots; add new error snapshot for Row 23b
+- `tests/testthat/_snaps/methods-print.md` — regenerate two-phase print/summary snapshots with updated column name
+- `plans/error-messages.md` — row 23b changed from WARN to ERROR (`surveycore_error_subset_na`); row 25 removed; Coverage Map updated
+- `plans/implementation-plan-phase-0.75.md` — mark PR 2 complete

--- a/plans/error-messages.md
+++ b/plans/error-messages.md
@@ -51,9 +51,8 @@ against the messages defined here.
 | 21 | `as_survey_twophase()` | `subset` selects >1 column | ERROR | `surveycore_error_subset_multiple` | `"{.arg subset} must select exactly one column, not {length(subset_cols)}"` |
 | 22 | `as_survey_twophase()` | `subset` column is not logical | ERROR | `surveycore_error_subset_not_logical` | `"{.arg subset} column {.field {subset_var}} must be logical, not {.cls {class(data[[subset_var]])}}"` |
 | 23 | `as_survey_twophase()` | `subset` is all TRUE or all FALSE (among non-NA) | ERROR | `surveycore_error_subset_degenerate` | `"{.arg subset} column {.field {subset_var}} must contain both TRUE and FALSE values (non-NA). Found {n_true} TRUE and {n_false} FALSE (non-NA) value(s)."` |
-| 23b | `as_survey_twophase()` | `subset` column contains NA values | WARN | `surveycore_warning_subset_na` | `"{.arg subset} column {.field {subset_var}} contains {n_na} NA value(s). Rows with NA are excluded from Phase 2. This may affect variance estimation."` |
+| 23b | `as_survey_twophase()` | `subset` column contains NA values | ERROR | `surveycore_error_subset_na` | `"x" = "{.arg subset} column {.field {subset_var}} contains {n_na} NA value(s).", "i" = "The phase 2 membership indicator must be fully observed for all phase 1 units.", "v" = "Remove rows with missing {.arg subset} values before calling {.fn as_survey_twophase}."` |
 | 24 | `as_survey_twophase()` | `method = "simple"` + clustered Phase 1 | WARN | `surveycore_warning_simple_clustered` | `'{.code method = "simple"} ignores the Phase 1 cluster design (PSUs: {.field {phase1@variables$ids}}). This understates variance. Use {.code method = "full"} or {.code method = "approx"}.'` |
-| 25 | `as_survey_twophase()` | `method = "full"` + no Phase 2 design info | WARN | `surveycore_warning_full_no_phase2` | `'No Phase 2 design information provided with {.code method = "full"}. Phase 2 selection treated as simple random subsampling within Phase 1 strata.'` |
 | 26 | `as_survey_twophase()` (validator) | Phase 2 design var all-NA within Phase 2 subset | WARN | `surveycore_warning_phase2_all_na` | `"Phase 2 design variable {.field {var}} is all NA within the Phase 2 subset. Check rows where {.field {subset_var}} is TRUE."` |
 | 27 | `set_var_label()` | Variable not found in data | ERROR | `surveycore_error_var_not_found` | `"Variable {.field {var_name}} not found in {.arg x}. Available: {.field {names(x@data)}}"` |
 | 28 | `set_variable_labels()` | One or more variables not found | ERROR | `surveycore_error_vars_not_found` | `"Variable(s) not found in {.arg x}: {.field {missing}}"` |
@@ -129,7 +128,7 @@ Which test files cover which error table rows:
 
 | Test File | Error Rows Covered |
 |-----------|-------------------|
-| `test-constructors.R` | 1–26, 56–61 |
+| `test-constructors.R` | 1–24, 23b, 56–61 |
 | `test-validators.R` | 27–35 |
 | `test-metadata-system.R` | 27–30 |
 | `test-s7-classes.R` | 31–35, 37–39 |

--- a/plans/implementation-plan-phase-0.75.md
+++ b/plans/implementation-plan-phase-0.75.md
@@ -35,7 +35,7 @@ quality gates from spec Section 11 are achieved by the time PR 3 merges.
 
 - [x] PR 1: `feature/variance-file-split` — Split `R/06-variance-estimation.R` into four
   engine-specific files and split the corresponding test file
-- [ ] PR 2: `feature/twophase-constructor-na` — Change Warning 23b to a hard error
+- [x] PR 2: `feature/twophase-constructor-na` — Change Warning 23b to a hard error
   (`surveycore_error_subset_na`) and remove Warning 25 from `as_survey_twophase()`; rename
   `phase2_ind` → `subset` in the test data generator
 - [ ] PR 3: `feature/variance-twophase` — Implement the two-phase variance engine, extend

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -133,7 +133,7 @@
 # as_survey_twophase() snapshot: method = 'simple' + clustered Phase 1 warning
 
     Code
-      as_survey_twophase(phase1, subset = phase2_ind, method = "simple")
+      as_survey_twophase(phase1, subset = subset, method = "simple")
     Condition
       Warning:
       ! `method = "simple"` ignores the Phase 1 cluster design (PSUs: psu). This understates variance. Use `method = "full"` or `method = "approx"`.
@@ -146,54 +146,24 @@
       
     Output
       # A tibble: 200 x 9
-         psu   strata      fpc    wt    y1      y2    y3 group phase2_ind
-         <chr> <chr>     <dbl> <dbl> <dbl>   <dbl> <int> <chr> <lgl>     
-       1 psu_1 stratum_1   416 12.2   48.4  0.0895     1 C     TRUE      
-       2 psu_1 stratum_1   416 10.8   42.3  0.231      0 A     FALSE     
-       3 psu_2 stratum_1   416 11.1   49.0 -0.0118     0 A     FALSE     
-       4 psu_2 stratum_1   416 14.7   50.4  0.885      0 A     TRUE      
-       5 psu_2 stratum_1   416 16.9   43.6  0.469      1 A     FALSE     
-       6 psu_2 stratum_1   416 11.7   44.3 -0.978      0 C     TRUE      
-       7 psu_2 stratum_1   416 16.4   40.0  0.631      0 A     FALSE     
-       8 psu_3 stratum_1   416 11.0   63.5 -0.509      0 B     FALSE     
-       9 psu_3 stratum_1   416 12.9   51.3  0.232      0 C     FALSE     
-      10 psu_4 stratum_1   416  9.48  45.8 -1.64       0 C     FALSE     
-      # i 190 more rows
-
-# as_survey_twophase() snapshot: method = 'full' + no Phase 2 info warning
-
-    Code
-      as_survey_twophase(phase1, subset = phase2_ind, method = "full")
-    Condition
-      Warning:
-      ! No Phase 2 design information provided with `method = "full"`. Phase 2 selection treated as simple random subsampling within Phase 1 strata.
-    Message
-      
-      -- Survey Design ---------------------------------------------------------------
-      <survey_twophase> (method: full)
-      Phase 1 sample size: 200
-      Phase 2 sample size: 76
-      
-    Output
-      # A tibble: 200 x 9
-         psu   strata      fpc    wt    y1      y2    y3 group phase2_ind
-         <chr> <chr>     <dbl> <dbl> <dbl>   <dbl> <int> <chr> <lgl>     
-       1 psu_1 stratum_1   613  14.2  50.8  0.863      1 B     FALSE     
-       2 psu_1 stratum_1   613  12.7  51.5  0.767      0 C     FALSE     
-       3 psu_1 stratum_1   613  16.1  58.5 -0.0415     0 B     TRUE      
-       4 psu_1 stratum_1   613  13.4  52.7 -1.31       0 C     FALSE     
-       5 psu_1 stratum_1   613  15.9  35.5 -1.75       0 C     TRUE      
-       6 psu_2 stratum_1   613  17.1  59.1  0.121      0 B     FALSE     
-       7 psu_2 stratum_1   613  16.3  50.4 -0.520      0 C     TRUE      
-       8 psu_3 stratum_1   613  13.5  63.6  0.471      0 A     TRUE      
-       9 psu_3 stratum_1   613  17.8  46.3 -1.27       0 B     FALSE     
-      10 psu_4 stratum_1   613  27.9  65.2 -0.797      0 A     FALSE     
+         psu   strata      fpc    wt    y1      y2    y3 group subset
+         <chr> <chr>     <dbl> <dbl> <dbl>   <dbl> <int> <chr> <lgl> 
+       1 psu_1 stratum_1   416 12.2   48.4  0.0895     1 C     TRUE  
+       2 psu_1 stratum_1   416 10.8   42.3  0.231      0 A     FALSE 
+       3 psu_2 stratum_1   416 11.1   49.0 -0.0118     0 A     FALSE 
+       4 psu_2 stratum_1   416 14.7   50.4  0.885      0 A     TRUE  
+       5 psu_2 stratum_1   416 16.9   43.6  0.469      1 A     FALSE 
+       6 psu_2 stratum_1   416 11.7   44.3 -0.978      0 C     TRUE  
+       7 psu_2 stratum_1   416 16.4   40.0  0.631      0 A     FALSE 
+       8 psu_3 stratum_1   416 11.0   63.5 -0.509      0 B     FALSE 
+       9 psu_3 stratum_1   416 12.9   51.3  0.232      0 C     FALSE 
+      10 psu_4 stratum_1   416  9.48  45.8 -1.64       0 C     FALSE 
       # i 190 more rows
 
 # as_survey_twophase() errors when phase1 is not a survey_taylor [row 19]
 
     Code
-      as_survey_twophase(df, subset = phase2_ind)
+      as_survey_twophase(df, subset = subset)
     Condition
       Error in `as_survey_twophase()`:
       x `phase1` must be a <survey_taylor> object, not <data.frame>.
@@ -210,7 +180,7 @@
 # as_survey_twophase() errors when subset selects multiple columns [row 21]
 
     Code
-      as_survey_twophase(phase1, subset = starts_with("phase2_ind"))
+      as_survey_twophase(phase1, subset = starts_with("subset"))
     Condition
       Error in `as_survey_twophase()`:
       x `subset` must select exactly one column, not 2
@@ -230,6 +200,16 @@
     Condition
       Error in `as_survey_twophase()`:
       x `subset` column all_true must contain both TRUE and FALSE values (non-NA). Found 200 TRUE and 0 FALSE (non-NA) value(s).
+
+# as_survey_twophase() errors for NA in subset column [row 23b]
+
+    Code
+      as_survey_twophase(phase1, subset = phase2_na, method = "approx")
+    Condition
+      Error in `as_survey_twophase()`:
+      x `subset` column phase2_na contains 1 NA value(s).
+      i The phase 2 membership indicator must be fully observed for all phase 1 units.
+      v Remove rows with missing `subset` values before calling `as_survey_twophase()`.
 
 # as_survey_calibrated() rejects non-data-frame input
 

--- a/tests/testthat/_snaps/methods-print.md
+++ b/tests/testthat/_snaps/methods-print.md
@@ -164,18 +164,18 @@
       
     Output
       # A tibble: 60 x 9
-         psu   strata      fpc    wt    y1         y2    y3 group phase2_ind
-         <chr> <chr>     <dbl> <dbl> <dbl>      <dbl> <int> <chr> <lgl>     
-       1 psu_1 stratum_1   451  14.3  60.4 -2.02          0 B     TRUE      
-       2 psu_1 stratum_1   451  21.8  59.2 -1.22          0 B     FALSE     
-       3 psu_1 stratum_1   451  14.4  57.2  0.180         1 B     FALSE     
-       4 psu_1 stratum_1   451  18.9  39.6  0.568         1 C     TRUE      
-       5 psu_2 stratum_1   451  23.0  49.1 -0.493         1 A     FALSE     
-       6 psu_2 stratum_1   451  11.0  56.2  0.0000629     0 C     TRUE      
-       7 psu_2 stratum_1   451  13.8  40.5  1.12          0 A     TRUE      
-       8 psu_2 stratum_1   451  14.2  44.6  1.44          0 C     FALSE     
-       9 psu_2 stratum_1   451  16.5  55.8 -1.10          0 A     TRUE      
-      10 psu_2 stratum_1   451  13.7  57.7 -0.117         1 B     TRUE      
+         psu   strata      fpc    wt    y1         y2    y3 group subset
+         <chr> <chr>     <dbl> <dbl> <dbl>      <dbl> <int> <chr> <lgl> 
+       1 psu_1 stratum_1   451  14.3  60.4 -2.02          0 B     TRUE  
+       2 psu_1 stratum_1   451  21.8  59.2 -1.22          0 B     FALSE 
+       3 psu_1 stratum_1   451  14.4  57.2  0.180         1 B     FALSE 
+       4 psu_1 stratum_1   451  18.9  39.6  0.568         1 C     TRUE  
+       5 psu_2 stratum_1   451  23.0  49.1 -0.493         1 A     FALSE 
+       6 psu_2 stratum_1   451  11.0  56.2  0.0000629     0 C     TRUE  
+       7 psu_2 stratum_1   451  13.8  40.5  1.12          0 A     TRUE  
+       8 psu_2 stratum_1   451  14.2  44.6  1.44          0 C     FALSE 
+       9 psu_2 stratum_1   451  16.5  55.8 -1.10          0 A     TRUE  
+      10 psu_2 stratum_1   451  13.7  57.7 -0.117         1 B     TRUE  
       # i 50 more rows
 
 # print.survey_twophase full=TRUE output matches snapshot
@@ -199,7 +199,7 @@
       
       -- Phase 2 design --
       
-      * Subset: phase2_ind
+      * Subset: subset
       
       
       -- Metadata --
@@ -208,18 +208,18 @@
       
     Output
       # A tibble: 60 x 9
-         psu   strata      fpc    wt    y1         y2    y3 group phase2_ind
-         <chr> <chr>     <dbl> <dbl> <dbl>      <dbl> <int> <chr> <lgl>     
-       1 psu_1 stratum_1   451  14.3  60.4 -2.02          0 B     TRUE      
-       2 psu_1 stratum_1   451  21.8  59.2 -1.22          0 B     FALSE     
-       3 psu_1 stratum_1   451  14.4  57.2  0.180         1 B     FALSE     
-       4 psu_1 stratum_1   451  18.9  39.6  0.568         1 C     TRUE      
-       5 psu_2 stratum_1   451  23.0  49.1 -0.493         1 A     FALSE     
-       6 psu_2 stratum_1   451  11.0  56.2  0.0000629     0 C     TRUE      
-       7 psu_2 stratum_1   451  13.8  40.5  1.12          0 A     TRUE      
-       8 psu_2 stratum_1   451  14.2  44.6  1.44          0 C     FALSE     
-       9 psu_2 stratum_1   451  16.5  55.8 -1.10          0 A     TRUE      
-      10 psu_2 stratum_1   451  13.7  57.7 -0.117         1 B     TRUE      
+         psu   strata      fpc    wt    y1         y2    y3 group subset
+         <chr> <chr>     <dbl> <dbl> <dbl>      <dbl> <int> <chr> <lgl> 
+       1 psu_1 stratum_1   451  14.3  60.4 -2.02          0 B     TRUE  
+       2 psu_1 stratum_1   451  21.8  59.2 -1.22          0 B     FALSE 
+       3 psu_1 stratum_1   451  14.4  57.2  0.180         1 B     FALSE 
+       4 psu_1 stratum_1   451  18.9  39.6  0.568         1 C     TRUE  
+       5 psu_2 stratum_1   451  23.0  49.1 -0.493         1 A     FALSE 
+       6 psu_2 stratum_1   451  11.0  56.2  0.0000629     0 C     TRUE  
+       7 psu_2 stratum_1   451  13.8  40.5  1.12          0 A     TRUE  
+       8 psu_2 stratum_1   451  14.2  44.6  1.44          0 C     FALSE 
+       9 psu_2 stratum_1   451  16.5  55.8 -1.10          0 A     TRUE  
+      10 psu_2 stratum_1   451  13.7  57.7 -0.117         1 B     TRUE  
       # i 50 more rows
 
 # summary.survey_taylor output matches snapshot
@@ -291,7 +291,7 @@
       
       -- Phase 2 design --
       
-      Subset: phase2_ind
+      Subset: subset
       
       Metadata: 0 of 9 variable(s) labeled
 

--- a/tests/testthat/helper-test-data.R
+++ b/tests/testthat/helper-test-data.R
@@ -32,7 +32,7 @@
 #'
 #' Additional columns by design:
 #'   - design = "replicate": repwt_1 ... repwt_R replicate weight columns
-#'   - design = "twophase":  phase2_ind (logical, ~40% TRUE)
+#'   - design = "twophase":  subset (logical, ~40% TRUE)
 #'
 #' @param n         Total number of rows. Default 500L.
 #' @param n_psu     Number of PSUs. Default 50L. For BRR/Fay must be even.
@@ -143,7 +143,7 @@ make_survey_data <- function(
 
   # --- Two-phase indicator ---
   if (design == "twophase") {
-    df$phase2_ind <- runif(n) < 0.4
+    df$subset <- runif(n) < 0.4
   }
 
   # --- Haven-style label attributes ---
@@ -443,7 +443,7 @@ make_all_designs <- function(seed = 42L) {
     df_p,
     ids = psu, weights = wt, strata = strata, fpc = fpc, nest = TRUE
   )
-  twophase <- suppressWarnings(as_survey_twophase(phase1, subset = phase2_ind))
+  twophase <- as_survey_twophase(phase1, subset = subset, method = "approx")
 
   # Calibrated design (non-probability, weights only)
   df_c <- make_survey_data(

--- a/tests/testthat/test-constructors.R
+++ b/tests/testthat/test-constructors.R
@@ -827,21 +827,17 @@ test_that("as_survey_rep() accepts bare name for weights", {
 test_that("as_survey_twophase() creates survey_twophase for minimal two-phase design", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 1L)
   phase1 <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  d2 <- suppressWarnings(
-    as_survey_twophase(phase1, subset = phase2_ind)
-  )
+  d2 <- as_survey_twophase(phase1, subset = subset)
   test_invariants(d2)
   expect_true(S7::S7_inherits(d2, survey_twophase))
-  expect_identical(d2@variables$subset, "phase2_ind")
+  expect_identical(d2@variables$subset, "subset")
   expect_identical(d2@variables$method, "full")
 })
 
 test_that("as_survey_twophase() creates survey_twophase with method = 'approx'", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 2L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  d2 <- suppressWarnings(
-    as_survey_twophase(phase1, subset = phase2_ind, method = "approx")
-  )
+  d2 <- as_survey_twophase(phase1, subset = subset, method = "approx")
   test_invariants(d2)
   expect_identical(d2@variables$method, "approx")
 })
@@ -850,9 +846,7 @@ test_that("as_survey_twophase() creates survey_twophase with method = 'simple' (
   # No PSUs in Phase 1 -> no 'simple' warning
   df <- make_survey_data(n = 200, design = "twophase", seed = 3L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  d2 <- suppressWarnings(
-    as_survey_twophase(phase1, subset = phase2_ind, method = "simple")
-  )
+  d2 <- as_survey_twophase(phase1, subset = subset, method = "simple")
   test_invariants(d2)
   expect_identical(d2@variables$method, "simple")
 })
@@ -860,9 +854,7 @@ test_that("as_survey_twophase() creates survey_twophase with method = 'simple' (
 test_that("as_survey_twophase() stores Phase 2 stratification in @variables$phase2", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 4L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  d2 <- suppressWarnings(
-    as_survey_twophase(phase1, strata2 = strata, subset = phase2_ind)
-  )
+  d2 <- as_survey_twophase(phase1, strata2 = strata, subset = subset)
   test_invariants(d2)
   expect_identical(d2@variables$phase2$strata, "strata")
   expect_null(d2@variables$phase2$ids)
@@ -875,10 +867,8 @@ test_that("as_survey_twophase() stores Phase 2 probs in @variables$phase2", {
   # Add a fake probs2 column
   df$subsamprate <- rep(0.4, nrow(df))
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  d2 <- suppressWarnings(
-    as_survey_twophase(phase1, probs2 = subsamprate, subset = phase2_ind,
-                       method = "full")
-  )
+  d2 <- as_survey_twophase(phase1, probs2 = subsamprate, subset = subset,
+                            method = "full")
   test_invariants(d2)
   expect_identical(d2@variables$phase2$probs, "subsamprate")
 })
@@ -886,9 +876,7 @@ test_that("as_survey_twophase() stores Phase 2 probs in @variables$phase2", {
 test_that("as_survey_twophase() stores Phase 2 cluster ids in @variables$phase2", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 6L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  d2 <- suppressWarnings(
-    as_survey_twophase(phase1, ids2 = psu, subset = phase2_ind)
-  )
+  d2 <- as_survey_twophase(phase1, ids2 = psu, subset = subset)
   test_invariants(d2)
   expect_identical(d2@variables$phase2$ids, "psu")
 })
@@ -896,9 +884,7 @@ test_that("as_survey_twophase() stores Phase 2 cluster ids in @variables$phase2"
 test_that("as_survey_twophase() stores Phase 2 fpc in @variables$phase2", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 7L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  d2 <- suppressWarnings(
-    as_survey_twophase(phase1, fpc2 = fpc, subset = phase2_ind)
-  )
+  d2 <- as_survey_twophase(phase1, fpc2 = fpc, subset = subset)
   test_invariants(d2)
   expect_identical(d2@variables$phase2$fpc, "fpc")
 })
@@ -906,9 +892,7 @@ test_that("as_survey_twophase() stores Phase 2 fpc in @variables$phase2", {
 test_that("as_survey_twophase() stores Phase 1 @variables in @variables$phase1", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 8L)
   phase1 <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  d2 <- suppressWarnings(
-    as_survey_twophase(phase1, subset = phase2_ind)
-  )
+  d2 <- as_survey_twophase(phase1, subset = subset)
   test_invariants(d2)
   # Phase 1 variables preserved in nested structure
   expect_identical(d2@variables$phase1$weights, "wt")
@@ -920,9 +904,7 @@ test_that("as_survey_twophase() stores Phase 1 @variables in @variables$phase1",
 test_that("as_survey_twophase() inherits metadata from phase1", {
   df <- make_survey_data(n = 200, design = "twophase", with_labels = TRUE, seed = 9L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  d2 <- suppressWarnings(
-    as_survey_twophase(phase1, subset = phase2_ind)
-  )
+  d2 <- as_survey_twophase(phase1, subset = subset)
   test_invariants(d2)
   # Metadata inherited from phase1
   expect_identical(
@@ -934,9 +916,7 @@ test_that("as_survey_twophase() inherits metadata from phase1", {
 test_that("as_survey_twophase() stores call in @call", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 10L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  d2 <- suppressWarnings(
-    as_survey_twophase(phase1, subset = phase2_ind)
-  )
+  d2 <- as_survey_twophase(phase1, subset = subset)
   expect_false(is.null(d2@call))
   expect_true(is.call(d2@call))
 })
@@ -944,9 +924,7 @@ test_that("as_survey_twophase() stores call in @call", {
 test_that("as_survey_twophase() uses @data from phase1 (no copy)", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 11L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  d2 <- suppressWarnings(
-    as_survey_twophase(phase1, subset = phase2_ind)
-  )
+  d2 <- as_survey_twophase(phase1, subset = subset)
   # @data should be the same data as phase1@data
   expect_identical(nrow(d2@data), nrow(phase1@data))
   expect_identical(names(d2@data), names(phase1@data))
@@ -955,9 +933,7 @@ test_that("as_survey_twophase() uses @data from phase1 (no copy)", {
 test_that("as_survey_twophase() sets all Phase 2 variables to NULL when not provided", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 12L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  d2 <- suppressWarnings(
-    as_survey_twophase(phase1, subset = phase2_ind)
-  )
+  d2 <- as_survey_twophase(phase1, subset = subset)
   test_invariants(d2)
   expect_null(d2@variables$phase2$ids)
   expect_null(d2@variables$phase2$strata)
@@ -975,7 +951,7 @@ test_that("as_survey_twophase() warns when method = 'simple' with clustered Phas
     as_survey(df, ids = psu, weights = wt, strata = strata)
   )
   expect_warning(
-    as_survey_twophase(phase1, subset = phase2_ind, method = "simple"),
+    as_survey_twophase(phase1, subset = subset, method = "simple"),
     class = "surveycore_warning_simple_clustered"
   )
 })
@@ -984,29 +960,8 @@ test_that("as_survey_twophase() does NOT warn for method = 'simple' when Phase 1
   df <- make_survey_data(n = 200, design = "twophase", seed = 14L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))  # no ids
   expect_no_warning(
-    as_survey_twophase(phase1, subset = phase2_ind, method = "simple"),
+    as_survey_twophase(phase1, subset = subset, method = "simple"),
     message = "surveycore_warning_simple_clustered"
-  )
-})
-
-# Row 25: method = "full" with no Phase 2 design info
-test_that("as_survey_twophase() warns when method = 'full' with no Phase 2 info [row 25]", {
-  df <- make_survey_data(n = 200, design = "twophase", seed = 15L)
-  phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  expect_warning(
-    as_survey_twophase(phase1, subset = phase2_ind, method = "full"),
-    class = "surveycore_warning_full_no_phase2"
-  )
-})
-
-test_that("as_survey_twophase() does NOT warn for method = 'full' when Phase 2 probs provided [row 25]", {
-  df <- make_survey_data(n = 200, design = "twophase", seed = 16L)
-  df$prob2 <- rep(0.4, nrow(df))
-  phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  expect_no_warning(
-    as_survey_twophase(phase1, probs2 = prob2, subset = phase2_ind,
-                       method = "full"),
-    message = "surveycore_warning_full_no_phase2"
   )
 })
 
@@ -1016,15 +971,7 @@ test_that("as_survey_twophase() snapshot: method = 'simple' + clustered Phase 1 
     as_survey(df, ids = psu, weights = wt, strata = strata)
   )
   expect_snapshot(
-    as_survey_twophase(phase1, subset = phase2_ind, method = "simple")
-  )
-})
-
-test_that("as_survey_twophase() snapshot: method = 'full' + no Phase 2 info warning", {
-  df <- make_survey_data(n = 200, design = "twophase", seed = 18L)
-  phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  expect_snapshot(
-    as_survey_twophase(phase1, subset = phase2_ind, method = "full")
+    as_survey_twophase(phase1, subset = subset, method = "simple")
   )
 })
 
@@ -1035,18 +982,19 @@ test_that("as_survey_twophase() snapshot: method = 'full' + no Phase 2 info warn
 test_that("as_survey_twophase() errors when phase1 is not a survey_taylor [row 19]", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 19L)
   expect_error(
-    as_survey_twophase(df, subset = phase2_ind),
+    as_survey_twophase(df, subset = subset),
     class = "surveycore_error_phase1_class"
   )
-  expect_snapshot(error = TRUE, as_survey_twophase(df, subset = phase2_ind))
+  expect_snapshot(error = TRUE, as_survey_twophase(df, subset = subset))
 })
 
 test_that("as_survey_twophase() errors when phase1 is a survey_replicate [row 19]", {
   df <- make_survey_data(n = 100, n_psu = 10L, design = "replicate", seed = 20L)
   phase_rep <- as_survey_rep(df, weights = wt, repweights = starts_with("repwt_"),
                               type = "JK1")
+  # phase1 class error fires before subset is resolved — bare name doesn't matter
   expect_error(
-    as_survey_twophase(phase_rep, subset = phase2_ind),
+    as_survey_twophase(phase_rep, subset = in_phase2),
     class = "surveycore_error_phase1_class"
   )
 })
@@ -1065,24 +1013,24 @@ test_that("as_survey_twophase() errors when subset is not provided [row 20]", {
 # Row 21: subset selects >1 column
 test_that("as_survey_twophase() errors when subset selects multiple columns [row 21]", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 22L)
-  # Add a second logical column with same prefix
-  df$phase2_ind2 <- runif(nrow(df)) < 0.4
+  # Add a second logical column with same prefix so starts_with("subset") matches both
+  df$subset2 <- runif(nrow(df)) < 0.4
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
   expect_error(
-    as_survey_twophase(phase1, subset = starts_with("phase2_ind")),
+    as_survey_twophase(phase1, subset = starts_with("subset")),
     class = "surveycore_error_subset_multiple"
   )
   expect_snapshot(
     error = TRUE,
-    as_survey_twophase(phase1, subset = starts_with("phase2_ind"))
+    as_survey_twophase(phase1, subset = starts_with("subset"))
   )
 })
 
 # Row 22: subset column is not logical
 test_that("as_survey_twophase() errors when subset column is not logical [row 22]", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 23L)
-  # Replace logical phase2_ind with integer
-  df$phase2_int <- as.integer(df$phase2_ind)
+  # Replace logical subset with integer
+  df$phase2_int <- as.integer(df$subset)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
   expect_error(
     as_survey_twophase(phase1, subset = phase2_int),
@@ -1116,38 +1064,35 @@ test_that("as_survey_twophase() errors when subset is all FALSE [row 23]", {
   )
 })
 
-# Row 23b: subset column contains NA values (new warning)
-test_that("as_survey_twophase() warns when subset column has NA values [row 23b]", {
-  df              <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L,
-                                      design = "twophase", seed = 30L)
-  df$phase2_na    <- df$phase2_ind
-  df$phase2_na[1] <- NA  # introduce one NA
-  phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  # Suppress secondary warnings (e.g. surveycore_warning_full_no_phase2) so only
-  # the expected surveycore_warning_subset_na class is visible to expect_warning.
-  got_na_warn <- FALSE
-  suppressWarnings(
-    withCallingHandlers(
-      as_survey_twophase(phase1, subset = phase2_na),
-      surveycore_warning_subset_na = function(w) {
-        got_na_warn <<- TRUE
-        invokeRestart("muffleWarning")
-      }
-    )
+# Row 23b: subset column contains NA values (hard error)
+test_that("as_survey_twophase() errors for NA in subset column [row 23b]", {
+  df           <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L,
+                                   design = "twophase", seed = 30L)
+  df$phase2_na    <- df$subset
+  df$phase2_na[1] <- NA
+  phase1 <- as_survey(df, weights = wt, strata = strata)
+  expect_error(
+    as_survey_twophase(phase1, subset = phase2_na, method = "approx"),
+    class = "surveycore_error_subset_na"
   )
-  expect_true(got_na_warn, label = "surveycore_warning_subset_na was raised")
+  expect_snapshot(
+    error = TRUE,
+    as_survey_twophase(phase1, subset = phase2_na, method = "approx")
+  )
 })
 
 test_that("as_survey_twophase() degenerate check uses non-NA count in message [row 23]", {
-  # All-TRUE case with some NAs — message should mention n_false = 0, not n_total
+  # All-TRUE case with some NAs — the NA error fires first (row 23b), then if we
+  # fix the NA we'd hit degenerate. Test that subset_na error fires before degenerate.
   df           <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L,
                                    design = "twophase", seed = 31L)
   df$all_true  <- TRUE
   df$all_true[1] <- NA
-  phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
+  phase1 <- as_survey(df, weights = wt, strata = strata)
+  # The NA check fires first (row 23b)
   expect_error(
-    suppressWarnings(as_survey_twophase(phase1, subset = all_true)),
-    class = "surveycore_error_subset_degenerate"
+    as_survey_twophase(phase1, subset = all_true),
+    class = "surveycore_error_subset_na"
   )
 })
 
@@ -1160,9 +1105,7 @@ test_that("as_survey_twophase() with multi-stage Phase 2 ids (c())", {
   df$psu2 <- rep(1:5, length.out = nrow(df))
   df$ssu2 <- rep(1:4, length.out = nrow(df))
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  d2 <- suppressWarnings(
-    as_survey_twophase(phase1, ids2 = c(psu2, ssu2), subset = phase2_ind)
-  )
+  d2 <- as_survey_twophase(phase1, ids2 = c(psu2, ssu2), subset = subset)
   test_invariants(d2)
   expect_identical(d2@variables$phase2$ids, c("psu2", "ssu2"))
 })
@@ -1170,9 +1113,7 @@ test_that("as_survey_twophase() with multi-stage Phase 2 ids (c())", {
 test_that("as_survey_twophase() preserves all Phase 1 data columns in @data", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 27L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  d2 <- suppressWarnings(
-    as_survey_twophase(phase1, subset = phase2_ind)
-  )
+  d2 <- as_survey_twophase(phase1, subset = subset)
   # All original columns must be in @data (none dropped)
   expect_true(all(names(df) %in% names(d2@data)))
 })
@@ -1187,30 +1128,25 @@ test_that("as_survey_twophase() subset with only 1 TRUE row is valid (not degene
   )
   phase1 <- as_survey(df, weights = wt, strata = strata)
   # 1 TRUE and 19 FALSE — not degenerate
-  d2 <- suppressWarnings(
-    as_survey_twophase(phase1, subset = in_phase2)
-  )
+  d2 <- as_survey_twophase(phase1, subset = in_phase2)
   test_invariants(d2)
   expect_true(S7::S7_inherits(d2, survey_twophase))
 })
 
-test_that("as_survey_twophase() with method = 'full' and strata2 does not warn [row 25]", {
-  # Providing strata2 counts as Phase 2 design info
+test_that("as_survey_twophase() with method = 'full' and strata2 does not produce unsupported warning", {
+  # Providing strata2 is valid Phase 2 design info for method = 'full'
   df <- make_survey_data(n = 200, design = "twophase", seed = 28L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
   expect_no_warning(
-    as_survey_twophase(phase1, strata2 = strata, subset = phase2_ind,
-                       method = "full"),
-    message = "surveycore_warning_full_no_phase2"
+    as_survey_twophase(phase1, strata2 = strata, subset = subset,
+                       method = "full")
   )
 })
 
 test_that("as_survey_twophase() populates all expected @variables keys", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 29L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  d2 <- suppressWarnings(
-    as_survey_twophase(phase1, subset = phase2_ind)
-  )
+  d2 <- as_survey_twophase(phase1, subset = subset)
   expected_keys <- c("phase1", "phase2", "subset", "method")
   expect_true(all(expected_keys %in% names(d2@variables)))
 })
@@ -1221,19 +1157,15 @@ test_that("as_survey_twophase() populates all expected @variables keys", {
 test_that("as_survey_twophase() accepts bare name for subset", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 30L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  d2 <- suppressWarnings(
-    as_survey_twophase(phase1, subset = phase2_ind)
-  )
+  d2 <- as_survey_twophase(phase1, subset = subset)
   test_invariants(d2)
-  expect_identical(d2@variables$subset, "phase2_ind")
+  expect_identical(d2@variables$subset, "subset")
 })
 
 test_that("as_survey_twophase() accepts bare name for strata2", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 31L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  d2 <- suppressWarnings(
-    as_survey_twophase(phase1, strata2 = strata, subset = phase2_ind)
-  )
+  d2 <- as_survey_twophase(phase1, strata2 = strata, subset = subset)
   test_invariants(d2)
   expect_identical(d2@variables$phase2$strata, "strata")
 })
@@ -1241,9 +1173,7 @@ test_that("as_survey_twophase() accepts bare name for strata2", {
 test_that("as_survey_twophase() accepts bare name for ids2", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 32L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
-  d2 <- suppressWarnings(
-    as_survey_twophase(phase1, ids2 = psu, subset = phase2_ind)
-  )
+  d2 <- as_survey_twophase(phase1, ids2 = psu, subset = subset)
   test_invariants(d2)
   expect_identical(d2@variables$phase2$ids, "psu")
 })
@@ -1304,7 +1234,7 @@ test_that("as_survey_twophase() errors when strata2 selects multiple columns", {
   df$st2b <- df$strata
   phase1  <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
   expect_error(
-    as_survey_twophase(phase1, strata2 = starts_with("st2"), subset = phase2_ind),
+    as_survey_twophase(phase1, strata2 = starts_with("st2"), subset = subset),
     class = "surveycore_error_strata_multiple"
   )
 })
@@ -1315,7 +1245,7 @@ test_that("as_survey_twophase() errors when probs2 selects multiple columns", {
   df$prob2b <- runif(nrow(df), 0.3, 0.8)
   phase1    <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
   expect_error(
-    as_survey_twophase(phase1, probs2 = starts_with("prob2"), subset = phase2_ind),
+    as_survey_twophase(phase1, probs2 = starts_with("prob2"), subset = subset),
     class = "surveycore_error_weights_multiple"
   )
 })
@@ -1326,7 +1256,7 @@ test_that("as_survey_twophase() errors when fpc2 selects multiple columns", {
   df$fpc2b <- rep(2000L, nrow(df))
   phase1   <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
   expect_error(
-    as_survey_twophase(phase1, fpc2 = starts_with("fpc2"), subset = phase2_ind),
+    as_survey_twophase(phase1, fpc2 = starts_with("fpc2"), subset = subset),
     class = "surveycore_error_fpc_multiple"
   )
 })

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -83,7 +83,7 @@ make_twophase <- function(seed = 42L) {
     n = 60L, n_psu = 10L, n_strata = 2L, design = "twophase", seed = seed
   )
   phase1 <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc, nest = TRUE)
-  suppressWarnings(as_survey_twophase(phase1, subset = phase2_ind))
+  as_survey_twophase(phase1, subset = subset)
 }
 
 
@@ -306,7 +306,7 @@ test_that("from_svydesign() converts twophase design to survey_twophase without 
   skip_if_not_installed("survey")
   df    <- make_survey_data(n = 60L, n_psu = 10L, n_strata = 2L, design = "twophase", seed = 42L)
   phase1 <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc, nest = TRUE)
-  d_sc  <- suppressWarnings(as_survey_twophase(phase1, subset = phase2_ind))
+  d_sc  <- as_survey_twophase(phase1, subset = subset)
   sv_tp <- suppressWarnings(as_svydesign(d_sc))
   d     <- suppressWarnings(from_svydesign(sv_tp))
   expect_true(!is.null(d))
@@ -345,7 +345,7 @@ test_that("from_svydesign(twophase) returns a survey_twophase object", {
   skip_if_not_installed("survey")
   df    <- make_survey_data(n = 60L, n_psu = 10L, n_strata = 2L, design = "twophase", seed = 42L)
   phase1 <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc, nest = TRUE)
-  d_sc  <- suppressWarnings(as_survey_twophase(phase1, subset = phase2_ind))
+  d_sc  <- as_survey_twophase(phase1, subset = subset)
   sv_tp <- suppressWarnings(as_svydesign(d_sc))
   d     <- suppressWarnings(from_svydesign(sv_tp))
   expect_true(S7::S7_inherits(d, survey_twophase))
@@ -526,7 +526,7 @@ test_that("as_svydesign() handles twophase design with SRS phase1 (no ids)", {
   df     <- make_survey_data(n = 100L, design = "twophase", seed = 301L)
   # phase1 with no ids (SRS-like) — p1$ids will be NULL
   phase1 <- as_survey(df, weights = wt, strata = strata)
-  d2     <- suppressWarnings(as_survey_twophase(phase1, subset = phase2_ind))
+  d2     <- as_survey_twophase(phase1, subset = subset)
   sv     <- suppressWarnings(as_svydesign(d2))
   expect_true(inherits(sv, "survey.design"))
 })
@@ -536,9 +536,7 @@ test_that("as_svydesign() handles twophase design with phase2 ids", {
   skip_if_not_installed("survey")
   df     <- make_survey_data(n = 100L, design = "twophase", seed = 302L)
   phase1 <- as_survey(df, weights = wt, strata = strata)
-  d2     <- suppressWarnings(
-    as_survey_twophase(phase1, ids2 = psu, subset = phase2_ind)
-  )
+  d2     <- as_survey_twophase(phase1, ids2 = psu, subset = subset)
   sv     <- suppressWarnings(as_svydesign(d2))
   expect_true(inherits(sv, "survey.design"))
 })

--- a/tests/testthat/test-methods-print.R
+++ b/tests/testthat/test-methods-print.R
@@ -97,7 +97,7 @@ make_twophase_design <- function(seed = 42L) {
     fpc     = fpc,
     nest    = TRUE
   )
-  suppressWarnings(as_survey_twophase(phase1, subset = phase2_ind))
+  as_survey_twophase(phase1, subset = subset)
 }
 
 

--- a/tests/testthat/test-update-design.R
+++ b/tests/testthat/test-update-design.R
@@ -160,7 +160,7 @@ test_that("update_design() validate=TRUE result passes test_invariants()", {
 test_that("update_design() errors for survey_twophase with unsupported class", {
   df     <- make_survey_data(n = 100L, design = "twophase", seed = 40L)
   phase1 <- as_survey(df, weights = wt, strata = strata)
-  d2     <- suppressWarnings(as_survey_twophase(phase1, subset = phase2_ind))
+  d2     <- as_survey_twophase(phase1, subset = subset)
   expect_error(
     update_design(d2, weights = wt),
     class = "surveycore_error_unsupported_class"

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -55,7 +55,7 @@ make_twophase <- function(seed = 42L) {
     n = 60L, n_psu = 10L, n_strata = 2L, design = "twophase", seed = seed
   )
   phase1 <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc, nest = TRUE)
-  suppressWarnings(as_survey_twophase(phase1, subset = phase2_ind))
+  as_survey_twophase(phase1, subset = subset)
 }
 
 make_twophase_with_p2 <- function(seed = 42L) {
@@ -173,7 +173,7 @@ test_that(".get_design_vars_flat() returns phase1, phase2, and subset vars for s
   expect_true("wt"         %in% flat)
   expect_true("strata"     %in% flat)
   expect_true("fpc"        %in% flat)
-  expect_true("phase2_ind" %in% flat)
+  expect_true("subset" %in% flat)
 })
 
 
@@ -283,7 +283,7 @@ test_that(".get_design_vars() unlist() gives all design var names for survey_two
   flat <- unlist(surveycore:::.get_design_vars(d), use.names = FALSE)
   expect_true("psu"        %in% flat)
   expect_true("wt"         %in% flat)
-  expect_true("phase2_ind" %in% flat)
+  expect_true("subset" %in% flat)
 })
 
 

--- a/tests/testthat/test-variance-dispatch.R
+++ b/tests/testthat/test-variance-dispatch.R
@@ -44,9 +44,7 @@ test_that("get_totals() returns correct structure", {
 test_that("get_means() errors on two-phase design (not yet implemented)", {
   d <- make_survey_data(design = "twophase", seed = 1)
   phase1 <- as_survey(d, ids = psu, strata = strata, weights = wt)
-  two    <- suppressWarnings(
-    as_survey_twophase(phase1, subset = phase2_ind)
-  )
+  two    <- as_survey_twophase(phase1, subset = subset, method = "approx")
   expect_error(
     get_means(two, y1),
     class = "surveycore_error_unsupported_class"
@@ -56,9 +54,7 @@ test_that("get_means() errors on two-phase design (not yet implemented)", {
 test_that("get_totals() errors on two-phase design (not yet implemented)", {
   d <- make_survey_data(design = "twophase", seed = 1)
   phase1 <- as_survey(d, ids = psu, strata = strata, weights = wt)
-  two    <- suppressWarnings(
-    as_survey_twophase(phase1, subset = phase2_ind)
-  )
+  two    <- as_survey_twophase(phase1, subset = subset, method = "approx")
   expect_error(
     get_totals(two, y1),
     class = "surveycore_error_unsupported_class"


### PR DESCRIPTION
## What

Converts the soft NA warning on `subset` columns to a hard error, removes
the `method = "full"` advisory warning (deferred to estimation time in PR 3),
and renames the `phase2_ind` test-data column to `subset` throughout.

## Checklist

- [x] Tests written and passing (`devtools::test()`)
- [x] R CMD check: 0 errors, 0 warnings (`devtools::check()`)
- [x] Roxygen docs updated and `devtools::document()` run (no roxygen changes)
- [x] `plans/error-messages.md` updated (row 23b changed WARN→ERROR; row 25 removed)
- [ ] `VENDORED.md` updated (no vendored code changes)
- [x] PR title is a valid Conventional Commit (`fix(constructors): description`)