### PR TITLE
docs(vignette): add creating-survey-objects vignette

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,7 @@
 ^docs$
 ^pkgdown$
 ^cran-comments\.md$
+
+# Quarto vignette build artifacts
+^vignettes/.*_files$
+^vignettes/.*\.html$

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@
 data-raw/brfss/LLCP2023.XPT
 data-raw/brfss/LLCP2023XPT.zip
 docs
+
+# Quarto vignette build artifacts — generated from .qmd source by R CMD check
+vignettes/*.html
+vignettes/*_files/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,10 @@ Suggests:
     lifecycle (>= 1.0.0),
     covr,
     knitr,
-    rmarkdown
+    rmarkdown,
+    quarto,
+    survival
+VignetteBuilder: quarto
 Config/testthat/edition: 3
 URL: https://github.com/JDenn0514/surveycore, https://jdenn0514.github.io/surveycore/
 BugReports: https://github.com/JDenn0514/surveycore/issues

--- a/changelog/phase-0.75/vignette-creating-survey-objects.md
+++ b/changelog/phase-0.75/vignette-creating-survey-objects.md
@@ -1,0 +1,40 @@
+# docs(vignette): add creating-survey-objects vignette
+
+**Date**: 2026-02-25
+**Branch**: docs/vignette-creating-survey-objects
+**Phase**: Phase 0.75
+
+## Changes
+
+- Add `vignettes/creating-survey-objects.qmd`: a full worked-example vignette
+  covering all five constructors (`as_survey()`, `as_survey_rep()`,
+  `as_survey_srs()`, `as_survey_calibrated()`, `as_survey_twophase()`)
+  with a decision guide, codebook variable reference tables (with Function
+  Argument column), and worked examples for NHANES, ANES, GSS, Pew NPORS,
+  ACS PUMS, Pew Jewish Americans, the school district SRS case, the
+  message-testing panel, and the university voluntary response case
+- Add `vignettes/references.bib`: bibliography covering Cochran (1977),
+  Lohr (2022), Lumley (2010), Wolter (2007), Valliant & Dever (2018),
+  Fay (1989), Judkins (1990), Baker et al. (2013), Elliott & Valliant (2017),
+  Mercer et al. (2018), McPhee et al. (2023), and Census Bureau (2022)
+- Include decision table mapping design type to constructor, reordered so
+  `as_survey_srs()` precedes `as_survey_calibrated()` and
+  `as_survey_twophase()` is last (rarest use case)
+- Add per-dataset variable reference tables with Variable, Role, and
+  Function Argument columns for all six bundled datasets
+- Add Section 5.3 clarification: unit of analysis is the school (not the
+  student) and why the weight is constant in SRS
+- Add Section 6.2 expansion: `as_survey_calibrated()` covers raking,
+  post-stratification, propensity score weighting, and matching-based weights
+- Add Section 6.6 worked example: university voluntary response survey,
+  with guidance for both the calibrated-weights and weights = 1 paths
+- Add Section 7: probability vs. calibration weights — comparison table and
+  practical test for choosing the right constructor
+- Add Section 8: when no constructor applies — program evaluation classrooms
+  as a worked example, with a general decision rule table
+- Add Section 9 (renumbered from 7): common codebook variable reference
+
+## Files Modified
+
+- `vignettes/creating-survey-objects.qmd` — new file: full vignette source
+- `vignettes/references.bib` — new file: bibliography

--- a/plans/aapor-compliance-review.md
+++ b/plans/aapor-compliance-review.md
@@ -1,0 +1,144 @@
+# AAPOR Compliance Review — surveycore Phase 1
+
+**Status:** Deferred — review after Phase 1 spec is finalized
+**Created:** 2026-02-24
+**Context:** Raised during Phase 1 spec-workflow Stage 3 issue resolution
+
+---
+
+## Background
+
+During spec review, the question arose of whether surveycore's analysis
+functions follow AAPOR (American Association for Public Opinion Research)
+reporting standards. This document captures the gap analysis and options for
+a future planning session.
+
+---
+
+## Relevant AAPOR Documents
+
+- [AAPOR Best Practices for Survey and Public Opinion Research](https://www.aapor.org/Standards-Ethics/Best-Practices.aspx)
+- [AAPOR Transparency Initiative Checklist](https://www.aapor.org/Transparency-Initiative/Transparency-Initiative.aspx)
+- AAPOR Standard Definitions (primarily about response rates — less relevant
+  for analysis functions)
+
+**Suggested starting point for the review session:** fetch the Best Practices
+and Transparency Initiative documents and assess surveycore against them
+systematically.
+
+---
+
+## Current Compliance Gap Analysis (Phase 1 as specced)
+
+| AAPOR Requirement | surveycore Phase 1 | Status |
+|---|---|---|
+| Unweighted n (sample basis) | `n` column on all functions | ✅ |
+| Weighted n (population estimate) | `n_weighted` in `get_freqs()` only | ⚠️ Partial |
+| Uncertainty measure (MOE or CI) | `variance` argument on all functions | ✅ |
+| Clear base definition | `n` docs + `meta()$n_respondents` | ✅ |
+| Design effect (DEFF) | Not in spec | ❌ Missing |
+| Cell suppression for small n | Warning only, no suppression | ⚠️ Partial |
+
+---
+
+## Key Gaps in Detail
+
+### 1. Design Effect (DEFF)
+
+DEFF = Var(complex design) / Var(SRS equivalent). AAPOR recommends reporting
+it so readers understand how much the sampling design inflates uncertainty
+relative to a simple random sample. Many polling organizations report DEFF
+alongside MOE.
+
+**Formula:** `DEFF = se_complex² / se_srs²`
+
+**Implementation options:**
+- Add `"deff"` as a `variance` argument value (consistent with existing pattern)
+- Always include in `meta(result)` for downstream consumers
+
+**Effort:** Low — both SE values are already computed. The division is trivial.
+
+### 2. `n_weighted` missing from 5 of 6 functions
+
+AAPOR recommends reporting both weighted and unweighted n in published tables.
+`get_freqs()` already has `n_weighted = FALSE` as an optional argument.
+The other five functions expose raw count (`n`) but not weighted population
+count.
+
+**Options:**
+- Add `n_weighted = FALSE` as a cross-cutting argument to all six functions
+  (parallel to `get_freqs()`)
+- Always include weighted n in `meta(result)` and document it there
+
+### 3. Cell Suppression
+
+AAPOR guidance (and many institutional standards) recommend suppressing
+(replacing with `*` or `NA`) cells where unweighted n falls below a threshold.
+Common thresholds: n < 5 (surveycore warning threshold), n < 30 (AAPOR
+common guidance for public reporting), n < 50 (some federal agencies).
+
+**Current behavior:** `surveycore_warning_small_cell` fires at n < 5 but does
+not suppress.
+
+**Options:**
+- Add `suppress_n = NULL` argument: cells with `n < suppress_n` are replaced
+  with `NA` and flagged
+- Add `min_n = 5` argument that controls the warning threshold AND optionally
+  suppresses
+- Leave suppression to downstream consumers (they can filter on `n`)
+
+---
+
+## Proposed `aapor_format` Argument (for discussion)
+
+A convenience argument that enforces a specific combination of outputs aligned
+with AAPOR public reporting conventions:
+
+```r
+get_means(design, x, aapor_format = FALSE)
+```
+
+When `aapor_format = TRUE`:
+- Forces `variance = c("ci", "moe")`
+- Forces `n_weighted = TRUE`
+- Adds `deff` column
+- Fires `surveycore_warning_small_cell` at `n < 30` instead of `n < 5`
+
+This is a convenience wrapper — all the underlying arguments already exist
+independently. `aapor_format = TRUE` just sets defaults that match AAPOR
+convention.
+
+**Risks:**
+- AAPOR standards evolve; hardcoding them in an argument name creates
+  maintenance burden
+- Different AAPOR publication types have different requirements — one flag
+  may not cover all cases
+- Better to document which combination of arguments produces AAPOR-compliant
+  output, rather than encoding it as a flag
+
+---
+
+## Recommended Questions for the Review Session
+
+1. Fetch the current AAPOR Best Practices document and do a line-by-line
+   assessment against the Phase 1 spec.
+2. Should `n_weighted` be a cross-cutting argument on all six functions, or
+   is `get_freqs()` the only function where weighted n is conventionally
+   reported?
+3. Should `"deff"` be a Phase 1 addition (as a `variance` value) or deferred
+   to Phase 2?
+4. Is a formal `aapor_format` argument worth the maintenance cost, or is
+   clear documentation of which argument combination produces AAPOR-compliant
+   output sufficient?
+5. What cell suppression behavior (if any) should be built into Phase 1?
+
+---
+
+## Decision Made in This Session
+
+- `n` = estimation-basis count (excludes zero-weight rows) — used for
+  `surveycore_warning_small_cell`
+- `meta(result)$n_respondents` = raw headcount including zero-weight rows —
+  always populated, accessible via `meta()`
+- All AAPOR compliance additions deferred to a dedicated review session after
+  Phase 1 spec is finalized

--- a/plans/spec-review-phase-1.md
+++ b/plans/spec-review-phase-1.md
@@ -1,0 +1,647 @@
+# Spec Review: Phase 1 Formal Specification
+
+**Reviewed:** `plans/phase-1-formal-specification.md` (v1.1, February 2026)
+**Reviewer:** Claude Code (adversarial pass — second round)
+**Date:** 2026-02-24
+**Note:** Previous review was incorporated into spec v1.1. This is a fresh pass on the updated spec.
+
+---
+
+## Section I: Scope
+
+No issues found.
+
+---
+
+## Section II: Architecture
+
+**Issue 1: `value_labels` in meta contract says "all functions" but `CORR_META_KEYS` and `RATIOS_META_KEYS` omit it**
+Severity: BLOCKING
+
+Section 2.4 states under "Variable metadata fields": `value_labels | all functions | named list | Always a named list...`
+
+But Section 2.2's required meta-key constants are:
+```r
+CORR_META_KEYS   <- c("variables", "variable_labels", "question_prefaces", "method")
+RATIOS_META_KEYS <- c("numerator", "numerator_label", "denominator", "denominator_label", "question_prefaces")
+```
+Neither includes `value_labels`. Every other function's constant (`FREQS_SINGLE_META_KEYS`, `FREQS_MULTI_META_KEYS`, `MEANS_META_KEYS`, `TOTALS_META_KEYS`, `QUANTILES_META_KEYS`) does include it.
+
+The spec also states: "Functions must supply exactly the keys shown below — no extras, no omissions." This creates a direct contradiction: Section 2.4 says `value_labels` is in "all functions," but the CORR and RATIOS constants omit it, meaning those functions must NOT supply it. An implementer following the constants contract will fail `test_result_invariants()` invariant #5. An implementer following the "all functions" claim will fail `stopifnot()` in `.make_result_tibble()` because the key is absent from the constant.
+
+Options:
+- **[A]** Add `value_labels` to `CORR_META_KEYS` and `RATIOS_META_KEYS`. Document the expected value: for numeric variables, `value_labels` is `list(var_name = NULL)` per the existing pattern. Add a note in Section 2.2 clarifying this. Effort: low, Risk: low, Impact: removes contradiction; consistent invariant behavior.
+- **[B]** Remove `value_labels` from the "all functions" claim in Section 2.4. Scope it to functions that accept categorical variables: `get_freqs()`, `get_means()`, `get_totals()`, `get_quantiles()`. Update `test_result_invariants()` invariant #5 to be function-specific. Effort: medium, Risk: low, Impact: accurate scoping but more complex invariant.
+- **[C] Do nothing** — implementer contradiction; `test_result_invariants()` and `stopifnot()` will fail for `get_corr()` and `get_ratios()`.
+
+**Recommendation: [A]** — consistency is simplest; `list(var = NULL)` for numeric variables is the established pattern.
+
+---
+
+**Issue 2: `test_result_invariants()` invariant #5 will fail for `get_corr()` and `get_ratios()`**
+Severity: REQUIRED
+
+A direct consequence of Issue 1. The invariant code in Section 11.2:
+```r
+# 5. value_labels always populated and is a non-empty named list
+expect_true("value_labels" %in% names(m))
+expect_type(m$value_labels, "list")
+expect_gt(length(m$value_labels), 0L)
+expect_false(is.null(names(m$value_labels)))
+```
+If `CORR_META_KEYS` and `RATIOS_META_KEYS` don't include `value_labels`, `meta(result)$value_labels` will be absent for those functions. Invariant #5 fails. This must be resolved together with Issue 1.
+
+Options:
+- **[A]** Resolve Issue 1 first (add `value_labels` to CORR/RATIOS keys). The invariant then holds universally. Effort: coupled to Issue 1.
+- **[B]** Guard invariant #5 per function class: only check for functions where `value_labels` is applicable. Effort: medium, Risk: medium (weakens the invariant).
+- **[C] Do nothing** — `test_result_invariants()` will fail for any `get_corr()` or `get_ratios()` test block.
+
+**Recommendation: [A]** — resolve Issue 1 and this issue disappears.
+
+---
+
+**Issue 3: `S3method(print, survey_result) <- function(x, ...)` is invalid R syntax**
+Severity: REQUIRED
+
+Section 2.5 shows:
+```r
+S3method(print, survey_result) <- function(x, ...) {
+  cls  <- class(x)[1]
+  dims <- paste(nrow(x), "\u00d7", ncol(x))
+  cat(sprintf("# A <%s> [%s]\n", cls, dims))
+  NextMethod()
+  invisible(x)
+}
+```
+`S3method(print, survey_result) <-` is invalid R. `S3method()` is a NAMESPACE directive recognized by `devtools::document()` — it is not assignable. If an implementer copies this code, they will get a parse-time error. `survey_result` is an S3 class (built on tibble), not an S7 class, so the `S7::method() <-` syntax from `code-style.md` does not apply.
+
+The correct R syntax is:
+```r
+print.survey_result <- function(x, ...) {
+  # body
+}
+```
+Registered in NAMESPACE via `#' @export` or `#' @method print survey_result` in roxygen2.
+
+Options:
+- **[A]** Fix the code block to use `print.survey_result <- function(x, ...) {...}`. Add a roxygen2 comment showing how to register it (`@method print survey_result`). Effort: trivial, Risk: low.
+- **[C] Do nothing** — implementers who copy the code block will get a parse error at `devtools::load_all()`.
+
+**Recommendation: [A]**.
+
+---
+
+**Issue 4: `.build_meta()` `design_type` mapping from S7 class to string not specified**
+Severity: REQUIRED
+
+Section 2.2 says `.build_meta()` derives `design_type` "from the S7 class of `design`." Section 2.4 lists valid string values: `"taylor"`, `"replicate"`, `"twophase"`, `"srs"`, `"calibrated"`. But the mapping is not defined anywhere:
+
+- `survey_taylor` → `"taylor"` ?
+- `survey_replicate` → `"replicate"` ?
+- `survey_twophase` → `"twophase"` ?
+- `survey_srs` → `"srs"` ?
+- `survey_calibrated` → `"calibrated"` ?
+
+The mapping is obvious by inspection, but an implementer could produce `"survey_taylor"` via `class(design)[1]` string manipulation, or `"SurveyTaylor"`, or anything else. If downstream code (e.g., in surveytidy) branches on `meta(result)$design_type == "taylor"`, a different string breaks it silently.
+
+Options:
+- **[A]** Add a lookup table to Section 2.2 (or as a constant `DESIGN_TYPE_MAP` in `R/09-analysis-helpers.R`):
+  ```r
+  # design_type mapping used in .build_meta()
+  # S7::S7_inherits() used per code-style.md §2
+  design_type <- dplyr::case_when(
+    S7::S7_inherits(design, survey_taylor)    ~ "taylor",
+    S7::S7_inherits(design, survey_replicate) ~ "replicate",
+    S7::S7_inherits(design, survey_twophase)  ~ "twophase",
+    S7::S7_inherits(design, survey_srs)       ~ "srs",
+    S7::S7_inherits(design, survey_calibrated)~ "calibrated"
+  )
+  ```
+  Or equivalent if-else chain. Effort: low, Risk: low, Impact: canonical string values enforced.
+- **[B]** Add the mapping table to the spec as prose without code. Effort: trivial.
+- **[C] Do nothing** — implementers will use different strings; downstream consumers will break.
+
+**Recommendation: [A]** — the canonical string values belong in the spec and implementation.
+
+---
+
+**Issue 5: `.make_result_tibble()` — `required_meta_keys` required vs. optional not specified**
+Severity: REQUIRED
+
+Section 2.2 says: "`.make_result_tibble()` validates `required_meta_keys` with `stopifnot(all(required_meta_keys %in% names(meta_args)))`. Each `get_*()` function passes its constant."
+
+But the function signature is:
+```r
+.make_result_tibble(result_cols, groups_df, class_name, design, meta_args,
+                    conf_level, call, group_names, required_meta_keys, ...)
+```
+
+The spec does not say whether `required_meta_keys` has a default (e.g., `NULL`, which would skip validation). If it is required (no default), the spec should state this. If it defaults to `NULL` (skip validation), the spec should state that too — otherwise the validation purpose is unclear. Given the DRY rationale, it should be required with no default.
+
+Options:
+- **[A]** Add to the `.make_result_tibble()` description: "`required_meta_keys` has no default and must always be provided; passing the function's `*_META_KEYS` constant is required." Effort: trivial, Risk: low.
+- **[C] Do nothing** — implementers will default it to NULL and skip the validation.
+
+**Recommendation: [A]**.
+
+---
+
+**Issue 6: `surveycore_error_all_na` scoped to `get_freqs()` in spec but "all `get_*()` functions" in `error-messages.md`**
+Severity: REQUIRED
+
+Section 2.6 and Section 3.5 both state `surveycore_error_all_na` is scoped to `get_freqs()` only:
+> "If the entire focal variable is NA and `na.rm = FALSE`, the function errors with `surveycore_error_all_na`. This differs from numeric functions (`get_means()`, etc.) where any NA with `na.rm = FALSE` throws `surveycore_error_na_in_variable` — including the all-NA case."
+
+But `error-messages.md` lists this error with "all `get_*()` functions" in the Function column. An implementer reading `error-messages.md` (the canonical error table) would incorrectly add `surveycore_error_all_na` handling to all six functions, creating a divergence from spec intent.
+
+Options:
+- **[A]** Update `error-messages.md` row for `surveycore_error_all_na` to scope it to `get_freqs()` only. Effort: trivial, Risk: low, Impact: canonical error table matches spec.
+- **[C] Do nothing** — numeric functions will have dead or incorrect error paths.
+
+**Recommendation: [A]**.
+
+---
+
+**Issue 7: `surveycore_warning_corr_non_numeric` — behavior after dropping leaves < 2 variables unspecified**
+Severity: REQUIRED
+
+Section X defines `surveycore_warning_corr_non_numeric` as firing when "Non-numeric variable in `x` silently dropped." Section 6.4 says `surveycore_error_insufficient_variables` fires when "fewer than 2 variables are supplied." But what if dropping non-numeric variables results in fewer than 2 remaining variables?
+
+Example: `get_corr(d, x = c(income, sex, region))` where `sex` and `region` are character. Both are dropped with `surveycore_warning_corr_non_numeric`, leaving 1 variable. The spec is silent on whether `surveycore_error_insufficient_variables` then fires.
+
+Options:
+- **[A]** Add to Section 6.4: "Insufficient-variable checking occurs *after* non-numeric variables are silently dropped. If fewer than 2 numeric variables remain after dropping, `surveycore_error_insufficient_variables` is thrown (in addition to any `surveycore_warning_corr_non_numeric` warnings already fired)." Effort: low, Risk: low.
+- **[B]** Check the variable count *before* dropping. If the user supplied < 2 numeric variables, throw the error immediately without warning. Effort: low, Risk: medium (changes interaction order).
+- **[C] Do nothing** — implementations will differ; one will warn then silently proceed, another will error.
+
+**Recommendation: [A]** — validation ordering should be explicit.
+
+---
+
+**Issue 8: `get_quantiles()` output column order contradicts Section 2.6; `[var]` and `[cv]` absent**
+Severity: REQUIRED
+
+Section 7.2 specifies:
+```
+[group_names...]   quantile   estimate   [ci_low   ci_high]   [se]   [moe]   n
+```
+
+Section 2.6 mandates the column order when multiple variance measures are present: `se`, `var`, `cv`, `ci_low`, `ci_high`, `moe`.
+
+Section 7.2 puts `[ci_low ci_high]` before `[se]` — directly inverting the Section 2.6 order. Additionally, `[var]` and `[cv]` are entirely absent from the column spec.
+
+The correct column spec for Section 7.2 should be:
+```
+[group_names...]   quantile   estimate   [se]   [var]   [cv]   [ci_low]   [ci_high]   [moe]   n
+```
+
+Options:
+- **[A]** Fix Section 7.2 column spec to match Section 2.6 order and include `[var]` and `[cv]`. Effort: trivial, Risk: low.
+- **[C] Do nothing** — `get_quantiles()` column order will contradict the cross-cutting contract.
+
+**Recommendation: [A]**.
+
+---
+
+**Issue 9: `[var]` and `[cv]` absent from `get_means()` and `get_ratios()` column specs**
+Severity: REQUIRED
+
+Section 4.2 (`get_means()`) output spec:
+```
+[group_names...]   mean   [se]   [ci_low  ci_high]   [moe]   n
+```
+
+Section 8.2 (`get_ratios()`) output spec:
+```
+[group_names...]   ratio   [se]   [ci_low  ci_high]   [moe]   n
+```
+
+Both omit `[var]` and `[cv]`. Section 2.6 says `"var"` and `"cv"` are accepted by all six functions. Compare `get_totals()` Section 5.2 which correctly includes `[var]` and `[cv]`. The column order in Sections 4.2 and 8.2 should also be updated to match the Section 2.6 ordering (`se`, `var`, `cv`, `ci_low`, `ci_high`, `moe`).
+
+Options:
+- **[A]** Fix both sections to include `[var]` and `[cv]` and correct column ordering. Effort: trivial.
+- **[C] Do nothing** — `get_means()` and `get_ratios()` will silently omit `var` and `cv` columns.
+
+**Recommendation: [A]**.
+
+---
+
+**Issue 10: Stale `variance = "both"` reference in Section 6.2**
+Severity: REQUIRED
+
+Line 1107 of the spec reads:
+> **`variance = "both"`:** includes `se`, `ci_low`, and `ci_high` columns.
+
+`"both"` is not a valid `variance` value. Per Section 2.6, valid values are `c("se", "ci", "var", "cv", "moe")`. A `variance = "both"` call would correctly trigger `surveycore_error_invalid_variance_arg`. The `claude-decisions-phase-1.md` log confirms `"both"` was eliminated when `variance` was redesigned as a character vector. This stale text will cause an implementer to add `"both"` handling to `.validate_shared_args()`, introducing an undocumented argument value.
+
+Options:
+- **[A]** Remove the `variance = "both"` paragraph. Replace with `variance = c("se", "ci")` if an example of combining values is desired. Effort: trivial.
+- **[C] Do nothing** — implementers add undocumented `"both"` logic that contradicts Section 2.6.
+
+**Recommendation: [A]**.
+
+---
+
+**Issue 11: `get_corr()` Section 6.2 column spec and `variance = "se"` example are internally inconsistent**
+Severity: REQUIRED
+
+The column spec header in Section 6.2:
+```
+var1   var2   r   ci_low   ci_high   p_value   statistic   df   n
+```
+`ci_low` and `ci_high` appear without brackets — implying they are always present.
+
+But the example immediately below:
+```r
+get_corr(d, x = c(income, bmi), variance = "se")
+  var1    var2     r      se   p_value  statistic    df     n
+```
+shows `ci_low` and `ci_high` absent when `variance = "se"`. The header and example contradict each other.
+
+The correct column spec should bracket them:
+```
+var1   var2   r   [se]   [var]   [cv]   [ci_low]   [ci_high]   [moe]   p_value   statistic   df   n
+```
+where `p_value`, `statistic`, `df`, and `n` are always-present.
+
+Options:
+- **[A]** Bracket all variance columns in the header. Separate the always-present columns explicitly. Effort: low, Risk: low.
+- **[C] Do nothing** — implementers treat `ci_low/ci_high` as always-present; tests break when `variance = NULL`.
+
+**Recommendation: [A]**.
+
+---
+
+**Issue 12: Section 6.3 "No uncertainty columns in wide format" does not address `p_value`, `statistic`, `df`, `n`**
+Severity: REQUIRED
+
+Section 6.3 says "No uncertainty columns in wide format." The wide format example shows only correlation coefficients. But "uncertainty columns" could mean only `se`/`var`/`cv`/`ci_low`/`ci_high`/`moe` — leaving `p_value`, `statistic`, `df`, and `n` potentially includable in wide format.
+
+The example implies only `r` values are shown, but implication is not specification. An implementer could add a separate `p_value` matrix or `n` matrix in wide format; there is no text prohibiting it.
+
+Options:
+- **[A]** Add to Section 6.3: "Wide format contains only the correlation matrix (r values). All other columns (`p_value`, `statistic`, `df`, `n`, and any variance columns) are excluded from wide format. Use `format = \"long\"` to access inference statistics." Effort: low, Risk: low.
+- **[C] Do nothing** — wide format scope is ambiguous; implementations differ.
+
+**Recommendation: [A]**.
+
+---
+
+**Issue 13: `n_respondents` is "always populated" but `test_result_invariants()` does not check it**
+Severity: REQUIRED
+
+Section 2.4 declares: `n_respondents | all functions | integer | Raw respondent headcount including zero-weight rows; always populated.`
+
+Section 2.6 reinforces: "This value is always populated and accessible via `meta()`."
+
+The `test_result_invariants()` function in Section 11.2 checks five common meta keys (`design_type`, `conf_level`, `call`, `group_names`, `group_labels`) and `value_labels`. It does not check `n_respondents`. An implementer who omits `n_respondents` from the meta output would pass all invariant tests. Given the spec's explicit "always populated" guarantee, it belongs in the invariant checker.
+
+Options:
+- **[A]** Add to `test_result_invariants()`:
+  ```r
+  # 6. n_respondents always present and is a positive integer
+  expect_true("n_respondents" %in% names(m))
+  expect_type(m$n_respondents, "integer")
+  expect_gt(m$n_respondents, 0L)
+  ```
+  Effort: low, Risk: low.
+- **[C] Do nothing** — `n_respondents` is silently absent from many implementations.
+
+**Recommendation: [A]**.
+
+---
+
+**Issue 14: Oracle test in Section 11.1 uses `get_corr(...)$se` without specifying `variance = "se"`**
+Severity: REQUIRED
+
+The oracle code in Section 11.1:
+```r
+expect_equal(get_corr(d_sc, c(x, y))$se, se_oracle, tolerance = 1e-8)
+```
+
+`get_corr()` has `variance = "ci"` as its default. The `se` column is only present when `variance` includes `"se"`. This oracle test as written will return `NULL` (not throw an error) because `tibble$absent_col` returns `NULL` — causing the tolerance comparison to fail with an opaque error rather than a clear test failure.
+
+The oracle call should be `get_corr(d_sc, c(x, y), variance = "se")$se` or `get_corr(d_sc, c(x, y), variance = c("ci", "se"))$se`.
+
+Options:
+- **[A]** Fix the oracle code to include `variance = "se"` explicitly. Effort: trivial.
+- **[C] Do nothing** — oracle test silently passes `NULL` to `expect_equal()` and fails with a confusing error.
+
+**Recommendation: [A]**.
+
+---
+
+**Issue 15: Stale `R/06-variance-estimation.R` single-file references throughout spec**
+Severity: SUGGESTION
+Violates current codebase state (PR #9 split this file into four engine-specific files)
+
+PR #9 (`refactor(variance): split variance-estimation.R into four engine-specific files`) replaced `R/06-variance-estimation.R` with:
+- `R/06-variance-dispatch.R`
+- `R/06-variance-replicate.R`
+- `R/06-variance-srs.R`
+- `R/06-variance-taylor.R`
+- `R/06-variance-twophase.R`
+
+The spec references the old single file in at least: Section I (Stub Migration paragraph), Section 2.2 (dispatch table note), Section 3.5, 4.3, 5.3, 7.3. An implementer looking for "stubs in `R/06-variance-estimation.R`" will not find that file.
+
+Options:
+- **[A]** Update all `R/06-variance-estimation.R` references to the correct split-file names. For the stub removal (Sections I and stub migration), note which file the stubs live in (`R/06-variance-dispatch.R`). For the dispatch table, reference the appropriate engine file per method. Effort: low.
+- **[C] Do nothing** — implementers check the codebase to find the actual files; confusing but not blocking.
+
+**Recommendation: [A]** — spec accuracy prevents needless confusion during implementation.
+
+---
+
+## Section III: `get_freqs()`
+
+**Issue 16: `get_freqs()` multi-var column spec uses `[variance cols]` without ordering; `[n_weighted]` absent**
+Severity: SUGGESTION
+
+Section 3.4 multi-var output spec:
+```
+[group_names...]   [names_to]   [values_to]   pct    n    [variance cols]
+```
+
+Two problems:
+1. `n` appears before `[variance cols]`, but Section 3.2 (single-var) specifies `pct [se] [var] [cv] [ci_low] [ci_high] [moe] n [n_weighted]` — `n` comes after variance columns. The two modes are inconsistent.
+2. `[n_weighted]` is documented as a parameter that applies to multi-var calls but is absent from the multi-var column spec.
+
+Options:
+- **[A]** Make multi-var column ordering consistent with single-var:
+  ```
+  [group_names...]   [names_to]   [values_to]   pct   [se]   [var]   [cv]   [ci_low]   [ci_high]   [moe]   n   [n_weighted]
+  ```
+  Effort: trivial.
+- **[C] Do nothing** — inconsistency between single-var and multi-var column ordering.
+
+**Recommendation: [A]**.
+
+---
+
+## Section IV: `get_means()`
+
+No issues found.
+
+---
+
+## Section V: `get_totals()`
+
+No issues found.
+
+---
+
+## Section VI: `get_corr()`
+
+Issues 7, 10, 11, 12 above cover this section. One additional suggestion:
+
+**Issue 17: `ci_low`/`ci_high` shown without brackets implies always-present**
+Severity: SUGGESTION
+
+(Incorporated into Issue 11 above as a REQUIRED issue. No separate suggestion entry needed.)
+
+**Issue 17: `surveycore_warning_small_cell` — "cell" undefined for `get_corr()`**
+Severity: SUGGESTION
+
+Section 2.6 and Section X define `surveycore_warning_small_cell` as firing when "any cell has unweighted `n < 5`." For tabular functions (`get_freqs()`, `get_means()`, etc.), "cell" is unambiguous: one row = one group-level combination. For `get_corr()`, each row represents a variable pair — a "cell" is not intuitive. Is the warning about pairwise `n`? Per-group-per-pair `n`?
+
+Options:
+- **[A]** Add to Section 6.2 or Section X: "For `get_corr()`, `surveycore_warning_small_cell` fires when any variable pair's pairwise `n < 5`." Effort: trivial.
+- **[C] Do nothing** — implementers will use different thresholds for `get_corr()`.
+
+**Recommendation: [A]**.
+
+---
+
+## Section VII: `get_quantiles()`
+
+Issue 8 above covers this section.
+
+---
+
+## Section VIII: `get_ratios()`
+
+Issue 9 above covers this section.
+
+---
+
+## Section IX: `get_diffs()` (Deferred)
+
+No issues found.
+
+---
+
+## Section X: Error and Warning Classes
+
+Issue 6 above covers `surveycore_error_all_na` scoping.
+
+**Issue 18: `n_respondents` meta field — scalar vs. per-group not specified**
+Severity: SUGGESTION
+
+Section 2.4 declares `n_respondents` as `integer` type with description "Raw respondent headcount including zero-weight rows; always populated." For a grouped analysis (`get_means(d, income, group = region)` with 4 regions), is `n_respondents` the total N across all groups (scalar), or a named integer vector with one entry per group level?
+
+The singular phrasing ("headcount") and `integer` type (not `integer vector`) suggest it is a scalar total-N. But this is not stated, and a per-group breakdown would be more informative.
+
+Options:
+- **[A]** Add to Section 2.4: "`n_respondents` is a scalar `integer` equal to `nrow(design@data)` — the total number of rows in the design regardless of groups, domain status, or weight." Effort: trivial.
+- **[C] Do nothing** — implementations vary; some produce total-N, some per-group.
+
+**Recommendation: [A]**.
+
+---
+
+## Section XI: Test Strategy
+
+Issues 2, 13, 14 above cover this section.
+
+---
+
+## Section XII: Quality Gates
+
+No issues found.
+
+---
+
+## Section XIII: Integration with surveytidy
+
+No issues found.
+
+---
+
+## Section: AAPOR Compliance Gaps
+*Source: `plans/aapor-compliance-review.md`. These issues were deferred from an
+earlier session and are now formally incorporated into this review pass.*
+
+**Issue 19: `n_weighted` present only on `get_freqs()` — spec silent on why other 5 functions omit it**
+Severity: REQUIRED
+Violates engineering-preferences.md §5 (explicit over clever) — intentional asymmetry requires a stated rationale.
+
+The spec includes `n_weighted = FALSE` in `get_freqs()` signature (Section 3.1) and documents
+the `n_weighted` column in Section 3.2. The other five functions (`get_means()`, `get_totals()`,
+`get_corr()`, `get_quantiles()`, `get_ratios()`) expose only unweighted `n`. No rationale is given
+for the asymmetry.
+
+AAPOR recommends reporting both weighted and unweighted n in published tables. The compliance
+review flags this as "⚠️ Partial." An implementer following the spec will implement five
+functions without `n_weighted`, not knowing whether this is a deliberate product decision or an
+oversight. If deliberate, the spec should state why (e.g., "weighted n is less conventionally
+reported for continuous-variable summaries"). If an oversight, `n_weighted = FALSE` must be added
+to all six signatures, the cross-cutting arguments table in Section 2.6 updated, `n_weighted`
+columns added to all output specs, and test categories extended.
+
+The test gap compounds the ambiguity: Section 11.2 specifies `n_weighted = TRUE` tests for
+`get_freqs()` but the equivalent test category is absent from all other function test plans.
+
+Options:
+- **[A]** Add `n_weighted = FALSE` as a cross-cutting argument to all six functions (parallel to
+  `get_freqs()`). Add to Section 2.6 cross-cutting arguments table, add the `[n_weighted]` column
+  to all six output column specs, add test categories to each function's test file.
+  Effort: medium, Risk: low, Impact: AAPOR-consistent; uniform API.
+- **[B]** Explicitly document in Section 2.6 that `n_weighted` is `get_freqs()`-only with stated
+  rationale (weighted n is most useful for frequency tables; for continuous summaries, users can
+  compute it from `meta(result)$n_respondents` and group weights). Update the AAPOR compliance
+  review accordingly. Effort: low, Risk: low, Impact: documents the intentional inconsistency.
+- **[C] Do nothing** — spec is silent; implementations will be inconsistent across functions.
+
+**Recommendation: [B] if intentional, [A] if an oversight** — resolution depends on product intent.
+The decision must be stated in the spec either way.
+
+---
+
+**Issue 20: Design Effect (DEFF) absent from Phase 1 — deferral not documented in spec**
+Severity: SUGGESTION
+Source: `plans/aapor-compliance-review.md §1`.
+
+DEFF = Var(complex design) / Var(SRS equivalent) is an AAPOR reporting recommendation. The
+compliance review notes: "Effort: Low — both SE values are already computed. The division is
+trivial." The spec does not mention DEFF anywhere — not in the `variance` argument table
+(Section 2.6), not in `meta()` (Section 2.4), not in the quality gates (Section XII).
+
+The implementation path would be adding `"deff"` as a valid `variance` value. This requires
+calling `.srs_mean()` (or equivalent) to get the SRS SE for comparison against the complex-design
+SE. For `survey_srs`, DEFF is identically 1.0 by definition. For `survey_twophase`, the SRS
+equivalent degf is non-trivial.
+
+The compliance review deferred DEFF to a post-Phase-1 session but did not record that decision
+back into the spec. The spec should state explicitly whether DEFF is Phase 1 or later.
+
+Options:
+- **[A]** Add `"deff"` as a valid `variance` value in Section 2.6. Define the formula:
+  `deff = (se_complex / se_srs)²`. Add `deff` column to all six output column specs. Update
+  `.validate_shared_args()`. Effort: medium, Risk: medium (`survey_twophase` SRS reference
+  requires design-specific degf logic), Impact: AAPOR-compliant output.
+- **[B]** Add DEFF to `meta(result)` only — always computed silently, accessible via
+  `meta(result)$deff`. Avoids `variance` argument complexity. Effort: medium, Risk: low.
+- **[C]** Add one sentence to Section 2.6 or Section XII noting that DEFF computation is deferred
+  to Phase 2 and document the rationale (SRS reference requires per-design-class handling).
+  Effort: trivial, Risk: none.
+- **[D] Do nothing** — DEFF absent with no explanation; users and downstream reviewers discover
+  the AAPOR compliance gap without guidance.
+
+**Recommendation: [C]** — explicitly note the deferral with a one-line forward reference. This
+closes the documentation gap without expanding Phase 1 scope.
+
+---
+
+**Issue 21: `surveycore_warning_small_cell` threshold undocumented relative to AAPOR standards**
+Severity: SUGGESTION
+Source: `plans/aapor-compliance-review.md §3`.
+
+The spec defines `surveycore_warning_small_cell` in Section X: "Any cell has unweighted `n < 5`."
+The AAPOR compliance review notes this as "⚠️ Partial":
+
+> "AAPOR guidance (and many institutional standards) recommend suppressing cells where unweighted
+> n falls below a threshold. Common thresholds: n < 5 (surveycore warning threshold), n < 30
+> (AAPOR common guidance for public reporting), n < 50 (some federal agencies)."
+
+The spec's n < 5 threshold is a surveycore convention, not an AAPOR standard. Users applying
+AAPOR reporting requirements at n < 30 must manually filter the output — there is no built-in
+support. The spec does not acknowledge this mismatch, leaving users to discover it independently.
+
+The spec also does not address suppression (replacing small-n cells with `NA`). Whether this is
+intentionally deferred or out of scope is not stated.
+
+Options:
+- **[A]** Add a `min_cell_n` cross-cutting argument (default `5`) controlling the warning
+  threshold. Cells with `n < min_cell_n` fire `surveycore_warning_small_cell`.
+  Effort: medium, Risk: low, Impact: configurable threshold.
+- **[B]** Add a `suppress_n = NULL` argument: cells with `n < suppress_n` are replaced with `NA`
+  in numeric output columns and a warning fires. Effort: medium, Risk: medium (NA cells can change
+  column types in tibble), Impact: suppression support.
+- **[C]** Add to the `surveycore_warning_small_cell` definition in Section X: a note documenting
+  that the n < 5 threshold is a surveycore convention that is more permissive than the AAPOR
+  n < 30 public-reporting guideline, and that users should filter on `n` to apply stricter
+  thresholds. Suppression and configurable thresholds deferred to Phase 2. Effort: trivial.
+- **[D] Do nothing** — threshold choice and AAPOR divergence go unacknowledged.
+
+**Recommendation: [C]** — document the convention difference. Suppression and configurable
+thresholds expand Phase 1 scope and can be addressed in Phase 2.
+
+---
+
+**Issue 22: AAPOR-compliant argument combination not documented anywhere in spec**
+Severity: SUGGESTION
+Source: `plans/aapor-compliance-review.md §Proposed aapor_format Argument`.
+
+The AAPOR compliance review proposes an `aapor_format = TRUE` convenience argument that would
+enforce: `variance = c("ci", "moe")`, `n_weighted = TRUE`, and raise `surveycore_warning_small_cell`
+at n < 30 instead of n < 5. The review correctly concludes against adding the argument:
+
+> "Better to document which combination of arguments produces AAPOR-compliant output, rather
+> than encoding it as a flag."
+
+Neither the compliance doc's conclusion nor the argument combination itself appears anywhere in the
+Phase 1 spec. There is no `@details` note, no vignette reference, no `@seealso`. A user trying
+to produce AAPOR-compliant output has no guidance from the spec or documentation.
+
+Options:
+- **[A]** Add to Section XII quality gates or the spec's documentation scope: a `@details` or
+  vignette section documenting the argument combination for AAPOR-compliant output
+  (`variance = c("ci", "moe")`, `n_weighted = TRUE` for `get_freqs()`). Reference
+  `plans/aapor-compliance-review.md` as background. Effort: low.
+- **[B]** Add `aapor_format = FALSE` to all six function signatures. Effort: medium, Risk: medium
+  (AAPOR standards evolve; hardcoding creates maintenance burden as identified in compliance review).
+- **[C] Do nothing** — AAPOR-compliant configuration is undiscoverable from the spec or docs.
+
+**Recommendation: [A]** — the compliance review's conclusion (document don't encode) is correct.
+Add the argument combination to spec documentation scope. No new argument needed.
+
+---
+
+## Summary
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 1 |
+| REQUIRED | 14 |
+| SUGGESTION | 7 |
+
+**Total issues:** 22
+
+**Issues by section:**
+
+| Issue | Section | Severity |
+|---|---|---|
+| 1: `value_labels` in "all functions" vs. absent from CORR/RATIOS_META_KEYS | 2.2, 2.4 | BLOCKING |
+| 2: `test_result_invariants()` invariant #5 fails for `get_corr()` / `get_ratios()` | 11.2 | REQUIRED |
+| 3: `S3method(print, survey_result) <-` is invalid R syntax | 2.5 | REQUIRED |
+| 4: `.build_meta()` `design_type` mapping not specified | 2.2 | REQUIRED |
+| 5: `.make_result_tibble()` `required_meta_keys` — required or optional? | 2.2 | REQUIRED |
+| 6: `surveycore_error_all_na` scoped wrong in `error-messages.md` | X, error-messages.md | REQUIRED |
+| 7: `surveycore_warning_corr_non_numeric` drop + < 2 vars interaction unspecified | 6.4, X | REQUIRED |
+| 8: `get_quantiles()` column order contradicts Section 2.6; `[var]`/`[cv]` absent | 7.2 | REQUIRED |
+| 9: `[var]`/`[cv]` absent from `get_means()` and `get_ratios()` column specs | 4.2, 8.2 | REQUIRED |
+| 10: Stale `variance = "both"` reference | 6.2 | REQUIRED |
+| 11: `get_corr()` column header and `variance = "se"` example contradictory | 6.2 | REQUIRED |
+| 12: Wide format scope — `p_value`/`statistic`/`df`/`n` not addressed | 6.3 | REQUIRED |
+| 13: `n_respondents` "always populated" but absent from `test_result_invariants()` | 11.2, 2.4 | REQUIRED |
+| 14: Oracle test `get_corr(...)$se` without `variance = "se"` | 11.1 | REQUIRED |
+| 15: Stale `R/06-variance-estimation.R` single-file references | I, 2.2, 3.5, 4.3, 5.3, 7.3 | SUGGESTION |
+| 16: `get_freqs()` multi-var column ordering inconsistent; `[n_weighted]` absent | 3.4 | SUGGESTION |
+| 17: `surveycore_warning_small_cell` — "cell" undefined for `get_corr()` | 6.2, X | SUGGESTION |
+| 18: `n_respondents` scalar vs. per-group not specified | 2.4 | SUGGESTION |
+| 19: `n_weighted` present only on `get_freqs()` — omission from other 5 functions unexplained | 2.6, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1 | REQUIRED |
+| 20: DEFF absent from Phase 1 — deferral not documented in spec | 2.6, XII | SUGGESTION |
+| 21: `surveycore_warning_small_cell` threshold undocumented relative to AAPOR standards | X | SUGGESTION |
+| 22: AAPOR-compliant argument combination not documented anywhere | XII | SUGGESTION |
+
+**Overall assessment:** The spec has been significantly improved from the first review pass — all 26 prior issues were addressed. This third pass (incorporating AAPOR compliance gaps from `plans/aapor-compliance-review.md`) brings the total to 22 issues: 1 blocking, 14 required, 7 suggestions. The 4 new AAPOR-derived issues add 1 required (Issue 19: the unexplained `n_weighted` asymmetry) and 3 suggestions (DEFF deferral documentation, cell suppression documentation, and AAPOR argument combination documentation). The blocking issue (Issue 1) and most required issues from the prior pass remain unresolved. The AAPOR issues do not change the implementability threshold — once Issues 1–14 are resolved, the spec is implementable — but Issue 19 requires a product decision (intentional or oversight?) before the first PR that touches a non-`get_freqs()` function.

--- a/vignettes/creating-survey-objects.qmd
+++ b/vignettes/creating-survey-objects.qmd
@@ -1,0 +1,782 @@
+---
+title: "Creating Survey Objects in surveycore"
+vignette: >
+  %\VignetteIndexEntry{Creating Survey Objects in surveycore}
+  %\VignetteEngine{quarto::html}
+  %\VignetteEncoding{UTF-8}
+format:
+  html:
+    toc: true
+    toc-depth: 3
+bibliography: references.bib
+---
+
+```{r setup}
+#| include: false
+library(surveycore)
+```
+
+## Introduction
+
+Every analysis function in surveycore — `get_means()`, `get_totals()`,
+`get_freqs()` — takes a **survey design object** as its first argument. That
+object encodes how your data were collected: which units were clustered
+together, which strata were defined, what weights apply, and how variance
+should be estimated. Without it, point estimates may be biased and standard
+errors are almost certainly wrong [@lumley2010; @lohr2022].
+
+This vignette answers one question: *given my data, which constructor do I
+call and how do I call it?*
+
+It is written for three audiences:
+
+- **Academic researchers** working with named public surveys (NHANES, ANES,
+  ACS, GSS). Jump to the relevant worked example in each section.
+- **Practitioners** running surveys of schools, businesses, or organizations.
+  The conceptual explanations in each section are for you.
+- **Non-probability panel users** — if you run message-testing or attitudinal
+  research on Lucid, Dynata, or a similar platform and have vendor-provided
+  raking weights, skip ahead to @sec-calibrated.
+
+This vignette covers object *creation* only. Estimation functions (`get_means()`,
+`get_totals()`, etc.) are covered in `vignette("estimation")`.
+
+---
+
+## 1. Decision Guide {#sec-decision}
+
+Read the first row that matches your data.
+
+| My data...                                                           | Constructor              | Why                                              |
+|----------------------------------------------------------------------|--------------------------|--------------------------------------------------|
+| Has cluster IDs, strata, and/or design weights                       | `as_survey()`            | Taylor series linearization — the general case   |
+| Comes with pre-built replicate weight columns (repwt_1, repwt_2, …) | `as_survey_rep()`        | Uses the agency-supplied variance replicates     |
+| Is a pure SRS — equal probability, no clustering, no strata          | `as_survey_srs()`        | Simpler estimator for equal-probability samples  |
+| Is a non-probability panel or opt-in sample with calibration weights | `as_survey_calibrated()` | Calibrated design; SEs are approximate           |
+| Was sampled in two stages with an expensive Phase 2 measurement      | `as_survey_twophase()`   | Two-phase variance accounting for both stages    |
+
+### Common surveys at a glance
+
+| Survey                    | Constructor              | Design                                        |
+|---------------------------|--------------------------|-----------------------------------------------|
+| NHANES                    | `as_survey()`            | Stratified cluster, Taylor series             |
+| ANES                      | `as_survey()`            | Stratified cluster, Taylor series             |
+| GSS                       | `as_survey()`            | Stratified multi-stage cluster                |
+| Pew NPORS                 | `as_survey()`            | Stratified address-based sample (no PSU)      |
+| ACS PUMS (1-year)         | `as_survey_rep()`        | 80 successive-difference replicate weights    |
+| Pew Jewish Americans 2020 | `as_survey_rep()`        | 100 JK1 jackknife replicate weights           |
+| BRFSS                     | `as_survey_rep()`        | Bootstrap replicate weights                   |
+| NAEP / PISA               | `as_survey_rep()`        | JK2 jackknife replicate weights               |
+| Opt-in online panels      | `as_survey_calibrated()` | Non-probability; vendor-supplied raking weights |
+
+---
+
+## 2. `as_survey()` — Taylor Series Designs {#sec-taylor}
+
+`as_survey()` is the right constructor for probability surveys with cluster
+and/or stratum information but no pre-computed replicate weights. It uses
+**Taylor series linearization** (also called the linearization or delta-method
+estimator), the standard approach for complex probability surveys
+[@lumley2010, ch. 2; @lohr2022, ch. 9].
+
+### 2.1 Core arguments
+
+| Argument  | Codebook term                                       | What it does                             |
+|-----------|-----------------------------------------------------|------------------------------------------|
+| `ids`     | "PSU", "primary sampling unit", "cluster ID"        | Stage-1 cluster identifier               |
+| `weights` | "sampling weight", "person weight", "design weight" | Inverse of selection probability         |
+| `strata`  | "stratum", "design stratum", "sampling stratum"     | Stratification variable                  |
+| `fpc`     | "FPC", "finite population correction", "N"          | Population size or sampling fraction     |
+| `nest`    | (see below)                                         | Whether PSU IDs are locally unique       |
+
+All arguments accept bare column names — no `~formula` syntax required.
+
+### 2.2 The `nest` argument
+
+Many government surveys assign PSU IDs locally within each stratum. NHANES,
+for example, assigns IDs 1 and 2 within *every* stratum — PSU 1 in stratum
+31 is a completely different unit from PSU 1 in stratum 32. If you do not
+account for this, surveycore treats PSU 1 from stratum 31 and PSU 1 from
+stratum 32 as the same cluster, which produces incorrect variance estimates.
+
+Set `nest = TRUE` when PSU IDs are not globally unique across strata
+[@lumley2010, p. 28]. A quick diagnostic:
+
+```{r nest-diagnostic}
+# NHANES: only two distinct PSU values, but 15 strata
+# Each stratum has its own PSU 1 and PSU 2 → nest = TRUE
+length(unique(nhanes_2017$sdmvpsu))  # 2
+length(unique(nhanes_2017$sdmvstra)) # 15
+```
+
+If the number of unique PSU values is much smaller than the number of strata,
+the IDs are almost certainly nested and you need `nest = TRUE`.
+
+### 2.3 The `fpc` argument
+
+The finite population correction (FPC) reduces variance estimates when you
+have sampled a substantial fraction of the population [@cochran1977, §2.8;
+@lohr2022, §2.8]. Supply either:
+
+- An **integer column** with the total population size in each stratum
+- A **numeric column** (0–1) with the sampling fraction
+
+FPC has a meaningful effect when the sampling rate exceeds roughly 5%
+[@cochran1977]. For large national surveys like NHANES and ANES, the sampling
+fraction is tiny and FPC can be safely omitted (`fpc = NULL`).
+
+### 2.4 Multi-level clustering
+
+For two-stage designs — counties then households, schools then students —
+pass both levels of IDs as a vector:
+
+```r
+as_survey(data, ids = c(county_id, household_id), weights = wt, strata = region)
+```
+
+### 2.5 Worked example: NHANES 2017–2018
+
+NHANES uses a stratified, multistage probability cluster sample. The design
+variables are documented in the analytic notes on the NHANES website
+[@lumley2010, ch. 4]:
+
+| Variable   | Role                                                      | Argument  |
+|------------|-----------------------------------------------------------|-----------|
+| `sdmvpsu`  | Masked variance PSU (cluster ID)                          | `ids`     |
+| `sdmvstra` | Masked variance stratum                                   | `strata`  |
+| `wtmec2yr` | 2-year MEC examination weight (blood pressure, lab tests) | `weights` |
+| `wtint2yr` | 2-year interview weight (income, education, etc.)         | `weights` |
+
+```{r nhanes}
+# Subset to MEC exam participants (ridstatr == 2) before using wtmec2yr.
+# The 550 interview-only participants have wtmec2yr = 0 and are not part
+# of the exam sample.
+nhanes_exam <- nhanes_2017[nhanes_2017$ridstatr == 2, ]
+
+svy_nhanes <- as_survey(
+  nhanes_exam,
+  ids     = sdmvpsu,
+  strata  = sdmvstra,
+  weights = wtmec2yr,
+  nest    = TRUE       # PSU IDs are locally unique within strata
+)
+svy_nhanes
+```
+
+For interview-only variables (income, education), use the full dataset with
+`wtint2yr` — all 9,254 participants have a positive interview weight:
+
+```{r nhanes-interview}
+svy_nhanes_int <- as_survey(
+  nhanes_2017,
+  ids     = sdmvpsu,
+  strata  = sdmvstra,
+  weights = wtint2yr,
+  nest    = TRUE
+)
+```
+
+### 2.6 Worked example: ANES 2024
+
+The 2024 American National Election Studies uses a stratified cluster design
+with separate pre- and post-election weights. Use the correct weight for the
+variables you are analyzing:
+
+| Variable   | Role                                                          | Argument  |
+|------------|---------------------------------------------------------------|-----------|
+| `v240103c` | PSU (FTF+Web combined) — cluster ID                          | `ids`     |
+| `v240103d` | Stratum (FTF+Web combined)                                    | `strata`  |
+| `v240103a` | Pre-election weight — use for pre-election variables          | `weights` |
+| `v240103b` | Post-election weight — use for validated vote choice          | `weights` |
+
+```{r anes}
+# Pre-election analysis (party ID, ideology, candidate preference)
+svy_anes_pre <- as_survey(
+  anes_2024,
+  ids     = v240103c,
+  strata  = v240103d,
+  weights = v240103a
+)
+
+# Post-election analysis (validated vote choice: v242066, v242067)
+svy_anes_post <- as_survey(
+  anes_2024,
+  ids     = v240103c,
+  strata  = v240103d,
+  weights = v240103b
+)
+```
+
+**Missing values:** ANES uses negative integer codes throughout — `−9` =
+Refused, `−8` = Don't know, `−1` = Inapplicable. Recode these to `NA`
+before analysis. Check `attr(anes_2024$v241177, "labels")` for the full set
+of codes for any variable.
+
+### 2.7 Worked example: GSS 2024
+
+The General Social Survey uses a stratified multi-stage cluster design. Two
+weights are available depending on whether non-response bias is a concern:
+
+| Variable    | Role                                                               | Argument  |
+|-------------|--------------------------------------------------------------------|-----------|
+| `vpsu`      | Variance primary sampling unit                                     | `ids`     |
+| `vstrat`    | Variance stratum                                                   | `strata`  |
+| `wtssps`    | Person post-stratification weight — standard analysis weight       | `weights` |
+| `wtssnrps`  | Person post-stratification weight, non-response adjusted           | `weights` |
+
+```{r gss}
+# Standard analysis weight
+svy_gss <- as_survey(
+  gss_2024,
+  ids     = vpsu,
+  strata  = vstrat,
+  weights = wtssps
+)
+
+# Non-response adjusted weight (preferred when non-response bias is a concern)
+svy_gss_nr <- as_survey(
+  gss_2024,
+  ids     = vpsu,
+  strata  = vstrat,
+  weights = wtssnrps
+)
+```
+
+**Missing values:** GSS uses `−100` = Inapplicable, `−99` = No answer,
+`−98` = Don't know, `−90` = Refused. These are stored as value labels on
+every column — check `attr(gss_2024$happy, "labels")` and recode to `NA`
+before analysis.
+
+### 2.8 Worked example: Pew NPORS 2025
+
+The 2025 National Public Opinion Reference Survey is an **address-based
+sample (ABS)** — units are drawn directly from the USPS Computerized Delivery
+Sequence file with no intermediate cluster stage. Each address is its own
+sampling unit, so there is no PSU variable. Omit `ids`:
+
+| Variable  | Role                                                              | Argument  |
+|-----------|-------------------------------------------------------------------|-----------|
+| `stratum` | Sampling stratum (10 levels, defined by census block group)       | `strata`  |
+| `weight`  | Final raked weight — base weight calibrated to Census targets     | `weights` |
+
+```{r npors}
+svy_npors <- as_survey(
+  pew_npors_2025,
+  strata  = stratum,
+  weights = weight
+)
+```
+
+---
+
+## 3. `as_survey_rep()` — Replicate Weight Designs {#sec-rep}
+
+Use `as_survey_rep()` when your data provider has supplied pre-computed
+replicate weight columns — columns like `repwt_1`, `repwt_2`, ..., or
+`pwgtp1`–`pwgtp80`. Replicate-based variance estimation works by repeatedly
+re-estimating the target statistic under small perturbations of the sample,
+embedding variance information directly in the weights
+[@wolter2007, ch. 1].
+
+**Use the agency-supplied replicate weights when they are available.**
+Survey agencies tune these weights for their specific design. Using them
+correctly replicates published point estimates and standard errors and is
+generally considered the preferred approach for variance estimation with major
+public surveys [@lohr2022, §9.4].
+
+### 3.1 The `type` argument
+
+The `type` argument specifies which replication variance formula applies.
+Getting this wrong produces systematically incorrect standard errors. Identify
+the correct type from your codebook's technical documentation.
+
+| Type                    | Full name                    | Identifying signs in codebook                     | Common surveys                           |
+|-------------------------|------------------------------|---------------------------------------------------|------------------------------------------|
+| `"JK1"`                 | Jackknife-1                  | "JK1"; one PSU dropped per replicate              | NHES, some Pew studies                   |
+| `"JK2"`                 | Jackknife-2                  | "JK2"; paired PSUs; exactly 2 PSUs per stratum    | NAEP, PISA, most NCES surveys            |
+| `"JKn"`                 | Jackknife-n                  | One stratum dropped per replicate                 | Less common; some multi-PSU designs      |
+| `"BRR"`                 | Balanced Repeated Replication| "BRR"; exactly 2 PSUs per stratum required        | Some CPS variants                        |
+| `"Fay"`                 | Fay's Modified BRR           | "Fay BRR" or "Fay's method"; BRR with epsilon     | Some Census Bureau surveys [@fay1989; @judkins1990] |
+| `"bootstrap"`           | Bootstrap                    | "bootstrap replication weights"; 100–500 replicates | BRFSS                                  |
+| `"successive-difference"` | Successive Difference      | "SDR" or "successive difference replication"      | ACS 1-year PUMS [@census2022]            |
+| `"ACS"`                 | ACS variant                  | Specific to ACS 5-year methodology                | ACS 5-year PUMS                          |
+
+The Fay epsilon parameter (`fay_rho`) controls how much each replicate weight
+differs from the full-sample weight. Its value is specified in the survey's
+technical documentation [@fay1989; @judkins1990].
+
+### 3.2 Worked example: ACS PUMS 2022 — Wyoming
+
+The ACS 1-year PUMS provides 80 successive-difference replicate weights for
+variance estimation, documented in the ACS Design and Methodology report
+[@census2022]:
+
+| Variable             | Role                                                    | Argument      |
+|----------------------|---------------------------------------------------------|---------------|
+| `pwgtp`              | Person weight                                           | `weights`     |
+| `pwgtp1`–`pwgtp80`   | Successive-difference replicate weights (80 replicates) | `repweights`  |
+
+```{r acs}
+svy_acs <- as_survey_rep(
+  acs_pums_wy,
+  weights    = pwgtp,
+  repweights = pwgtp1:pwgtp80,
+  type       = "successive-difference"
+)
+svy_acs
+```
+
+### 3.3 Worked example: Pew Jewish Americans 2020
+
+This Pew study provides 100 jackknife-1 replicate weights alongside the
+full-sample weight:
+
+| Variable                       | Role                                          | Argument     |
+|--------------------------------|-----------------------------------------------|--------------|
+| `extweight`                    | Full-sample base weight                       | `weights`    |
+| `extweight1`–`extweight100`    | JK1 jackknife replicate weights (100 replicates) | `repweights` |
+
+```{r pew-jewish}
+svy_jewish <- as_survey_rep(
+  pew_jewish_2020,
+  weights    = extweight,
+  repweights = extweight1:extweight100,
+  type       = "JK1"
+)
+svy_jewish
+```
+
+### 3.4 The `scale` and `rscales` arguments
+
+Most users can omit `scale` and `rscales`. surveycore computes defaults based
+on `type` and the number of replicates. Override them only when your
+codebook's technical documentation specifies custom values [@wolter2007, ch. 3].
+
+---
+
+## 4. `as_survey_twophase()` — Two-Phase Designs {#sec-twophase}
+
+> **If you are not sure whether your design is two-phase, it almost certainly
+> is not.** Skip to @sec-srs or @sec-calibrated.
+
+### 4.1 What two-phase sampling is
+
+Two-phase (or double-sampling) designs collect data in two stages
+[@lumley2010, ch. 9]:
+
+1. **Phase 1:** A large, inexpensive sample that records basic variables
+   (demographics, a screening question, administrative records).
+2. **Phase 2:** A subsample drawn from Phase 1 that collects expensive or
+   difficult measurements — lab tests, in-person interviews, expert coding.
+
+The variance estimator accounts for uncertainty from both sampling stages
+[@saegusa2013]. You must have retained the Phase 1 data and know which
+Phase 1 units were selected into Phase 2.
+
+Common contexts: case-cohort studies, medical validation studies, surveys
+with a screening phase [@breslow1988].
+
+### 4.2 Arguments
+
+| Argument                          | What it does                                                             |
+|-----------------------------------|--------------------------------------------------------------------------|
+| `phase1`                          | A `survey_taylor` object representing the Phase 1 design                 |
+| `subset`                          | Bare name of a logical column: `TRUE` = selected into Phase 2            |
+| `ids2`, `strata2`, `probs2`, `fpc2` | Phase 2 design variables (all optional)                                |
+| `method`                          | `"full"` (default), `"approx"`, or `"simple"`                            |
+
+The `method` argument:
+
+- `"full"`: Correct variance accounting for both phases. Requires Phase 1
+  cluster information.
+- `"approx"`: Faster approximation; adequate when the Phase 1 sampling
+  fraction is small.
+- `"simple"`: Ignores the Phase 1 design. Use only if Phase 1 is a census.
+
+### 4.3 Worked example: National Wilms Tumor Study
+
+The `nwtco` dataset from the `survival` package records outcomes for 4,028
+children enrolled in the National Wilms Tumor Study — a multi-institution
+clinical trial. This is a case-cohort design: a random subcohort was selected
+from all enrolled children (Phase 1), and expensive central-laboratory
+histology was measured only for subcohort members plus all relapse cases
+[@breslow1988].
+
+```{r nwtco}
+#| eval: !expr requireNamespace("survival", quietly = TRUE)
+nwtco <- survival::nwtco
+
+# in.subcohort is stored as 0/1 — must be logical for as_survey_twophase()
+nwtco$in.subcohort <- as.logical(nwtco$in.subcohort)
+
+# Phase 1: all 4,028 enrolled patients (each patient is their own unit)
+phase1 <- as_survey(nwtco, ids = seqno)
+
+# Phase 2: subcohort, with Phase 2 sampling stratified by relapse status
+svy_twophase <- as_survey_twophase(
+  phase1,
+  strata2 = rel,           # Phase 2 strata: cases (rel=1) vs. non-cases (rel=0)
+  subset  = in.subcohort,  # Logical column: TRUE = selected into Phase 2
+  method  = "full"
+)
+svy_twophase
+```
+
+---
+
+## 5. `as_survey_srs()` — Simple Random Sample {#sec-srs}
+
+Use `as_survey_srs()` when every unit in your target population had an equal,
+known probability of selection — no clustering, no stratification
+[@cochran1977, ch. 2; @lohr2022, ch. 2]. This design is common in:
+
+- Surveys of a complete organizational roster (all employees at a company,
+  all students at a school) where units are drawn directly from a list
+- Small-scale research with a well-defined, numbered sampling frame
+- Pilot studies and classroom experiments
+
+### 5.1 Arguments
+
+| Argument  | What it does                                                                  |
+|-----------|-------------------------------------------------------------------------------|
+| `weights` | Sampling weight column — inverse of selection probability                     |
+| `probs`   | Selection probability column — supply `weights` *or* `probs`, not both        |
+| `fpc`     | Population size (integer column) or sampling fraction (numeric column, 0–1)   |
+
+### 5.2 The `fpc` argument matters more here
+
+Without clustering or stratification, the FPC has a proportionally larger
+effect on variance estimates than in complex designs [@cochran1977, §2.8].
+Supply it when you know the population size or sampling fraction. For the
+example below, the population is N = 400 schools.
+
+### 5.3 Worked example: School district survey
+
+A district administrator draws a simple random sample of 80 schools from a
+complete roster of 400 schools. Every school has an equal probability of
+selection (80/400 = 0.20) — the textbook SRS case [@cochran1977, ch. 2;
+@lohr2022, ch. 2]:
+
+```{r apisrs}
+set.seed(101)
+N <- 400   # total schools in district
+n <- 80    # schools sampled
+
+school_survey <- data.frame(
+  school_id  = sample(seq_len(N), n),
+  avg_score  = round(rnorm(n, mean = 72, sd = 11), 1),
+  pct_frpl   = round(runif(n, 0.10, 0.85), 2),  # % free/reduced price lunch
+  enrollment = round(runif(n, 180, 850)),
+  sw         = N / n,   # equal sampling weight = 400/80 = 5.0
+  fpc        = N        # population size for FPC
+)
+
+svy_srs <- as_survey_srs(
+  school_survey,
+  weights = sw,   # each sampled school represents 5 schools in the population
+  fpc     = fpc   # reduces SEs: we sampled 20% of the population
+)
+svy_srs
+```
+
+Two things worth making explicit so this example is not misread:
+
+**The unit of analysis is the school, not the student.** Variables like
+`avg_score`, `pct_frpl`, and `enrollment` are school-level aggregates drawn
+from administrative records for each sampled school. This is a survey *of
+schools*. If you wanted individual student-level data from each selected
+school, you would need a two-stage cluster design — sample schools, then
+sample students within each school — and use `as_survey()` with
+`ids = school_id` to account for the clustering.
+
+**The weight is constant because this is SRS.** Each school was selected
+with probability 80/400 = 0.20, so each receives weight 1/0.20 = 5.0. The
+weight is the same for every school because no school was oversampled or
+undersampled relative to any other. Uniform weights are not a simplification
+— they are the defining signature of simple random sampling.
+
+### 5.4 Relationship to `as_survey()`
+
+When `as_survey()` is called without specifying `ids` or `strata`, it
+automatically creates a `survey_srs` object and issues a warning. Use
+`as_survey_srs()` explicitly when you know your design is SRS — it suppresses
+the warning and signals your intent clearly to future readers of your code:
+
+```{r srs-dispatch}
+# These produce the same object:
+# as_survey_srs() — explicit, no warning
+svy_a <- as_survey_srs(school_survey, weights = sw, fpc = fpc)
+
+# as_survey() — warns that it is dispatching to SRS
+svy_b <- as_survey(school_survey, weights = sw, fpc = fpc)
+```
+
+---
+
+## 6. `as_survey_calibrated()` — Non-Probability and Calibrated Samples {#sec-calibrated}
+
+If you conduct research on opt-in panels — Lucid, Dynata, Qualtrics panels,
+Prolific, or similar — and your vendor has provided raking or
+post-stratification weights, this section is for you.
+
+The short answer: **you are probably doing it roughly right, and
+`as_survey_calibrated()` is the correct constructor to use.** Here is what
+you can and cannot claim from your estimates, and how to report them honestly.
+
+### 6.1 The fundamental distinction
+
+A **probability sample** gives every unit in the target population a known,
+positive inclusion probability. Design-based variance estimators are valid
+because the randomness that justifies them comes from the sampling mechanism
+itself [@cochran1977, ch. 1; @lohr2022, ch. 1].
+
+A **non-probability sample** — an opt-in online panel — has unknown inclusion
+probabilities. The decision to join a panel and to complete a particular
+survey is self-selected. No mechanical property of the data guarantees
+representativeness [@baker2013; @elliott2017].
+
+### 6.2 What your vendor's weights actually are
+
+Regardless of where they come from, `as_survey_calibrated()` is the right
+constructor whenever weights were derived *after* data collection to make
+the sample resemble a target population. Common forms include
+[@valliant2018, ch. 3]:
+
+- **Raking** (iterative proportional fitting): adjusts sample marginals to
+  match population marginals on age, gender, education, race/ethnicity, etc.
+  The standard approach used by most panel vendors.
+- **Post-stratification**: assigns a single weight to all respondents
+  within a demographic cell defined by the cross-product of variables.
+- **Propensity score weighting (PSW)**: fits a model predicting the
+  probability of being in the sample, then weights each respondent by the
+  inverse of their predicted probability. Functionally equivalent to
+  calibration — the weights make the sample resemble the population on the
+  modeled covariates.
+- **Matching-based weights**: assigns weights based on similarity to a
+  reference population sample (e.g., entropy balancing, MatchIt outputs).
+  Another approach to demographic alignment.
+
+All four share the same fundamental property: the weights were computed from
+the data, not fixed by the sampling protocol. Use `as_survey_calibrated()`
+for all of them.
+
+What calibration weights accomplish [@mercer2018; @mcphee2023]:
+
+- They reduce bias from *measured* demographic confounders
+- Point estimates for outcomes correlated with calibration variables
+  improve meaningfully compared to unweighted estimates
+- They do **not** correct for selection on unobserved variables
+- They do **not** make the design a probability sample
+
+### 6.3 What you can and cannot claim
+
+| Claim                                                             | Valid?         | Notes                                                                     |
+|-------------------------------------------------------------------|----------------|---------------------------------------------------------------------------|
+| Point estimates representative of calibration margins             | ✅ Yes          | Calibrated to age, gender, education, etc. targets                        |
+| Estimates more accurate than unweighted                           | ✅ Usually      | Especially for outcomes correlated with demographic variables              |
+| Standard errors reflect true sampling uncertainty                 | ⚠️ Approximately | SEs computed under approximate variance model; likely underestimated     |
+| Results equivalent to a probability-sample estimate               | ❌ No           | Selection mechanism is unknown and cannot be fully corrected               |
+
+This is the standard practice across the industry — used routinely by
+academic researchers, major survey organizations, and commercial firms
+[@baker2013; @mcphee2023]. The key is transparency: **your methods section
+should state that you used a non-probability sample with vendor-supplied
+calibration weights, describe the calibration targets, and acknowledge that
+standard errors are approximate.**
+
+### 6.4 Worked example: Message-testing panel
+
+A policy organization recruits 500 opt-in panelists to test two framings of
+a healthcare message. The panel vendor provides raking weights calibrated to
+Current Population Survey marginals for age, gender, education, and
+race/ethnicity:
+
+```{r calibrated}
+set.seed(2024)
+n <- 500
+
+panel_data <- data.frame(
+  respondent_id = seq_len(n),
+  age_group     = sample(
+    c("18-34", "35-54", "55+"), n,
+    replace = TRUE, prob = c(0.38, 0.37, 0.25)
+  ),
+  gender        = sample(c("Man", "Woman"), n, replace = TRUE),
+  education     = sample(
+    c("HS or less", "Some college", "College+"), n,
+    replace = TRUE, prob = c(0.38, 0.30, 0.32)
+  ),
+  race_eth      = sample(
+    c("White", "Black", "Hispanic", "Other"), n,
+    replace = TRUE, prob = c(0.60, 0.12, 0.18, 0.10)
+  ),
+  message_arm   = sample(c("Framing A", "Framing B"), n, replace = TRUE),
+  support       = sample(1:5, n, replace = TRUE),
+  rake_weight   = runif(n, 0.4, 3.2)  # vendor-provided raking weights
+)
+
+svy_panel <- as_survey_calibrated(panel_data, weights = rake_weight)
+svy_panel
+```
+
+This produces a `survey_calibrated` object. Use it with `get_means()`,
+`get_freqs()`, and other estimation functions exactly as you would any other
+survey object. Standard errors are computed under an approximate variance
+model and should be interpreted with appropriate caution and disclosed in
+your methods section.
+
+### 6.5 What not to do
+
+Do not use `as_survey()` for a non-probability sample and present standard
+errors as if the design were a probability sample:
+
+```r
+# Creates a survey_taylor object, which misrepresents the design
+svy_wrong <- as_survey(panel_data, weights = rake_weight)
+```
+
+Using `as_survey_calibrated()` makes the non-probability nature of the design
+explicit — both to R and to future readers of your code. This distinction
+matters for transparency in reporting and for correctly interpreting what
+your uncertainty estimates actually mean [@elliott2017; @baker2013].
+
+### 6.6 Worked example: University voluntary response survey
+
+A university sends an email to all 8,000 enrolled students inviting them
+to complete a campus climate survey. 2,400 respond (30%). The response is
+self-selected — students with strong opinions are more likely to complete
+the survey than those who are neutral.
+
+**If calibration weights are available:** If the university has computed
+post-stratification or raking weights using registrar demographics (year,
+major, housing status), use `as_survey_calibrated()`. This is the appropriate
+constructor whenever the weights were derived to make the respondents
+resemble the full student body:
+
+```r
+svy_campus <- as_survey_calibrated(campus_survey, weights = ps_weight)
+```
+
+**If no calibration weights are available and you still want to use
+surveycore functions:** Add a column of 1s and use `as_survey_srs()`:
+
+```r
+campus_survey$wt <- 1
+svy_campus <- as_survey_srs(campus_survey, weights = wt)
+```
+
+This treats all respondents as equally weighted. The SEs it produces reflect
+variability *among the 2,400 respondents* — they do not measure how
+representative those respondents are of the full student body. This framing
+is valid when your target population is "students who chose to respond," not
+"all students at the university."
+
+**Disclosure:** Whether you use calibration weights or equal weights, your
+methods section should state the response rate, describe the weighting
+approach, and acknowledge the limitation: voluntary response bias cannot be
+fully corrected by any weighting strategy [@baker2013].
+
+---
+
+## 7. Probability, SRS, and calibration weights: understanding the distinction {#sec-weight-types}
+
+The three constructors most users encounter — `as_survey()`,
+`as_survey_srs()`, and `as_survey_calibrated()` — differ in one fundamental
+way: *where the weights come from*.
+
+| | `as_survey()` / `as_survey_rep()` | `as_survey_srs()` | `as_survey_calibrated()` |
+|---|---|---|---|
+| Weight source | Sampling protocol (1/π_i) | Equal-probability selection | Post-hoc adjustment |
+| Selection probabilities | Known and controlled | Known; equal for all units | Unknown or overridden by calibration |
+| Weight values | Vary across respondents | Same for all respondents | Vary (reflect adjustment, not design) |
+| Variance estimator | Design-based (exact) | Design-based (exact) | Approximate |
+
+In `as_survey()` and `as_survey_srs()`, every weight traces back to a
+specific moment in the sampling protocol — the moment each unit's selection
+probability was fixed. A PSU drawn with probability 1-in-10 gets weight 10.
+A school drawn from a roster of 400 with probability 1-in-5 gets weight 5.
+The randomness that makes design-based inference valid is mechanical and
+recorded.
+
+In `as_survey_calibrated()`, weights were computed *after* data collection
+to make the sample resemble a target population. The underlying selection
+mechanism is either unknown (opt-in panel, voluntary response) or was
+overridden by the calibration adjustment. Standard errors are approximate
+because the calibration step itself introduces additional uncertainty
+that standard variance formulas do not fully capture.
+
+The practical test: **if you can point to the sampling protocol that fixed
+each unit's probability of selection, use `as_survey()` or
+`as_survey_srs()`.** If the weights were derived from the data after
+collection, use `as_survey_calibrated()`.
+
+---
+
+## 8. When no constructor applies: convenience and purposive samples {#sec-no-constructor}
+
+Not every data collection fits the survey design framework.
+
+### 8.1 Example: program evaluation classrooms
+
+A researcher surveys students in five classrooms that volunteered to
+participate in a new educational program and wants to assess whether the
+program changed their attitudes.
+
+The classrooms were not randomly selected from any defined population. There
+is no sampling mechanism to justify a design-based variance estimator, and
+no calibration weights that would correct for the non-random selection. The
+inferential question — whether the program *caused* attitude change — is a
+**causal inference** problem requiring a control group and appropriate
+methods (difference-in-differences, matching, regression discontinuity),
+not a survey design object.
+
+If the goal is purely **descriptive** — summarizing the attitudes of
+students in these specific classrooms without generalizing — you can treat
+the participants as a census. Add a column of 1s and use `as_survey_srs()`:
+
+```r
+classroom_data$wt <- 1
+svy_participants <- as_survey_srs(classroom_data, weights = wt)
+```
+
+Equal weights treat all participants as equally represented. The SEs reflect
+variation *among participants*. Do not interpret results as representative
+of all students at the school.
+
+### 8.2 General decision rule
+
+| Design | Appropriate tool | Notes |
+|---|---|---|
+| Probability sample with design weights | `as_survey()`, `as_survey_rep()`, `as_survey_srs()` | Exact variance |
+| Any sample with calibration/raking/PSW/matching weights | `as_survey_calibrated()` | Approximate variance |
+| Voluntary response or convenience sample, no weights | `as_survey_srs()` with `weights = 1` | Conditional inference only; disclose |
+| Causal inference (treatment effect estimation) | Not surveycore | Use MatchIt, WeightIt, lme4, etc. |
+
+When you use `as_survey_srs()` with equal weights for a non-probability
+sample, surveycore produces estimates and SEs without error. The SEs are
+valid as a measure of variability *among the observed participants*. They
+should not be interpreted as uncertainty about a broader population unless
+the sample can be independently defended as representative.
+
+---
+
+## 9. Reference: Common Codebook Variables {#sec-reference}
+
+A lookup table for common codebook terms and how they map to constructor
+arguments:
+
+| Codebook term                                                    | Maps to                              | Notes                                     |
+|------------------------------------------------------------------|--------------------------------------|-------------------------------------------|
+| "sampling weight", "survey weight", "person weight"              | `weights =`                          |                                           |
+| "PSU", "primary sampling unit", "cluster ID"                     | `ids =`                              |                                           |
+| "stratum", "design stratum", "sampling stratum"                  | `strata =`                           |                                           |
+| "FPC", "finite population correction", "population size"         | `fpc =`                              |                                           |
+| "replicate weights", "bootstrap weights", "BRR weights"          | `repweights =`                       | Use `as_survey_rep()`                     |
+| "base weight", "design weight" (with separate replicates)        | `weights =` in `as_survey_rep()`     |                                           |
+| "Fay coefficient", "Fay factor", "epsilon"                       | `fay_rho =`                          | With `type = "Fay"`                       |
+| "raking weights", "post-stratification weights", "cal weights"   | `weights =` in `as_survey_calibrated()` | Non-probability design               |
+| "two-phase", "double sampling", "case-cohort"                    | Phase 1 → `as_survey()`, then `as_survey_twophase()` |                        |
+
+---
+
+## References

--- a/vignettes/references.bib
+++ b/vignettes/references.bib
@@ -1,0 +1,136 @@
+@article{baker2013,
+  author  = {Baker, Reg and Brick, J. Michael and Bates, Nancy A. and
+             Battaglia, Mike and Couper, Mick P. and Dever, Jill A. and
+             Gile, Krista J. and Tourangeau, Roger},
+  title   = {Summary Report of the {AAPOR} Task Force on Non-Probability
+             Sampling},
+  journal = {Journal of Survey Statistics and Methodology},
+  year    = {2013},
+  volume  = {1},
+  number  = {2},
+  pages   = {90--143},
+  doi     = {10.1093/jssam/smt008}
+}
+
+@article{breslow1988,
+  author  = {Breslow, Norman E. and Cain, Kevin C.},
+  title   = {Logistic Regression for Two-Stage Case-Control Data},
+  journal = {Biometrika},
+  year    = {1988},
+  volume  = {75},
+  number  = {1},
+  pages   = {11--20},
+  doi     = {10.1093/biomet/75.1.11}
+}
+
+@techreport{census2022,
+  author      = {{U.S. Census Bureau}},
+  title       = {American Community Survey Design and Methodology,
+                 Chapter 12: Variance Estimation},
+  institution = {U.S. Census Bureau},
+  year        = {2022},
+  url         = {https://www2.census.gov/programs-surveys/acs/methodology/design_and_methodology/2022/acs_design_methodology_ch12_2022.pdf}
+}
+
+@book{cochran1977,
+  author    = {Cochran, William G.},
+  title     = {Sampling Techniques},
+  edition   = {3rd},
+  publisher = {John Wiley \& Sons},
+  year      = {1977}
+}
+
+@article{elliott2017,
+  author  = {Elliott, Michael R. and Valliant, Richard},
+  title   = {Inference for Nonprobability Samples},
+  journal = {Statistical Science},
+  year    = {2017},
+  volume  = {32},
+  number  = {2},
+  pages   = {249--264},
+  doi     = {10.1214/16-STS598}
+}
+
+@inproceedings{fay1989,
+  author    = {Fay, Robert E.},
+  title     = {Theory and Application of Replicate Weighting for Variance
+               Calculations},
+  booktitle = {Proceedings of the Section on Survey Research Methods},
+  publisher = {American Statistical Association},
+  year      = {1989},
+  pages     = {212--217}
+}
+
+@article{judkins1990,
+  author  = {Judkins, David R.},
+  title   = {{Fay's} Method for Variance Estimation},
+  journal = {Journal of Official Statistics},
+  year    = {1990},
+  volume  = {6},
+  number  = {3},
+  pages   = {223--239}
+}
+
+@book{lohr2022,
+  author    = {Lohr, Sharon L.},
+  title     = {Sampling: Design and Analysis},
+  edition   = {3rd},
+  publisher = {CRC Press},
+  year      = {2022}
+}
+
+@book{lumley2010,
+  author    = {Lumley, Thomas},
+  title     = {Complex Surveys: A Guide to Analysis Using {R}},
+  publisher = {John Wiley \& Sons},
+  year      = {2010},
+  doi       = {10.1002/9780470580066}
+}
+
+@techreport{mcphee2023,
+  author      = {McPhee, Cameron and Barlas, Frances and Brigham, Nancy and
+                 Darling, Jill and Dutwin, David and Jackson, Chris and
+                 Jackson, Mickey and Kirzinger, Ashley and Little, Roderick
+                 and Lorenz, Emily and Marlar, Jenny and Mercer, Andrew and
+                 Scanlon, Paul J. and Weiss, Steffen and Wronski, Laura},
+  title       = {Data Quality Metrics for Online Samples: Considerations for
+                 Study Design \& Analysis},
+  institution = {American Association for Public Opinion Research},
+  year        = {2023},
+  url         = {https://aapor.org/wp-content/uploads/2023/02/Task-Force-Report-FINAL.pdf}
+}
+
+@techreport{mercer2018,
+  author      = {Mercer, Andrew and Lau, Arnold and Kennedy, Courtney},
+  title       = {For Weighting Online Opt-In Samples, What Matters Most?},
+  institution = {Pew Research Center},
+  year        = {2018},
+  url         = {https://www.pewresearch.org/methods/2018/01/26/for-weighting-online-opt-in-samples-what-matters-most/}
+}
+
+@article{saegusa2013,
+  author  = {Saegusa, Takumi and Wellner, Jon A.},
+  title   = {Weighted Likelihood Estimation under Two-Phase Sampling},
+  journal = {Annals of Statistics},
+  year    = {2013},
+  volume  = {41},
+  number  = {1},
+  pages   = {269--295},
+  doi     = {10.1214/12-AOS1073}
+}
+
+@book{valliant2018,
+  author    = {Valliant, Richard and Dever, Jill A.},
+  title     = {Survey Weights: A Step-by-Step Guide to Calculation},
+  publisher = {Stata Press},
+  year      = {2018}
+}
+
+@book{wolter2007,
+  author    = {Wolter, Kirk M.},
+  title     = {Introduction to Variance Estimation},
+  edition   = {2nd},
+  publisher = {Springer},
+  year      = {2007},
+  doi       = {10.1007/978-0-387-35099-8}
+}


### PR DESCRIPTION
## What

Adds the `creating-survey-objects` vignette: a full worked-example guide
covering all five survey constructors with a decision guide, per-dataset
variable reference tables, and conceptual explanations of when each
constructor applies.

## Checklist

- [x] Tests written and passing (`devtools::test()`) — 2795 tests, 0 failures
- [x] R CMD check: 0 errors, 0 warnings, 1 note (future timestamp — pre-approved) (`devtools::check()`)
- [x] Roxygen docs updated and `devtools::document()` run — n/a (no roxygen changes)
- [x] `plans/error-messages.md` updated — n/a (no new error classes)
- [x] `VENDORED.md` updated — n/a (no vendored code)
- [x] PR title is a valid Conventional Commit (`docs(vignette): description`)

## Details

- Decision guide table with all five constructors, reordered so `as_survey_srs()` precedes `as_survey_calibrated()` and `as_survey_twophase()` is last
- Variable reference tables (Variable / Role / Function Argument) for all six bundled datasets: NHANES, ANES, GSS, Pew NPORS, ACS PUMS, Pew Jewish Americans
- Section 5.3: clarification that the school district SRS example is school-level, not student-level, and why weights are constant in SRS
- Section 6.2: `as_survey_calibrated()` expanded to cover raking, post-stratification, propensity score weighting, and matching-based weights
- Section 6.6: university voluntary response example with both the calibrated-weights and weights = 1 paths documented
- Section 7: probability vs. calibration weights — comparison table and practical test
- Section 8: when no constructor applies (convenience/purposive samples)
- `DESCRIPTION`: added `VignetteBuilder: quarto`, `quarto` and `survival` to Suggests