### PR TITLE
fix(utils): add survey_srs and survey_calibrated branches to .get_design_vars_flat() and .get_design_vars()

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -147,7 +147,8 @@ SURVEYCORE_DOMAIN_COL <- "..surveycore_domain.."
 
 # Return a flat character vector of all design-variable column names.
 # NULL entries are dropped by c(). Unique names are returned.
-# Works for survey_taylor, survey_replicate, and survey_twophase.
+# Works for all five survey types: survey_taylor, survey_replicate,
+# survey_twophase, survey_calibrated, and survey_srs.
 # Used by conversion methods (05-methods-conversion.R), variance
 # estimation (06-variance-dispatch.R), and surveytidy verbs.
 # Exported (with @export) so surveytidy can call surveycore::.get_design_vars_flat()
@@ -181,6 +182,10 @@ SURVEYCORE_DOMAIN_COL <- "..surveycore_domain.."
       p2_cols,
       design@variables$subset
     ))
+  } else if (S7::S7_inherits(design, survey_calibrated)) {
+    unique(c(design@variables$weights))
+  } else if (S7::S7_inherits(design, survey_srs)) {
+    unique(c(design@variables$weights, design@variables$fpc))
   } else {
     character(0L) # nocov — defensive: all known types handled above
   }
@@ -226,6 +231,19 @@ SURVEYCORE_DOMAIN_COL <- "..surveycore_domain.."
       subset  = design@variables$subset
     )
     Filter(Negate(is.null), raw)
+  } else if (S7::S7_inherits(design, survey_calibrated)) {
+    Filter(
+      Negate(is.null),
+      list(weights = design@variables$weights)
+    )
+  } else if (S7::S7_inherits(design, survey_srs)) {
+    Filter(
+      Negate(is.null),
+      list(
+        weights = design@variables$weights,
+        fpc     = design@variables$fpc
+      )
+    )
   } else {
     list() # nocov — defensive: all known types handled above
   }

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -14,24 +14,26 @@
 #   5. .get_design_vars_flat() — survey_twophase (no p2 info)
 #   6. .get_design_vars_flat() — NULL design variables dropped
 #   7. .get_design_vars_flat() — survey_twophase with p2 design info
-#   8. .get_design_vars_flat() — survey_calibrated returns character(0)
-#   9. .get_design_vars() — survey_taylor named list
-#  10. .get_design_vars() — survey_replicate named list
-#  11. .get_design_vars() — survey_twophase named list (no p2 info)
-#  12. .get_design_vars() — survey_twophase with p2 design info
-#  13. .get_design_vars() — survey_calibrated returns empty list
-#  14. .resolve_tidy_select() — NULL quosure → NULL
-#  15. .resolve_tidy_select() — bare name → character vector
-#  16. .resolve_tidy_select() — c() → multiple column names
-#  17. .resolve_tidy_select() — starts_with() helper
-#  18. .resolve_single_col() — NULL quosure, required = FALSE → NULL
-#  19. .resolve_single_col() — NULL quosure, required = TRUE → error
-#  20. .resolve_single_col() — single column match → char(1)
-#  21. .resolve_single_col() — 0 columns → error with class_none
-#  22. .resolve_single_col() — >1 columns → error with class_multi
-#  23. .resolve_single_col() — custom error classes forwarded
-#  24. SURVEYCORE_DOMAIN_COL — correct constant value
-#  25. .SURVEYCORE_WT_COL — correct constant value
+#   8. .get_design_vars_flat() — survey_calibrated returns weights column
+#   9. .get_design_vars_flat() — survey_srs returns weights (and fpc when set)
+#  10. .get_design_vars() — survey_taylor named list
+#  11. .get_design_vars() — survey_replicate named list
+#  12. .get_design_vars() — survey_twophase named list (no p2 info)
+#  13. .get_design_vars() — survey_twophase with p2 design info
+#  14. .get_design_vars() — survey_calibrated returns weights entry
+#  15. .get_design_vars() — survey_srs returns weights (and fpc when set)
+#  16. .resolve_tidy_select() — NULL quosure → NULL
+#  17. .resolve_tidy_select() — bare name → character vector
+#  18. .resolve_tidy_select() — c() → multiple column names
+#  19. .resolve_tidy_select() — starts_with() helper
+#  20. .resolve_single_col() — NULL quosure, required = FALSE → NULL
+#  21. .resolve_single_col() — NULL quosure, required = TRUE → error
+#  22. .resolve_single_col() — single column match → char(1)
+#  23. .resolve_single_col() — 0 columns → error with class_none
+#  24. .resolve_single_col() — >1 columns → error with class_multi
+#  25. .resolve_single_col() — custom error classes forwarded
+#  26. SURVEYCORE_DOMAIN_COL — correct constant value
+#  27. .SURVEYCORE_WT_COL — correct constant value
 
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -81,6 +83,22 @@ make_twophase_with_p2 <- function(seed = 42L) {
 make_calibrated <- function() {
   df <- data.frame(y = 1:10, w = rep(1, 10))
   as_survey_calibrated(df, weights = w)
+}
+
+make_srs <- function(seed = 42L) {
+  set.seed(seed)
+  df <- data.frame(y = rnorm(20L), w = runif(20L, 0.5, 2.0))
+  suppressWarnings(as_survey_srs(df, weights = w))
+}
+
+make_srs_with_fpc <- function(seed = 42L) {
+  set.seed(seed)
+  df <- data.frame(
+    y   = rnorm(20L),
+    w   = runif(20L, 0.5, 2.0),
+    fpc = rep(200L, 20L)
+  )
+  suppressWarnings(as_survey_srs(df, weights = w, fpc = fpc))
 }
 
 
@@ -210,17 +228,39 @@ test_that(".get_design_vars_flat() returns unique names for twophase with p2 inf
 })
 
 
