### PR TITLE
chore(vignette): convert vignette from Quarto to R Markdown

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,6 +14,6 @@
 ^pkgdown$
 ^cran-comments\.md$
 
-# Quarto vignette build artifacts
+# Vignette build artifacts (pre-built HTML from local development)
 ^vignettes/.*_files$
 ^vignettes/.*\.html$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,7 +22,7 @@ jobs:
         config:
           - {os: ubuntu-latest,  r: 'release',  build-args: 'character(0)', extra-check-args: ''}
           - {os: ubuntu-latest,  r: 'devel',    http-user-agent: 'release', build-args: 'character(0)', extra-check-args: ''}
-          - {os: windows-latest, r: 'release',  build-args: '"--no-build-vignettes"', extra-check-args: ', "--no-vignettes"'}
+          - {os: windows-latest, r: 'release',  build-args: 'character(0)', extra-check-args: ''}
           - {os: macos-latest,   r: 'release',  build-args: 'character(0)', extra-check-args: ''}
 
     env:
@@ -40,11 +40,9 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: quarto-dev/quarto-actions/setup@v2
-
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, quarto-dev/quarto-r
+          extra-packages: any::rcmdcheck
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,10 +33,8 @@ Suggests:
     lifecycle (>= 1.0.0),
     covr,
     knitr,
-    rmarkdown,
-    quarto,
-    survival
-VignetteBuilder: quarto
+    rmarkdown
+VignetteBuilder: knitr
 Config/testthat/edition: 3
 URL: https://github.com/JDenn0514/surveycore, https://jdenn0514.github.io/surveycore/
 BugReports: https://github.com/JDenn0514/surveycore/issues

--- a/changelog/phase-0.75/chore-vignette-rmd-conversion.md
+++ b/changelog/phase-0.75/chore-vignette-rmd-conversion.md
@@ -1,0 +1,31 @@
+# chore(vignette): convert vignette from Quarto (.qmd) to R Markdown (.Rmd)
+
+**Date**: 2026-02-25
+**Branch**: chore/vignette-rmd-conversion
+**Phase**: Phase 0.75
+
+## Changes
+
+- Replace `vignettes/creating-survey-objects.qmd` with `vignettes/creating-survey-objects.Rmd`
+  using standard `rmarkdown::html_vignette` output; preserves all content, structure, and
+  bibliography unchanged
+- Convert Quarto-specific YAML (`VignetteEngine{quarto::html}`, `format: html:`) to
+  standard knitr/rmarkdown YAML (`VignetteEngine{knitr::rmarkdown}`, `output: rmarkdown::html_vignette`)
+- Convert Quarto hash-pipe chunk options (`#| include: false`, `#| eval: !expr ...`) to
+  standard knitr chunk header options (`include=FALSE`, `eval=requireNamespace(...)`)
+- Replace Quarto cross-reference syntax (`@sec-calibrated`, `@sec-srs`) with standard
+  pandoc anchor links (`[Section 6](#sec-calibrated)`, `[Section 5](#sec-srs)`)
+- Update `DESCRIPTION`: `VignetteBuilder: quarto` → `VignetteBuilder: knitr`; remove
+  `quarto` from Suggests; fix duplicate `survival` entry
+- Update `R-CMD-check.yaml`: remove `quarto-dev/quarto-actions/setup@v2` step and
+  `quarto-dev/quarto-r` extra-package; restore Windows to build vignettes normally
+  (remove `--no-build-vignettes` / `--no-vignettes` flags)
+- Update `.Rbuildignore` comment from "Quarto vignette build artifacts" to generic
+
+## Files Modified
+
+- `vignettes/creating-survey-objects.Rmd` — new file: full Rmd vignette (replaces .qmd)
+- `vignettes/creating-survey-objects.qmd` — deleted
+- `DESCRIPTION` — VignetteBuilder changed to knitr; quarto removed from Suggests; duplicate survival removed
+- `.github/workflows/R-CMD-check.yaml` — Quarto CI setup removed; Windows vignette skip removed
+- `.Rbuildignore` — comment updated

