### PR TITLE
fix(analysis): output pct as proportion (0-1) and add decimals argument

### DIFF
--- a/R/analysis-corr.R
+++ b/R/analysis-corr.R
@@ -36,6 +36,9 @@
 #' @param conf_level Numeric scalar in (0, 1). Default `0.95`.
 #' @param n_weighted Logical. If `TRUE`, add an `n_weighted` column with the
 #'   pairwise sum of weights (both variables non-NA). Default `FALSE`.
+#' @param decimals Integer or `NULL`. If an integer, rounds all numeric output
+#'   columns (e.g., `r`, `se`, `ci_low`, `ci_high`) to this many decimal
+#'   places. Default `NULL` (no rounding).
 #' @param min_cell_n Integer. Minimum pairwise unweighted count before
 #'   `surveycore_warning_small_cell` fires. Default `30L` (AAPOR guidance).
 #' @param na.rm Logical. If `TRUE` (default), pairs use complete cases for
@@ -97,6 +100,7 @@ get_corr <- function(
   variance     = "ci",
   conf_level   = 0.95,
   n_weighted   = FALSE,
+  decimals     = NULL,
   min_cell_n   = 30L,
   na.rm        = TRUE,
   label_values = TRUE,
@@ -105,7 +109,7 @@ get_corr <- function(
 ) {
   # ── Step 1: Validate ────────────────────────────────────────────────────────
   .check_unsupported_class(design, "get_corr")
-  .validate_shared_args(variance, conf_level, name_style)
+  .validate_shared_args(variance, conf_level, name_style, decimals = decimals)
   format <- match.arg(format)
 
   # ── Step 2: Resolve variables ────────────────────────────────────────────────
@@ -404,7 +408,8 @@ get_corr <- function(
   result$var1  <- factor(result$var1, levels = uniq_display)
   result$var2  <- factor(result$var2, levels = uniq_display)
 
-  # ── Step 16: Apply name style ─────────────────────────────────────────────────
+  # ── Step 16: Apply decimals and name style ────────────────────────────────────
+  if (!is.null(decimals)) result <- .apply_decimals(result, decimals)
   .apply_name_style(result, name_style)
 }
 

--- a/R/analysis-freqs-helpers.R
+++ b/R/analysis-freqs-helpers.R
@@ -137,9 +137,9 @@
   }
 
   list(
-    pct        = p * 100,
-    se         = se * 100,
-    se_srs     = se_srs * 100,
+    pct        = p,
+    se         = se,
+    se_srs     = se_srs,
     n          = n_cell,
     n_weighted = Y
   )
@@ -196,9 +196,9 @@
   }
 
   list(
-    pct        = p * 100,
-    se         = se * 100,
-    se_srs     = se_srs * 100,
+    pct        = p,
+    se         = se,
+    se_srs     = se_srs,
     n          = n_cell,
     n_weighted = Y
   )
@@ -236,7 +236,7 @@
 
   if (is.na(p) || n_g < 2L) {
     return(list(
-      pct        = if (is.na(p)) NA_real_ else p * 100,
+      pct        = if (is.na(p)) NA_real_ else p,
       se         = NA_real_,
       se_srs     = NA_real_,
       n          = n_cell,
@@ -265,9 +265,9 @@
   se    <- sqrt(max(0, var_p))
 
   list(
-    pct        = p * 100,
-    se         = se * 100,
-    se_srs     = se * 100,    # se_srs = se for SRS (design effect = 1)
+    pct        = p,
+    se         = se,
+    se_srs     = se,    # se_srs = se for SRS (design effect = 1)
     n          = n_cell,
     n_weighted = Y
   )
@@ -330,9 +330,9 @@
   }
 
   list(
-    pct        = p * 100,
-    se         = se * 100,
-    se_srs     = se_srs * 100,
+    pct        = p,
+    se         = se,
+    se_srs     = se_srs,
     n          = n_cell,
     n_weighted = Y
   )

--- a/R/analysis-freqs.R
+++ b/R/analysis-freqs.R
@@ -38,6 +38,9 @@
 #'   Default `0.95`.
 #' @param n_weighted Logical. If `TRUE`, add an `n_weighted` column with the
 #'   sum of weights (estimated population count) per cell. Default `FALSE`.
+#' @param decimals Integer or `NULL`. If an integer, rounds all numeric output
+#'   columns (e.g., `pct`, `se`, `ci_low`, `ci_high`) to this many decimal
+#'   places. Default `NULL` (no rounding).
 #' @param min_cell_n Integer. Minimum unweighted cell count before
 #'   `surveycore_warning_small_cell` fires. Default `30L` (AAPOR guidance).
 #' @param na.rm Logical. If `TRUE` (default), `NA` values are excluded from
@@ -69,13 +72,13 @@
 #'
 #' **`na.rm = FALSE`:** `NA` is appended as the last level. All proportions
 #' (including non-`NA` levels) have their denominator inflated to include
-#' `NA` rows, so the `pct` column sums to 100.
+#' `NA` rows, so the `pct` column sums to 1.
 #'
 #' @return A `survey_freqs` tibble (also inheriting `survey_result`). Columns:
 #' \itemize{
 #'   \item `[group_cols...]` — group variable columns (when active), first.
 #'   \item `[variable_name]` (single) or `[names_to]` + `[values_to]` (multi).
-#'   \item `pct` — weighted proportion as a percentage (0–100).
+#'   \item `pct` — weighted proportion (0–1).
 #'   \item Variance columns (`se`, `var`, `cv`, `ci_low`, `ci_high`, `moe`,
 #'     `deff`) — only those requested via `variance`.
 #'   \item `n` — unweighted cell count (sample basis of each estimate).
@@ -114,6 +117,7 @@ get_freqs <- function(
   variance     = NULL,
   conf_level   = 0.95,
   n_weighted   = FALSE,
+  decimals     = NULL,
   min_cell_n   = 30L,
   na.rm        = TRUE,
   label_values = TRUE,
@@ -122,7 +126,7 @@ get_freqs <- function(
 ) {
   # ── Step 1: Validate ────────────────────────────────────────────────────────
   .check_unsupported_class(design, "get_freqs")
-  .validate_shared_args(variance, conf_level, name_style)
+  .validate_shared_args(variance, conf_level, name_style, decimals = decimals)
 
   # ── Step 2: Resolve variables, groups, domain ───────────────────────────────
   x_quo     <- rlang::enquo(x)
@@ -443,6 +447,7 @@ get_freqs <- function(
     required_keys
   )
 
-  # ── Step 13: Apply name style ─────────────────────────────────────────────────
+  # ── Step 13: Apply decimals and name style ────────────────────────────────────
+  if (!is.null(decimals)) result <- .apply_decimals(result, decimals)
   .apply_name_style(result, name_style)
 }

--- a/R/analysis-helpers.R
+++ b/R/analysis-helpers.R
@@ -293,21 +293,23 @@ RATIOS_META_KEYS    <- c("group", "numerator", "denominator")
 # ── .validate_shared_args() ───────────────────────────────────────────────────
 #
 # Validate the cross-cutting arguments that appear on all get_*() functions:
-# variance, conf_level, and name_style.
+# variance, conf_level, name_style, and decimals.
 #
 # Call this as the FIRST action in every get_*() function, before any tidy-
 # select resolution or estimation logic. This is the single canonical source
-# for these three validation errors — never duplicate the checks inside
-# individual get_*() functions.
+# for these validation errors — never duplicate the checks inside individual
+# get_*() functions.
 #
 # Errors (from plans/error-messages.md):
 #   surveycore_error_invalid_variance_arg  (row 45)
 #   surveycore_error_invalid_conf_level    (row 45a)
 #   surveycore_error_invalid_name_style    (row 46)
+#   surveycore_error_invalid_decimals      (row 45b)
 #
 # @param variance       NULL or character vector of variance types.
 # @param conf_level     Numeric scalar in (0, 1).
 # @param name_style     "surveycore" or "broom".
+# @param decimals       NULL or a non-negative whole number.
 # @param valid_variance Character vector of accepted variance values.
 # @param call           Caller environment for error attribution.
 # @return invisible(TRUE) on success.
@@ -315,6 +317,7 @@ RATIOS_META_KEYS    <- c("group", "numerator", "denominator")
   variance,
   conf_level,
   name_style,
+  decimals       = NULL,
   valid_variance = c("se", "ci", "var", "cv", "moe", "deff"),
   call = rlang::caller_env()
 ) {
@@ -352,7 +355,52 @@ RATIOS_META_KEYS    <- c("group", "numerator", "denominator")
       call  = call
     )
   }
+  if (!is.null(decimals)) {
+    if (
+      !is.numeric(decimals) ||
+      length(decimals) != 1L ||
+      decimals < 0 ||
+      decimals != round(decimals)
+    ) {
+      cli::cli_abort(
+        c(
+          "x" = paste0(
+            "{.arg decimals} must be a non-negative whole number or ",
+            "{.code NULL}."
+          ),
+          "i" = "Got {.val {decimals}}."
+        ),
+        class = "surveycore_error_invalid_decimals",
+        call  = call
+      )
+    }
+  }
   invisible(TRUE)
+}
+
+
+# ── .apply_decimals() ─────────────────────────────────────────────────────────
+#
+# Round all double-typed columns in a survey_result tibble to the specified
+# number of decimal places. Integer columns (e.g., n) and non-numeric columns
+# (group vars, character columns) are left unchanged. The .meta attribute and
+# S3 class are preserved across rounding using the same pattern as
+# .apply_name_style().
+#
+# @param result   A survey_result tibble.
+# @param decimals A non-negative whole number.
+# @return The result tibble with double columns rounded.
+.apply_decimals <- function(result, decimals) {
+  saved_meta  <- attr(result, ".meta")
+  saved_class <- class(result)
+  for (i in seq_along(result)) {
+    if (is.double(result[[i]])) {
+      result[[i]] <- round(result[[i]], decimals)
+    }
+  }
+  attr(result, ".meta") <- saved_meta
+  class(result) <- saved_class
+  result
 }
 
 