-# ── 8. .get_design_vars_flat() — survey_calibrated returns character(0) ──────
+# ── 8. .get_design_vars_flat() — survey_calibrated returns weights column ─────
 
-test_that(".get_design_vars_flat() returns character(0) for survey_calibrated", {
+test_that(".get_design_vars_flat() returns weights column name for survey_calibrated", {
   d    <- make_calibrated()
   flat <- surveycore:::.get_design_vars_flat(d)
-  expect_true(is.character(flat))
-  expect_length(flat, 0L)
+  expect_identical(flat, d@variables$weights)
 })
 
 
-# ── 9. .get_design_vars() — survey_taylor named list ────────────────────────
+# ── 9. .get_design_vars_flat() — survey_srs returns weights (and fpc) ────────
+
+test_that(".get_design_vars_flat() returns weights column name for survey_srs", {
+  d    <- make_srs()
+  flat <- surveycore:::.get_design_vars_flat(d)
+  expect_true(d@variables$weights %in% flat)
+})
+
+test_that(".get_design_vars_flat() includes fpc column for survey_srs with fpc", {
+  d    <- make_srs_with_fpc()
+  flat <- surveycore:::.get_design_vars_flat(d)
+  expect_true(d@variables$weights %in% flat)
+  expect_true(d@variables$fpc     %in% flat)
+})
+
+test_that(".get_design_vars_flat() excludes fpc for survey_srs without fpc", {
+  d    <- make_srs()
+  flat <- surveycore:::.get_design_vars_flat(d)
+  expect_null(d@variables$fpc)
+  expect_false("fpc" %in% flat)
+})
+
+
+# ── 10. .get_design_vars() — survey_taylor named list ────────────────────────
 
 test_that(".get_design_vars() returns a named list for survey_taylor", {
   d    <- make_taylor()
@@ -308,17 +348,37 @@ test_that(".get_design_vars() strata2/probs2 slots hold correct column names", {
 })
 
 
-# ── 13. .get_design_vars() — survey_calibrated returns empty list ─────────────
+# ── 14. .get_design_vars() — survey_calibrated returns weights entry ──────────
 
-test_that(".get_design_vars() returns an empty list for survey_calibrated", {
+test_that(".get_design_vars() returns a list with weights entry for survey_calibrated", {
   d    <- make_calibrated()
   vars <- surveycore:::.get_design_vars(d)
   expect_true(is.list(vars))
-  expect_length(vars, 0L)
+  expect_true("weights" %in% names(vars))
+  expect_identical(vars$weights, d@variables$weights)
 })
 
 
-# ── 14. .resolve_tidy_select() — NULL quosure → NULL ────────────────────────
+# ── 15. .get_design_vars() — survey_srs returns weights (and fpc when set) ───
+
+test_that(".get_design_vars() returns weights entry for survey_srs", {
+  d    <- make_srs()
+  vars <- surveycore:::.get_design_vars(d)
+  expect_true(is.list(vars))
+  expect_true("weights" %in% names(vars))
+  expect_false("fpc" %in% names(vars))
+})
+
+test_that(".get_design_vars() includes fpc entry for survey_srs with fpc", {
+  d    <- make_srs_with_fpc()
+  vars <- surveycore:::.get_design_vars(d)
+  expect_true("weights" %in% names(vars))
+  expect_true("fpc"     %in% names(vars))
+  expect_identical(vars$fpc, d@variables$fpc)
+})
+
+
+# ── 16. .resolve_tidy_select() — NULL quosure → NULL ────────────────────────
 
 test_that(".resolve_tidy_select() returns NULL for a NULL quosure", {
   df     <- data.frame(x = 1:3, y = 4:6)


### PR DESCRIPTION
## What

Both `.get_design_vars_flat()` and `.get_design_vars()` previously had no branch for `survey_calibrated` or `survey_srs`, falling through to the defensive `else` which returned `character(0L)` / `list()`. This caused callers (e.g. surveytidy's `select()` and `dplyr_reconstruct()`) to treat those design variables as unprotected and silently drop them.

## Changes

- **`R/utils.R`** — added `survey_calibrated` and `survey_srs` branches to both `.get_design_vars_flat()` and `.get_design_vars()`:
  - `survey_calibrated`: returns `weights` only (no ids/strata/fpc/repweights)
  - `survey_srs`: returns `weights` + optional `fpc`
- **`tests/testthat/test-utils.R`** — updated 2 existing tests that were asserting the old wrong behavior, added 5 new tests covering `survey_srs` with and without FPC

## Checklist

- [x] Tests written and passing (`devtools::test()`)
- [x] R CMD check: 0 errors, 0 warnings (`devtools::check()`)
- [x] Roxygen docs updated and `devtools::document()` run
- [x] PR title is a valid Conventional Commit (`feat(scope): description`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)