### PR TITLE
fix(analysis): fix get_freqs() crash when group variable has NA values

### DIFF
--- a/R/analysis-freqs.R
+++ b/R/analysis-freqs.R
@@ -198,7 +198,8 @@ get_freqs <- function(
   # (representing the single "all in-domain rows" group).
   if (length(group_vars) > 0L) {
     domain_data   <- design@data[domain_mask, group_vars, drop = FALSE]
-    group_combos  <- unique(domain_data)
+    complete_idx  <- stats::complete.cases(domain_data)
+    group_combos  <- unique(domain_data[complete_idx, , drop = FALSE])
     # Sort ascending by each group variable (leftmost first)
     ord <- do.call(
       order,
@@ -288,7 +289,9 @@ get_freqs <- function(
         combo_row   <- group_combos[ci, , drop = FALSE]
         group_match <- rep(TRUE, nrow(design@data))
         for (gv in group_vars) {
-          group_match <- group_match & (design@data[[gv]] == combo_row[[gv]])
+          gv_col <- design@data[[gv]]
+          cv     <- combo_row[[gv]]
+          group_match <- group_match & !is.na(gv_col) & (gv_col == cv)
         }
         active_mask <- domain_mask & group_match
       } else {

--- a/changelog/phase-1/fix-freqs-group-na-crash.md
+++ b/changelog/phase-1/fix-freqs-group-na-crash.md
@@ -1,0 +1,23 @@
+# fix(analysis): fix get_freqs() crash when group variable has NA values
+
+**Date**: 2026-03-02
+**Branch**: fix/freqs-group-na-crash
+**Phase**: Phase 1
+
+## Changes
+
+- Fix `get_freqs()` throwing `! missing value where TRUE/FALSE needed` when the
+  `group` variable contains `NA` values (e.g., Nationscape `cand_favorability_biden`)
+- Filter `NA` rows from `group_combos` using `complete.cases()` before building
+  group combinations, matching the pattern already used in `get_means()`,
+  `get_totals()`, `get_quantiles()`, `get_ratios()`, and `get_corr()`
+- Replace bare `==` in the group matching loop with an NA-safe guard
+  (`!is.na(gv_col) & (gv_col == cv)`), consistent with all other analysis functions
+- Add two regression tests covering the crash case and verifying that pcts sum
+  to 1 within each non-NA group
+
+## Files Modified
+
+- `R/analysis-freqs.R` — add `complete.cases()` filter when building `group_combos`;
+  use NA-safe matching in the group loop
+- `tests/testthat/test-analysis-freqs.R` — two new tests for group variable with NAs

--- a/tests/testthat/test-analysis-freqs.R
+++ b/tests/testthat/test-analysis-freqs.R
@@ -876,3 +876,43 @@ test_that("get_freqs() rejects non-integer decimals", {
     class = "surveycore_error_invalid_decimals"
   )
 })
+
+
+# ── NA in group variable ────────────────────────────────────────────────────
+
+test_that("get_freqs() silently excludes rows where group variable is NA", {
+  df <- make_survey_data(n = 300L, n_psu = 30L, n_strata = 3L, seed = 301L)
+  # Add a second categorical column with some NA values to use as the group
+  set.seed(301L)
+  df$grp2 <- sample(c("X", "Y"), nrow(df), replace = TRUE)
+  df$grp2[1:60] <- NA
+
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc,
+                 nest = TRUE)
+
+  # Must not error — this was the reported crash
+  r <- get_freqs(d, group, group = grp2)
+
+  # Only non-NA group levels appear as rows
+  expect_false(anyNA(r$grp2))
+
+  # Still a valid survey_freqs tibble
+  expect_true("survey_freqs" %in% class(r))
+  expect_true(is.numeric(r$pct))
+})
+
+test_that("get_freqs() group NA exclusion: pct sums to ~1 within each non-NA group", {
+  df <- make_survey_data(n = 300L, n_psu = 30L, n_strata = 3L, seed = 302L)
+  set.seed(302L)
+  df$grp2 <- sample(c("X", "Y"), nrow(df), replace = TRUE)
+  df$grp2[1:50] <- NA
+
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc,
+                 nest = TRUE)
+
+  r <- get_freqs(d, group, group = grp2)
+
+  # Within each group level, pct sums to 1
+  grp_sums <- as.numeric(tapply(r$pct, r$grp2, sum))
+  expect_equal(grp_sums, rep(1, length(grp_sums)), tolerance = 1e-10)
+})


### PR DESCRIPTION
## Summary

- `get_freqs()` threw `! missing value where TRUE/FALSE needed` when the `group` variable contained `NA` values (e.g., Nationscape's `cand_favorability_biden`)
- Root cause: `group_combos` included `NA` rows, and bare `==` propagated `NA` through `active_mask → denom → n_g/N_d`, crashing the `if (n_g == 0L || N_d <= 0)` guard
- Fix mirrors the pattern already used in all five other analysis functions (`get_means`, `get_totals`, `get_quantiles`, `get_ratios`, `get_corr`)

## Changes

- `R/analysis-freqs.R` — add `complete.cases()` filter when building `group_combos`; replace bare `==` with NA-safe `!is.na(gv_col) & (gv_col == cv)` in the matching loop
- `tests/testthat/test-analysis-freqs.R` — two regression tests: no error on NA group variable, and pcts sum to 1 within each surviving non-NA group level

## Test plan

- [x] `devtools::test()` — 4841 passed, 0 failures
- [x] `R CMD check` — Status: OK (0 errors, 0 warnings, 0 notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)