--- a/R/analysis-means.R
+++ b/R/analysis-means.R
@@ -27,6 +27,9 @@
 #'   Default `0.95`.
 #' @param n_weighted Logical. If `TRUE`, add an `n_weighted` column with the
 #'   sum of weights for non-NA observations in each group. Default `FALSE`.
+#' @param decimals Integer or `NULL`. If an integer, rounds all numeric output
+#'   columns (e.g., `mean`, `se`, `ci_low`, `ci_high`) to this many decimal
+#'   places. Default `NULL` (no rounding).
 #' @param min_cell_n Integer. Minimum unweighted cell count before
 #'   `surveycore_warning_small_cell` fires. Default `30L` (AAPOR guidance).
 #' @param na.rm Logical. If `TRUE` (default), `NA` values in `x` are excluded.
@@ -72,6 +75,7 @@ get_means <- function(
   variance     = "ci",
   conf_level   = 0.95,
   n_weighted   = FALSE,
+  decimals     = NULL,
   min_cell_n   = 30L,
   na.rm        = TRUE,
   label_values = TRUE,
@@ -80,7 +84,7 @@ get_means <- function(
 ) {
   # ── Step 1: Validate ────────────────────────────────────────────────────────
   .check_unsupported_class(design, "get_means")
-  .validate_shared_args(variance, conf_level, name_style)
+  .validate_shared_args(variance, conf_level, name_style, decimals = decimals)
 
   # ── Step 2: Resolve variable, groups, domain ─────────────────────────────────
   x_quo     <- rlang::enquo(x)
@@ -261,7 +265,8 @@ get_means <- function(
     MEANS_META_KEYS
   )
 
-  # ── Step 12: Apply name style ─────────────────────────────────────────────────
+  # ── Step 12: Apply decimals and name style ────────────────────────────────────
+  if (!is.null(decimals)) result <- .apply_decimals(result, decimals)
   .apply_name_style(result, name_style)
 }
 

--- a/R/analysis-quantiles.R
+++ b/R/analysis-quantiles.R
@@ -32,6 +32,9 @@
 #'   intervals. Default `0.95`.
 #' @param n_weighted Logical. If `TRUE`, add an `n_weighted` column with the
 #'   sum of weights for non-NA observations in each group. Default `FALSE`.
+#' @param decimals Integer or `NULL`. If an integer, rounds all numeric output
+#'   columns (e.g., `estimate`, `se`, `ci_low`, `ci_high`) to this many
+#'   decimal places. Default `NULL` (no rounding).
 #' @param min_cell_n Integer. Minimum unweighted cell count before
 #'   `surveycore_warning_small_cell` fires. Default `30L` (AAPOR guidance).
 #' @param na.rm Logical. If `TRUE` (default), `NA` values in `x` are excluded.
@@ -87,6 +90,7 @@ get_quantiles <- function(
   variance     = "ci",
   conf_level   = 0.95,
   n_weighted   = FALSE,
+  decimals     = NULL,
   min_cell_n   = 30L,
   na.rm        = TRUE,
   label_values = TRUE,
@@ -95,7 +99,7 @@ get_quantiles <- function(
 ) {
   # ── Step 1: Validate ────────────────────────────────────────────────────────
   .check_unsupported_class(design, "get_quantiles")
-  .validate_shared_args(variance, conf_level, name_style)
+  .validate_shared_args(variance, conf_level, name_style, decimals = decimals)
 
   if (
     !is.numeric(probs) ||
@@ -364,6 +368,7 @@ get_quantiles <- function(
     QUANTILES_META_KEYS
   )
 
-  # ── Step 13: Apply name style ─────────────────────────────────────────────────
+  # ── Step 13: Apply decimals and name style ────────────────────────────────────
+  if (!is.null(decimals)) result <- .apply_decimals(result, decimals)
   .apply_name_style(result, name_style)
 }

--- a/R/analysis-ratios.R
+++ b/R/analysis-ratios.R
@@ -39,6 +39,9 @@
 #' @param n_weighted Logical. If `TRUE`, add an `n_weighted` column with the
 #'   sum of weights for rows where both numerator and denominator are non-NA
 #'   in each group. Default `FALSE`.
+#' @param decimals Integer or `NULL`. If an integer, rounds all numeric output
+#'   columns (e.g., `ratio`, `se`, `ci_low`, `ci_high`) to this many decimal
+#'   places. Default `NULL` (no rounding).
 #' @param min_cell_n Integer. Minimum unweighted cell count before
 #'   `surveycore_warning_small_cell` fires. Default `30L` (AAPOR guidance).
 #' @param na.rm Logical. If `TRUE` (default), rows where either the numerator
@@ -89,6 +92,7 @@ get_ratios <- function(
   variance     = "ci",
   conf_level   = 0.95,
   n_weighted   = FALSE,
+  decimals     = NULL,
   min_cell_n   = 30L,
   na.rm        = TRUE,
   label_values = TRUE,
@@ -97,7 +101,7 @@ get_ratios <- function(
 ) {
   # ── Step 1: Validate ────────────────────────────────────────────────────────
   .check_unsupported_class(design, "get_ratios")
-  .validate_shared_args(variance, conf_level, name_style)
+  .validate_shared_args(variance, conf_level, name_style, decimals = decimals)
 
   # ── Step 2: Resolve variables, groups, domain ─────────────────────────────
   num_quo   <- rlang::enquo(numerator)
@@ -371,6 +375,7 @@ get_ratios <- function(
     RATIOS_META_KEYS
   )
 
-  # ── Step 13: Apply name style ─────────────────────────────────────────────
+  # ── Step 13: Apply decimals and name style ────────────────────────────────
+  if (!is.null(decimals)) result <- .apply_decimals(result, decimals)
   .apply_name_style(result, name_style)
 }

--- a/R/analysis-totals.R
+++ b/R/analysis-totals.R
@@ -27,6 +27,9 @@
 #' @param n_weighted Logical. For `get_totals(d)` (no variable), equals the
 #'   `total` column and is included for API uniformity. For variable mode,
 #'   adds the sum of weights for non-NA observations. Default `FALSE`.
+#' @param decimals Integer or `NULL`. If an integer, rounds all numeric output
+#'   columns (e.g., `total`, `se`, `ci_low`, `ci_high`) to this many decimal
+#'   places. Default `NULL` (no rounding).
 #' @param min_cell_n Integer. Default `30L`.
 #' @param na.rm Logical. If `TRUE` (default), `NA` values are excluded.
 #' @param label_values Logical. Accepted for API uniformity. Default `TRUE`.
@@ -67,6 +70,7 @@ get_totals <- function(
   variance     = "ci",
   conf_level   = 0.95,
   n_weighted   = FALSE,
+  decimals     = NULL,
   min_cell_n   = 30L,
   na.rm        = TRUE,
   label_values = TRUE,
@@ -75,7 +79,7 @@ get_totals <- function(
 ) {
   # ── Step 1: Validate ────────────────────────────────────────────────────────
   .check_unsupported_class(design, "get_totals")
-  .validate_shared_args(variance, conf_level, name_style)
+  .validate_shared_args(variance, conf_level, name_style, decimals = decimals)
 
   # ── Step 2: Resolve variable, groups, domain ─────────────────────────────────
   x_quo     <- rlang::enquo(x)
@@ -278,6 +282,7 @@ get_totals <- function(
     TOTALS_META_KEYS
   )
 
-  # ── Step 12: Apply name style ─────────────────────────────────────────────────
+  # ── Step 12: Apply decimals and name style ────────────────────────────────────
+  if (!is.null(decimals)) result <- .apply_decimals(result, decimals)
   .apply_name_style(result, name_style)
 }

--- a/changelog/phase-1/fix-pct-proportion-decimals-arg.md
+++ b/changelog/phase-1/fix-pct-proportion-decimals-arg.md
@@ -1,0 +1,52 @@
+# fix(analysis): output pct as proportion (0–1) and add decimals argument
+
+**Date**: 2026-02-27
+**Branch**: fix/pct-proportion-decimals-arg
+**Phase**: Phase 1
+
+## Changes
+
+- Fix `get_freqs()` to output `pct` as a proportion (0–1) instead of a
+  percentage (0–100); `se` and `se_srs` are now on the same proportion scale
+- Add `decimals` argument to all six analysis functions (`get_freqs`,
+  `get_means`, `get_totals`, `get_corr`, `get_quantiles`, `get_ratios`) that
+  rounds all numeric output columns to the specified number of decimal places
+- Add `.apply_decimals()` shared helper to `R/analysis-helpers.R`
+- Add `decimals` validation to `.validate_shared_args()` (new error class
+  `surveycore_error_invalid_decimals`)
+- Update all `sum(pct) == 100` test assertions to `sum(pct) == 1` and remove
+  `* 100` scaling from numerical oracle tests
+- Add `decimals` tests to all six analysis test files and to
+  `test-analysis-helpers.R`
+
+## Files Modified
+
+- `R/analysis-freqs-helpers.R` — remove `* 100` from `pct`, `se`, `se_srs`
+  in all four cell estimators (`.taylor_freq_cell`, `.replicate_freq_cell`,
+  `.srs_freq_cell`, `.twophase_freq_cell`)
+- `R/analysis-freqs.R` — add `decimals` arg; update docstring (pct 0–1, sums to 1)
+- `R/analysis-means.R` — add `decimals` arg
+- `R/analysis-totals.R` — add `decimals` arg
+- `R/analysis-corr.R` — add `decimals` arg
+- `R/analysis-quantiles.R` — add `decimals` arg
+- `R/analysis-ratios.R` — add `decimals` arg
+- `R/analysis-helpers.R` — add `.apply_decimals()`; add `decimals` validation
+  to `.validate_shared_args()`
+- `man/get_freqs.Rd` — regenerated with updated docstring
+- `man/get_means.Rd` — regenerated with `decimals` param
+- `man/get_totals.Rd` — regenerated with `decimals` param
+- `man/get_corr.Rd` — regenerated with `decimals` param
+- `man/get_quantiles.Rd` — regenerated with `decimals` param
+- `man/get_ratios.Rd` — regenerated with `decimals` param
+- `plans/error-messages.md` — add row 45b for `surveycore_error_invalid_decimals`
+- `tests/testthat/test-analysis-freqs.R` — update pct sum assertions; update
+  oracle tests; add `decimals` tests
+- `tests/testthat/test-analysis-means.R` — add `decimals` tests
+- `tests/testthat/test-analysis-totals.R` — add `decimals` tests
+- `tests/testthat/test-analysis-corr.R` — add `decimals` tests
+- `tests/testthat/test-analysis-quantiles.R` — add `decimals` tests
+- `tests/testthat/test-analysis-ratios.R` — add `decimals` tests
+- `tests/testthat/test-analysis-helpers.R` — add `.apply_decimals()` unit tests
+  and `.validate_shared_args()` decimals validation tests
+- `tests/testthat/_snaps/analysis-freqs.md` — new snapshot for `decimals = -1`
+- `tests/testthat/_snaps/analysis-helpers.md` — new snapshot for `decimals = -1`

--- a/man/get_corr.Rd
+++ b/man/get_corr.Rd
@@ -13,6 +13,7 @@ get_corr(
   variance = "ci",
   conf_level = 0.95,
   n_weighted = FALSE,
+  decimals = NULL,
   min_cell_n = 30L,
   na.rm = TRUE,
   label_values = TRUE,
@@ -51,6 +52,10 @@ applies to long format.}
 
 \item{n_weighted}{Logical. If \code{TRUE}, add an \code{n_weighted} column with the
 pairwise sum of weights (both variables non-NA). Default \code{FALSE}.}
+
+\item{decimals}{Integer or \code{NULL}. If an integer, rounds all numeric output
+columns (e.g., \code{r}, \code{se}, \code{ci_low}, \code{ci_high}) to this many decimal
+places. Default \code{NULL} (no rounding).}
 
 \item{min_cell_n}{Integer. Minimum pairwise unweighted count before
 \code{surveycore_warning_small_cell} fires. Default \code{30L} (AAPOR guidance).}

--- a/man/get_freqs.Rd
+++ b/man/get_freqs.Rd
@@ -14,6 +14,7 @@ get_freqs(
   variance = NULL,
   conf_level = 0.95,
   n_weighted = FALSE,
+  decimals = NULL,
   min_cell_n = 30L,
   na.rm = TRUE,
   label_values = TRUE,
@@ -53,6 +54,10 @@ Default \code{0.95}.}
 \item{n_weighted}{Logical. If \code{TRUE}, add an \code{n_weighted} column with the
 sum of weights (estimated population count) per cell. Default \code{FALSE}.}
 
+\item{decimals}{Integer or \code{NULL}. If an integer, rounds all numeric output
+columns (e.g., \code{pct}, \code{se}, \code{ci_low}, \code{ci_high}) to this many decimal
+places. Default \code{NULL} (no rounding).}
+
 \item{min_cell_n}{Integer. Minimum unweighted cell count before
 \code{surveycore_warning_small_cell} fires. Default \code{30L} (AAPOR guidance).}
 
@@ -76,7 +81,7 @@ A \code{survey_freqs} tibble (also inheriting \code{survey_result}). Columns:
 \itemize{
 \item \verb{[group_cols...]} — group variable columns (when active), first.
 \item \verb{[variable_name]} (single) or \verb{[names_to]} + \verb{[values_to]} (multi).
-\item \code{pct} — weighted proportion as a percentage (0–100).
+\item \code{pct} — weighted proportion (0–1).
 \item Variance columns (\code{se}, \code{var}, \code{cv}, \code{ci_low}, \code{ci_high}, \code{moe},
 \code{deff}) — only those requested via \code{variance}.
 \item \code{n} — unweighted cell count (sample basis of each estimate).
@@ -107,7 +112,7 @@ not physically removed for domain/group subsets.
 
 \strong{\code{na.rm = FALSE}:} \code{NA} is appended as the last level. All proportions
 (including non-\code{NA} levels) have their denominator inflated to include
-\code{NA} rows, so the \code{pct} column sums to 100.
+\code{NA} rows, so the \code{pct} column sums to 1.
 }
 \examples{
 # NHANES exam weights are 0 for non-examined participants; filter first

--- a/man/get_means.Rd
+++ b/man/get_means.Rd
@@ -11,6 +11,7 @@ get_means(
   variance = "ci",
   conf_level = 0.95,
   n_weighted = FALSE,
+  decimals = NULL,
   min_cell_n = 30L,
   na.rm = TRUE,
   label_values = TRUE,
@@ -38,6 +39,10 @@ Default \code{0.95}.}
 
 \item{n_weighted}{Logical. If \code{TRUE}, add an \code{n_weighted} column with the
 sum of weights for non-NA observations in each group. Default \code{FALSE}.}
+
+\item{decimals}{Integer or \code{NULL}. If an integer, rounds all numeric output
+columns (e.g., \code{mean}, \code{se}, \code{ci_low}, \code{ci_high}) to this many decimal
+places. Default \code{NULL} (no rounding).}
 
 \item{min_cell_n}{Integer. Minimum unweighted cell count before
 \code{surveycore_warning_small_cell} fires. Default \code{30L} (AAPOR guidance).}

--- a/man/get_quantiles.Rd
+++ b/man/get_quantiles.Rd
@@ -12,6 +12,7 @@ get_quantiles(
   variance = "ci",
   conf_level = 0.95,
   n_weighted = FALSE,
+  decimals = NULL,
   min_cell_n = 30L,
   na.rm = TRUE,
   label_values = TRUE,
@@ -44,6 +45,10 @@ intervals. Default \code{0.95}.}
 
 \item{n_weighted}{Logical. If \code{TRUE}, add an \code{n_weighted} column with the
 sum of weights for non-NA observations in each group. Default \code{FALSE}.}
+
+\item{decimals}{Integer or \code{NULL}. If an integer, rounds all numeric output
+columns (e.g., \code{estimate}, \code{se}, \code{ci_low}, \code{ci_high}) to this many
+decimal places. Default \code{NULL} (no rounding).}
 
 \item{min_cell_n}{Integer. Minimum unweighted cell count before
 \code{surveycore_warning_small_cell} fires. Default \code{30L} (AAPOR guidance).}

--- a/man/get_ratios.Rd
+++ b/man/get_ratios.Rd
@@ -12,6 +12,7 @@ get_ratios(
   variance = "ci",
   conf_level = 0.95,
   n_weighted = FALSE,
+  decimals = NULL,
   min_cell_n = 30L,
   na.rm = TRUE,
   label_values = TRUE,
@@ -27,6 +28,7 @@ get_ratios(
   variance = "ci",
   conf_level = 0.95,
   n_weighted = FALSE,
+  decimals = NULL,
   min_cell_n = 30L,
   na.rm = TRUE,
   label_values = TRUE,
@@ -62,6 +64,10 @@ confidence intervals. Default \code{0.95}.}
 \item{n_weighted}{Logical. If \code{TRUE}, add an \code{n_weighted} column with the
 sum of weights for rows where both numerator and denominator are non-NA
 in each group. Default \code{FALSE}.}
+
+\item{decimals}{Integer or \code{NULL}. If an integer, rounds all numeric output
+columns (e.g., \code{ratio}, \code{se}, \code{ci_low}, \code{ci_high}) to this many decimal
+places. Default \code{NULL} (no rounding).}
 
 \item{min_cell_n}{Integer. Minimum unweighted cell count before
 \code{surveycore_warning_small_cell} fires. Default \code{30L} (AAPOR guidance).}

--- a/man/get_totals.Rd
+++ b/man/get_totals.Rd
@@ -11,6 +11,7 @@ get_totals(
   variance = "ci",
   conf_level = 0.95,
   n_weighted = FALSE,
+  decimals = NULL,
   min_cell_n = 30L,
   na.rm = TRUE,
   label_values = TRUE,
@@ -37,6 +38,10 @@ variable(s). Default \code{NULL}.}
 \item{n_weighted}{Logical. For \code{get_totals(d)} (no variable), equals the
 \code{total} column and is included for API uniformity. For variable mode,
 adds the sum of weights for non-NA observations. Default \code{FALSE}.}
+
+\item{decimals}{Integer or \code{NULL}. If an integer, rounds all numeric output
+columns (e.g., \code{total}, \code{se}, \code{ci_low}, \code{ci_high}) to this many decimal
+places. Default \code{NULL} (no rounding).}
 
 \item{min_cell_n}{Integer. Default \code{30L}.}
 

--- a/plans/error-messages.md
+++ b/plans/error-messages.md
@@ -75,6 +75,7 @@ against the messages defined here.
 | 44 | `get_corr()` | Fewer than 2 variables supplied | ERROR | `surveycore_error_insufficient_variables` | `"{.fn get_corr} requires at least 2 variables, but {.arg x} resolved to {length(vars)} variable{?s}."` |
 | 45 | all `get_*()` | Unknown value for `variance` argument | ERROR | `surveycore_error_invalid_variance_arg` | `'{.arg variance} values must be from {.val {valid_variance}}. Unknown value{?s}: {.val {bad_vals}}.'` |
 | 45a | all `get_*()` | `conf_level` not a single number strictly between 0 and 1 | ERROR | `surveycore_error_invalid_conf_level` | `"{.arg conf_level} must be a single number strictly between 0 and 1. Got {.val {conf_level}}."` |
+| 45b | all `get_*()` | `decimals` is not a non-negative whole number or `NULL` | ERROR | `surveycore_error_invalid_decimals` | `"{.arg decimals} must be a non-negative whole number or {.code NULL}. Got {.val {decimals}}."` |
 | 46 | all `get_*()` | Unknown value for `name_style` argument | ERROR | `surveycore_error_invalid_name_style` | `'{.arg name_style} must be {.val "surveycore"} or {.val "broom"}, not {.val {name_style}}.'` |
 | 47 | `get_quantiles()` | `probs` outside (0,1) or length 0 | ERROR | `surveycore_error_invalid_probs` | `"{.arg probs} must be a non-empty numeric vector with all values in (0, 1). Invalid value{?s}: {.val {bad_probs}}."` |
 | 48 | `get_ratios()` | All denominator values are zero | ERROR | `surveycore_error_ratio_zero_denominator` | `"All values of the denominator ({.field {denom_var}}) are zero. Cannot compute ratio."` |
@@ -150,12 +151,12 @@ Which test files cover which error table rows:
 | `test-metadata-system.R` | 27–30 |
 | `test-s7-classes.R` | 31–35, 37–39 |
 | `test-update-design.R` | 36 |
-| `test-analysis-helpers.R` | 45, 45a, 46 (direct unit tests on `.validate_shared_args()`); 64 (`.check_unsupported_class()` and `.build_meta()` fallback); also integration-checked in per-function files |
-| `test-analysis-freqs.R` | 45, 45a, 46, 49, 50, 52, 53, 55 |
-| `test-analysis-means.R` | 43, 45, 45a, 46, 49, 50, 54 |
-| `test-analysis-totals.R` | 43, 45, 45a, 46, 49, 50, 54 |
-| `test-analysis-corr.R` | 43, 44, 45, 45a, 46, 49, 50, 51, 54 |
-| `test-analysis-quantiles.R` | 45, 45a, 46, 47, 49, 50, 54 |
-| `test-analysis-ratios.R` | 43, 45, 45a, 46, 48, 49, 50, 54 |
+| `test-analysis-helpers.R` | 45, 45a, 45b, 46 (direct unit tests on `.validate_shared_args()` and `.apply_decimals()`); 64 (`.check_unsupported_class()` and `.build_meta()` fallback); also integration-checked in per-function files |
+| `test-analysis-freqs.R` | 45, 45a, 45b, 46, 49, 50, 52, 53, 55 |
+| `test-analysis-means.R` | 43, 45, 45a, 45b, 46, 49, 50, 54 |
+| `test-analysis-totals.R` | 43, 45, 45a, 45b, 46, 49, 50, 54 |
+| `test-analysis-corr.R` | 43, 44, 45, 45a, 45b, 46, 49, 50, 51, 54 |
+| `test-analysis-quantiles.R` | 45, 45a, 45b, 46, 47, 49, 50, 54 |
+| `test-analysis-ratios.R` | 43, 45, 45a, 45b, 46, 48, 49, 50, 54 |
 | `test-glm.R` | 64 (via `.check_unsupported_class()`), 65–74 (Layer 3 dual pattern), 77; S7 validator errors in Section 3.3 (class= only, not in this table) |
 | `test-glm-methods.R` | 76 |

--- a/tests/testthat/_snaps/analysis-freqs.md
+++ b/tests/testthat/_snaps/analysis-freqs.md
@@ -43,3 +43,12 @@
       x All values of group_all_na are `NA`.
       i Cannot compute estimate with `na.rm = FALSE`. Set `na.rm = TRUE` to exclude `NA` values.
 
+# get_freqs() rejects negative decimals
+
+    Code
+      get_freqs(d, group, decimals = -1L)
+    Condition
+      Error in `get_freqs()`:
+      x `decimals` must be a non-negative whole number or `NULL`.
+      i Got -1.
+

--- a/tests/testthat/_snaps/analysis-helpers.md
+++ b/tests/testthat/_snaps/analysis-helpers.md
@@ -42,3 +42,12 @@
       x `get_means()` requires a survey design object.
       i Got <data.frame>.
 
+# .validate_shared_args() rejects negative decimals
+
+    Code
+      .validate_shared_args(NULL, 0.95, "surveycore", decimals = -1L)
+    Condition
+      Error:
+      x `decimals` must be a non-negative whole number or `NULL`.
+      i Got -1.
+

--- a/tests/testthat/test-analysis-corr.R
+++ b/tests/testthat/test-analysis-corr.R
@@ -701,3 +701,29 @@ test_that("get_corr() meta$x has nested structure for each variable", {
   expect_true(all(c("variable_label", "question_preface", "value_labels") %in%
                     names(m$x$y1)))
 })
+
+# ── decimals argument ──────────────────────────────────────────────────────────
+
+test_that("get_corr() decimals=2 rounds all double columns", {
+  df <- make_survey_data(n = 200L, n_psu = 20L, n_strata = 4L, seed = 501L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc,
+                  nest = TRUE)
+  r  <- get_corr(d, x = c(y1, y2), variance = "ci", decimals = 2L)
+
+  dbl_cols <- names(r)[vapply(r, is.double, logical(1L))]
+  for (col in dbl_cols) {
+    expect_equal(r[[col]], round(r[[col]], 2L),
+                 label = paste0(col, " rounded to 2 decimals"))
+  }
+})
+
+test_that("get_corr() rejects invalid decimals", {
+  df <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 502L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc,
+                  nest = TRUE)
+
+  expect_error(
+    get_corr(d, x = c(y1, y2), decimals = -2L),
+    class = "surveycore_error_invalid_decimals"
+  )
+})

--- a/tests/testthat/test-analysis-freqs.R
+++ b/tests/testthat/test-analysis-freqs.R
@@ -29,7 +29,7 @@ test_that("get_freqs() returns a survey_freqs object for a Taylor design", {
   test_result_invariants(r, "survey_freqs")
   expect_identical(names(r), c("group", "pct", "n"))
   expect_identical(r$group, c("A", "B", "C"))
-  expect_equal(sum(r$pct), 100, tolerance = 1e-8)
+  expect_equal(sum(r$pct), 1, tolerance = 1e-8)
   expect_true(all(r$n > 0L))
 })
 
@@ -77,7 +77,7 @@ test_that("get_freqs() works for binary (0/1 integer) variable", {
 
   test_result_invariants(r, "survey_freqs")
   expect_equal(nrow(r), 2L)
-  expect_equal(sum(r$pct), 100, tolerance = 1e-8)
+  expect_equal(sum(r$pct), 1, tolerance = 1e-8)
 })
 
 
@@ -93,11 +93,11 @@ test_that("get_freqs() stacks rows in multi-variable mode", {
   expect_identical(names(r), c("item", "response", "pct", "n"))
   # group: 3 levels; y3: 2 levels; total = 5
   expect_equal(nrow(r), 5L)
-  # Percents within each variable sum to 100
+  # Proportions within each variable sum to 1
   pct_group <- r$pct[r$item == "group"]
   pct_y3    <- r$pct[r$item == "y3"]
-  expect_equal(sum(pct_group), 100, tolerance = 1e-8)
-  expect_equal(sum(pct_y3),    100, tolerance = 1e-8)
+  expect_equal(sum(pct_group), 1, tolerance = 1e-8)
+  expect_equal(sum(pct_y3),    1, tolerance = 1e-8)
 })
 
 test_that("get_freqs() multi-var meta has required keys", {
@@ -148,8 +148,8 @@ test_that("get_freqs() pct sums to 100 within each group combo", {
   r  <- suppressWarnings(get_freqs(d, group, group = strata))
 
   for (s in unique(r$strata)) {
-    expect_equal(sum(r$pct[r$strata == s]), 100, tolerance = 1e-8,
-                 label = paste0("pct sums to 100 in strata = ", s))
+    expect_equal(sum(r$pct[r$strata == s]), 1, tolerance = 1e-8,
+                 label = paste0("pct sums to 1 in strata = ", s))
   }
 })
 
@@ -349,8 +349,8 @@ test_that("get_freqs() na.rm=TRUE excludes NA from levels and denominator", {
   expect_false(any(is.na(r$group)))
   # n sums to non-NA rows only
   expect_equal(sum(r$n), sum(!is.na(df$group)))
-  # pct sums to 100
-  expect_equal(sum(r$pct), 100, tolerance = 1e-8)
+  # pct sums to 1
+  expect_equal(sum(r$pct), 1, tolerance = 1e-8)
 })
 
 test_that("get_freqs() na.rm=FALSE adds NA as last level", {
@@ -366,8 +366,8 @@ test_that("get_freqs() na.rm=FALSE adds NA as last level", {
   expect_true(any(is.na(r$group)))
   # NA row is last
   expect_true(is.na(r$group[[nrow(r)]]))
-  # pct including NA sums to 100
-  expect_equal(sum(r$pct), 100, tolerance = 1e-8)
+  # pct including NA sums to 1
+  expect_equal(sum(r$pct), 1, tolerance = 1e-8)
 })
 
 
@@ -524,7 +524,7 @@ test_that("get_freqs() single-level variable returns 1 row with pct=100", {
 
   test_result_invariants(r, "survey_freqs")
   expect_equal(nrow(r), 1L)
-  expect_equal(r$pct[[1L]], 100, tolerance = 1e-8)
+  expect_equal(r$pct[[1L]], 1, tolerance = 1e-8)
 })
 
 test_that("get_freqs() min_cell_n=0 suppresses small-cell warnings", {
@@ -571,7 +571,7 @@ test_that("get_freqs() replicate design produces correct row count", {
 
   test_result_invariants(r, "survey_freqs")
   expect_equal(nrow(r), 3L)
-  expect_equal(sum(r$pct), 100, tolerance = 1e-8)
+  expect_equal(sum(r$pct), 1, tolerance = 1e-8)
 })
 
 test_that("get_freqs() two-phase design returns valid result", {
@@ -584,7 +584,7 @@ test_that("get_freqs() two-phase design returns valid result", {
 
   test_result_invariants(r, "survey_freqs")
   expect_equal(nrow(r), 3L)
-  expect_equal(sum(r$pct), 100, tolerance = 1e-8)
+  expect_equal(sum(r$pct), 1, tolerance = 1e-8)
 })
 
 test_that("get_freqs() na.rm=FALSE NA row is last", {
@@ -618,7 +618,7 @@ test_that("get_freqs() survey_calibrated design returns valid result", {
 
   test_result_invariants(r, "survey_freqs")
   expect_equal(nrow(r), 3L)
-  expect_equal(sum(r$pct), 100, tolerance = 1e-8)
+  expect_equal(sum(r$pct), 1, tolerance = 1e-8)
 })
 
 
@@ -645,17 +645,17 @@ test_that("get_freqs() Taylor pct matches survey::svymean on indicator [numerica
   sv_C <- survey::svymean(~ind_C, d_sv)
 
   expect_equal(r_sc$pct[r_sc$group == "A"],
-               as.numeric(coef(sv_A)) * 100, tolerance = 1e-10)
+               as.numeric(coef(sv_A)), tolerance = 1e-10)
   expect_equal(r_sc$pct[r_sc$group == "B"],
-               as.numeric(coef(sv_B)) * 100, tolerance = 1e-10)
+               as.numeric(coef(sv_B)), tolerance = 1e-10)
   expect_equal(r_sc$pct[r_sc$group == "C"],
-               as.numeric(coef(sv_C)) * 100, tolerance = 1e-10)
+               as.numeric(coef(sv_C)), tolerance = 1e-10)
   expect_equal(r_sc$se[r_sc$group == "A"],
-               as.numeric(survey::SE(sv_A)) * 100, tolerance = 1e-8)
+               as.numeric(survey::SE(sv_A)), tolerance = 1e-8)
   expect_equal(r_sc$se[r_sc$group == "B"],
-               as.numeric(survey::SE(sv_B)) * 100, tolerance = 1e-8)
+               as.numeric(survey::SE(sv_B)), tolerance = 1e-8)
   expect_equal(r_sc$se[r_sc$group == "C"],
-               as.numeric(survey::SE(sv_C)) * 100, tolerance = 1e-8)
+               as.numeric(survey::SE(sv_C)), tolerance = 1e-8)
 })
 
 test_that("get_freqs() replicate (BRR) pct matches survey::svymean [numerical]", {
@@ -684,23 +684,23 @@ test_that("get_freqs() replicate (BRR) pct matches survey::svymean [numerical]",
   sv_B <- survey::svymean(~ind_B, d_sv)
 
   expect_equal(r_sc$pct[r_sc$group == "A"],
-               as.numeric(coef(sv_A)) * 100, tolerance = 1e-10)
+               as.numeric(coef(sv_A)), tolerance = 1e-10)
   expect_equal(r_sc$pct[r_sc$group == "B"],
-               as.numeric(coef(sv_B)) * 100, tolerance = 1e-10)
+               as.numeric(coef(sv_B)), tolerance = 1e-10)
   expect_equal(r_sc$se[r_sc$group == "A"],
-               as.numeric(survey::SE(sv_A)) * 100, tolerance = 1e-8)
+               as.numeric(survey::SE(sv_A)), tolerance = 1e-8)
   expect_equal(r_sc$se[r_sc$group == "B"],
-               as.numeric(survey::SE(sv_B)) * 100, tolerance = 1e-8)
+               as.numeric(survey::SE(sv_B)), tolerance = 1e-8)
 })
 
-test_that("get_freqs() pct sums to 100 for all design types [oracle sanity]", {
+test_that("get_freqs() pct sums to 1 for all design types [oracle sanity]", {
   skip_if_not_installed("survey")
 
   designs <- make_all_designs(seed = 123L)
   for (nm in names(designs)) {
     r <- suppressWarnings(get_freqs(designs[[nm]], group))
-    expect_equal(sum(r$pct), 100, tolerance = 1e-8,
-                 label = paste0("pct sums to 100 for design = ", nm))
+    expect_equal(sum(r$pct), 1, tolerance = 1e-8,
+                 label = paste0("pct sums to 1 for design = ", nm))
   }
 })
 
@@ -809,4 +809,70 @@ test_that("get_freqs() meta$group always present (empty list when no groups)", {
   r  <- get_freqs(d, x)
   expect_type(meta(r)$group, "list")
   expect_length(meta(r)$group, 0L)
+})
+
+
+# ── decimals argument ──────────────────────────────────────────────────────────
+
+test_that("get_freqs() decimals=2 rounds all double columns", {
+  df <- make_survey_data(n = 200L, n_psu = 20L, n_strata = 4L, seed = 201L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc,
+                  nest = TRUE)
+  r  <- get_freqs(d, group, variance = "ci", decimals = 2L)
+
+  # All double columns should have at most 2 decimal places
+  dbl_cols <- names(r)[vapply(r, is.double, logical(1L))]
+  for (col in dbl_cols) {
+    expect_equal(r[[col]], round(r[[col]], 2L),
+                 label = paste0(col, " rounded to 2 decimals"))
+  }
+  # integer n column must not be rounded
+  expect_identical(class(r$n)[[1L]], "integer")
+})
+
+test_that("get_freqs() decimals=NULL applies no rounding", {
+  df <- make_survey_data(n = 200L, n_psu = 20L, n_strata = 4L, seed = 202L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc,
+                  nest = TRUE)
+  r_none    <- get_freqs(d, group, variance = "se", decimals = NULL)
+  r_rounded <- get_freqs(d, group, variance = "se", decimals = 4L)
+
+  # At least one pct value should differ (more precision without rounding)
+  expect_false(identical(r_none$pct, r_rounded$pct))
+})
+
+test_that("get_freqs() decimals preserves .meta and S3 class", {
+  df <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 203L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc,
+                  nest = TRUE)
+  r  <- get_freqs(d, group, decimals = 2L)
+
+  expect_true("survey_freqs" %in% class(r))
+  expect_false(is.null(attr(r, ".meta")))
+})
+
+test_that("get_freqs() rejects negative decimals", {
+  df <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 204L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc,
+                  nest = TRUE)
+
+  expect_error(
+    get_freqs(d, group, decimals = -1L),
+    class = "surveycore_error_invalid_decimals"
+  )
+  expect_snapshot(
+    error = TRUE,
+    get_freqs(d, group, decimals = -1L)
+  )
+})
+
+test_that("get_freqs() rejects non-integer decimals", {
+  df <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 205L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc,
+                  nest = TRUE)
+
+  expect_error(
+    get_freqs(d, group, decimals = 1.5),
+    class = "surveycore_error_invalid_decimals"
+  )
 })

--- a/tests/testthat/test-analysis-helpers.R
+++ b/tests/testthat/test-analysis-helpers.R
@@ -960,3 +960,95 @@ test_that(".apply_group_labels() only converts labelled columns in multi-group c
   expect_false(is.factor(result$region))
   expect_identical(result$region, c(1L, 1L, 2L, 2L, 3L, 3L))
 })
+
+
+# ── .apply_decimals() ─────────────────────────────────────────────────────────
+
+test_that(".apply_decimals() rounds double columns to specified places", {
+  df <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 51L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
+  r  <- get_means(d, y1, variance = "se")
+
+  r_rounded <- .apply_decimals(r, 2L)
+
+  expect_equal(r_rounded$mean, round(r$mean, 2L))
+  expect_equal(r_rounded$se,   round(r$se,   2L))
+})
+
+test_that(".apply_decimals() leaves integer columns unchanged", {
+  df <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 52L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
+  r  <- get_means(d, y1)
+
+  r_rounded <- .apply_decimals(r, 0L)
+
+  expect_identical(r_rounded$n, r$n)
+  expect_identical(class(r_rounded$n)[[1L]], "integer")
+})
+
+test_that(".apply_decimals() preserves .meta attribute", {
+  df <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 53L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
+  r  <- get_means(d, y1)
+  m_before <- attr(r, ".meta")
+
+  r_rounded <- .apply_decimals(r, 2L)
+
+  expect_identical(attr(r_rounded, ".meta"), m_before)
+})
+
+test_that(".apply_decimals() preserves S3 class", {
+  df <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 54L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
+  r  <- get_means(d, y1)
+  cls_before <- class(r)
+
+  r_rounded <- .apply_decimals(r, 2L)
+
+  expect_identical(class(r_rounded), cls_before)
+})
+
+# ── .validate_shared_args() — decimals validation ─────────────────────────────
+
+test_that(".validate_shared_args() accepts decimals = NULL", {
+  expect_no_error(
+    .validate_shared_args(NULL, 0.95, "surveycore", decimals = NULL)
+  )
+})
+
+test_that(".validate_shared_args() accepts decimals = 0", {
+  expect_no_error(
+    .validate_shared_args(NULL, 0.95, "surveycore", decimals = 0L)
+  )
+})
+
+test_that(".validate_shared_args() accepts decimals = 4", {
+  expect_no_error(
+    .validate_shared_args(NULL, 0.95, "surveycore", decimals = 4L)
+  )
+})
+
+test_that(".validate_shared_args() rejects negative decimals", {
+  expect_error(
+    .validate_shared_args(NULL, 0.95, "surveycore", decimals = -1L),
+    class = "surveycore_error_invalid_decimals"
+  )
+  expect_snapshot(
+    error = TRUE,
+    .validate_shared_args(NULL, 0.95, "surveycore", decimals = -1L)
+  )
+})
+
+test_that(".validate_shared_args() rejects non-integer decimals", {
+  expect_error(
+    .validate_shared_args(NULL, 0.95, "surveycore", decimals = 1.5),
+    class = "surveycore_error_invalid_decimals"
+  )
+})
+
+test_that(".validate_shared_args() rejects non-numeric decimals", {
+  expect_error(
+    .validate_shared_args(NULL, 0.95, "surveycore", decimals = "2"),
+    class = "surveycore_error_invalid_decimals"
+  )
+})

--- a/tests/testthat/test-analysis-means.R
+++ b/tests/testthat/test-analysis-means.R
@@ -513,3 +513,41 @@ test_that("get_means() meta$x has correct nested structure", {
   expect_true(all(c("variable_label", "question_preface", "value_labels") %in%
                     names(m$x$y)))
 })
+
+
+# ── decimals argument ──────────────────────────────────────────────────────────
+
+test_that("get_means() decimals=2 rounds all double columns", {
+  df <- make_survey_data(n = 200L, n_psu = 20L, n_strata = 4L, seed = 301L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc,
+                  nest = TRUE)
+  r  <- get_means(d, y1, variance = "ci", decimals = 2L)
+
+  dbl_cols <- names(r)[vapply(r, is.double, logical(1L))]
+  for (col in dbl_cols) {
+    expect_equal(r[[col]], round(r[[col]], 2L),
+                 label = paste0(col, " rounded to 2 decimals"))
+  }
+})
+
+test_that("get_means() decimals=NULL applies no rounding", {
+  df <- make_survey_data(n = 200L, n_psu = 20L, n_strata = 4L, seed = 302L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc,
+                  nest = TRUE)
+  r_none    <- get_means(d, y1, variance = "se", decimals = NULL)
+  r_rounded <- get_means(d, y1, variance = "se", decimals = 0L)
+
+  # Rounding to 0 places changes at least one value
+  expect_false(identical(r_none$mean, r_rounded$mean))
+})
+
+test_that("get_means() rejects invalid decimals", {
+  df <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 303L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc,
+                  nest = TRUE)
+
+  expect_error(
+    get_means(d, y1, decimals = -1L),
+    class = "surveycore_error_invalid_decimals"
+  )
+})

--- a/tests/testthat/test-analysis-quantiles.R
+++ b/tests/testthat/test-analysis-quantiles.R
@@ -704,3 +704,30 @@ test_that("get_quantiles() probs in meta match argument value", {
   expect_identical(meta(result)$probs, probs)
   expect_equal(names(meta(result)$x), "y1")
 })
+
+
+# ── decimals argument ──────────────────────────────────────────────────────────
+
+test_that("get_quantiles() decimals=2 rounds all double columns", {
+  df <- make_survey_data(n = 200L, n_psu = 20L, n_strata = 4L, seed = 601L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc,
+                  nest = TRUE)
+  r  <- get_quantiles(d, y1, variance = "ci", decimals = 2L)
+
+  dbl_cols <- names(r)[vapply(r, is.double, logical(1L))]
+  for (col in dbl_cols) {
+    expect_equal(r[[col]], round(r[[col]], 2L),
+                 label = paste0(col, " rounded to 2 decimals"))
+  }
+})
+
+test_that("get_quantiles() rejects invalid decimals", {
+  df <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 602L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc,
+                  nest = TRUE)
+
+  expect_error(
+    get_quantiles(d, y1, decimals = "two"),
+    class = "surveycore_error_invalid_decimals"
+  )
+})

--- a/tests/testthat/test-analysis-ratios.R
+++ b/tests/testthat/test-analysis-ratios.R
@@ -688,3 +688,29 @@ test_that("get_ratios() meta$group stores labels regardless of label_values", {
   expect_equal(meta(r_false)$group$gender$value_labels,
                c(Male = 1L, Female = 2L))
 })
+
+# ── decimals argument ──────────────────────────────────────────────────────────
+
+test_that("get_ratios() decimals=2 rounds all double columns", {
+  df <- make_survey_data(n = 200L, n_psu = 20L, n_strata = 4L, seed = 701L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc,
+                  nest = TRUE)
+  r  <- get_ratios(d, y1, y2, variance = "ci", decimals = 2L)
+
+  dbl_cols <- names(r)[vapply(r, is.double, logical(1L))]
+  for (col in dbl_cols) {
+    expect_equal(r[[col]], round(r[[col]], 2L),
+                 label = paste0(col, " rounded to 2 decimals"))
+  }
+})
+
+test_that("get_ratios() rejects invalid decimals", {
+  df <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 702L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc,
+                  nest = TRUE)
+
+  expect_error(
+    get_ratios(d, y1, y2, decimals = -1),
+    class = "surveycore_error_invalid_decimals"
+  )
+})

--- a/tests/testthat/test-analysis-totals.R
+++ b/tests/testthat/test-analysis-totals.R
@@ -361,3 +361,39 @@ test_that("get_totals() no-variable mode returns finite total for all 5 design t
     )
   }
 })