--- a/vignettes/creating-survey-objects.Rmd
+++ b/vignettes/creating-survey-objects.Rmd
@@ -1,18 +1,18 @@
 ---
 title: "Creating Survey Objects in surveycore"
+output:
+  rmarkdown::html_vignette:
+    toc: true
+    toc_depth: 3
+bibliography: references.bib
+link-citations: yes
 vignette: >
   %\VignetteIndexEntry{Creating Survey Objects in surveycore}
-  %\VignetteEngine{quarto::html}
+  %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
-format:
-  html:
-    toc: true
-    toc-depth: 3
-bibliography: references.bib
 ---
 
-```{r setup}
-#| include: false
+```{r setup, include=FALSE}
 library(surveycore)
 ```
 
@@ -36,7 +36,7 @@ It is written for three audiences:
   The conceptual explanations in each section are for you.
 - **Non-probability panel users** — if you run message-testing or attitudinal
   research on Lucid, Dynata, or a similar platform and have vendor-provided
-  raking weights, skip ahead to @sec-calibrated.
+  raking weights, skip ahead to [Section 6](#sec-calibrated).
 
 This vignette covers object *creation* only. Estimation functions (`get_means()`,
 `get_totals()`, etc.) are covered in `vignette("estimation")`.
@@ -357,7 +357,7 @@ codebook's technical documentation specifies custom values [@wolter2007, ch. 3].
 ## 4. `as_survey_twophase()` — Two-Phase Designs {#sec-twophase}
 
 > **If you are not sure whether your design is two-phase, it almost certainly
-> is not.** Skip to @sec-srs or @sec-calibrated.
+> is not.** Skip to [Section 5](#sec-srs) or [Section 6](#sec-calibrated).
 
 ### 4.1 What two-phase sampling is
 
@@ -402,8 +402,7 @@ from all enrolled children (Phase 1), and expensive central-laboratory
 histology was measured only for subcohort members plus all relapse cases
 [@breslow1988].
 
-```{r nwtco}
-#| eval: !expr requireNamespace("survival", quietly = TRUE)
+```{r nwtco, eval=requireNamespace("survival", quietly=TRUE)}
 nwtco <- survival::nwtco
 
 # in.subcohort is stored as 0/1 — must be logical for as_survey_twophase()


### PR DESCRIPTION
## What

Convert the creating-survey-objects vignette from Quarto (.qmd) to standard R Markdown (.Rmd) so it builds on all platforms without a Quarto CLI installation.

## Changes

- `vignettes/creating-survey-objects.Rmd` — replaces `.qmd`; all content unchanged; YAML updated to `rmarkdown::html_vignette`; Quarto hash-pipe chunk options converted to knitr header options; `@sec-X` cross-references converted to pandoc anchor links
- `DESCRIPTION` — `VignetteBuilder: knitr`; `quarto` removed from Suggests; duplicate `survival` entry fixed
- `.github/workflows/R-CMD-check.yaml` — removed `quarto-dev/quarto-actions/setup` step and `quarto-dev/quarto-r` extra-package; Windows now builds vignettes normally (no more `--no-build-vignettes`/`--no-vignettes`)
- `.Rbuildignore` — comment updated

## Checklist

- [x] Tests written and passing (`devtools::test()`) — 2858 passed, 0 failed
- [x] R CMD check: 0 errors, 0 warnings (`devtools::check()`)
- [x] Roxygen docs updated and `devtools::document()` run — no roxygen changes
- [ ] `plans/error-messages.md` updated (if new errors/warnings added) — N/A
- [ ] `VENDORED.md` updated (if variance code vendored in this PR) — N/A
- [x] PR title is a valid Conventional Commit (`chore(vignette): convert vignette from Quarto to R Markdown`)