+
+# ── decimals argument ──────────────────────────────────────────────────────────
+
+test_that("get_totals() decimals=2 rounds all double columns", {
+  df <- make_survey_data(n = 200L, n_psu = 20L, n_strata = 4L, seed = 401L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc,
+                  nest = TRUE)
+  r  <- get_totals(d, y1, variance = "ci", decimals = 2L)
+
+  dbl_cols <- names(r)[vapply(r, is.double, logical(1L))]
+  for (col in dbl_cols) {
+    expect_equal(r[[col]], round(r[[col]], 2L),
+                 label = paste0(col, " rounded to 2 decimals"))
+  }
+})
+
+test_that("get_totals() decimals=NULL applies no rounding", {
+  df <- make_survey_data(n = 200L, n_psu = 20L, n_strata = 4L, seed = 402L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc,
+                  nest = TRUE)
+  r_none    <- get_totals(d, y1, variance = NULL, decimals = NULL)
+  r_rounded <- get_totals(d, y1, variance = NULL, decimals = 0L)
+
+  expect_false(identical(r_none$total, r_rounded$total))
+})
+
+test_that("get_totals() rejects invalid decimals", {
+  df <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 403L)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc,
+                  nest = TRUE)
+
+  expect_error(
+    get_totals(d, y1, decimals = 1.5),
+    class = "surveycore_error_invalid_decimals"
+  )
+})


### PR DESCRIPTION
## Summary

- Fix `get_freqs()` `pct` column to output a proportion (0–1) instead of a
  percentage (0–100). The `se` and `se_srs` columns scale accordingly. All
  sum-to-100 test assertions updated to sum-to-1; oracle tests no longer
  multiply by 100.
- Add `decimals` argument to all six `get_*()` analysis functions. When
  supplied as a non-negative integer, rounds all `double` output columns
  (point estimates, SE, CI bounds, etc.) to the specified decimal places.
  Integer columns (`n`) and non-numeric columns are unchanged. Default `NULL`
  (no rounding).
- New shared helper `.apply_decimals()` in `R/analysis-helpers.R`.
- New error class `surveycore_error_invalid_decimals` validated by
  `.validate_shared_args()`.

## Test plan

- [ ] `devtools::test(filter = "analysis")` — all 1778 analysis tests pass
- [ ] `devtools::check()` — 0 errors, 0 warnings, ≤2 notes
- [ ] `get_freqs(d, riagendr)$pct` values are in (0, 1) and sum to 1
- [ ] `get_means(d, ridageyr, variance = "ci", decimals = 2)` returns `mean` and CI bounds rounded to 2 decimal places
- [ ] `get_freqs(d, x, decimals = -1)` throws `surveycore_error_invalid_decimals`

🤖 Generated with [Claude Code](https://claude.com/claude-code)