### PR TITLE
fix(analysis): extend get_freqs() to include NA group rows when na.rm = FALSE

### DIFF
--- a/R/analysis-freqs.R
+++ b/R/analysis-freqs.R
@@ -44,8 +44,12 @@
 #' @param min_cell_n Integer. Minimum unweighted cell count before
 #'   `surveycore_warning_small_cell` fires. Default `30L` (AAPOR guidance).
 #' @param na.rm Logical. If `TRUE` (default), `NA` values are excluded from
-#'   all proportions; `NA` does not appear as a level. If `FALSE`, `NA`
-#'   appears as its own last row and the denominator includes `NA` rows.
+#'   analysis: observations where the focal variable is `NA` are dropped from
+#'   frequency counts, and observations where any group variable is `NA` are
+#'   excluded from the output. If `FALSE`, `NA` values in the focal variable
+#'   appear as a dedicated frequency row in the output (not merely counted),
+#'   and observations where a group variable is `NA` are collected into their
+#'   own group row (appearing after all non-`NA` group rows).
 #' @param label_values Logical. If `TRUE` (default), convert raw variable
 #'   values to labels using metadata or `haven` attributes. Falls back to
 #'   raw values when no labels exist.
@@ -126,7 +130,8 @@ get_freqs <- function(
 ) {
   # ── Step 1: Validate ────────────────────────────────────────────────────────
   .check_unsupported_class(design, "get_freqs")
-  .validate_shared_args(variance, conf_level, name_style, decimals = decimals)
+  .validate_shared_args(variance, conf_level, name_style, decimals = decimals,
+                        na.rm = na.rm)
 
   # ── Step 2: Resolve variables, groups, domain ───────────────────────────────
   x_quo     <- rlang::enquo(x)
@@ -145,17 +150,29 @@ get_freqs <- function(
     for (gv in group_vars) {
       gv_vals  <- design@data[[gv]][domain_mask]
       uniq_lvls <- unique(gv_vals[!is.na(gv_vals)])
-      if (length(uniq_lvls) == 1L) {
-        lvl_str <- as.character(uniq_lvls[[1L]])
-        cli::cli_warn(
-          c(
-            "!" = paste0(
-              "Grouping variable {.field {gv}} has only one observed level ",
-              "({.val {lvl_str}}). Grouped estimates will have a single row."
-            )
-          ),
-          class = "surveycore_warning_single_level"
-        )
+      if (length(uniq_lvls) < 2L) {
+        if (length(uniq_lvls) == 0L) {
+          cli::cli_warn(
+            c(
+              "!" = paste0(
+                "Grouping variable {.field {gv}} has no non-{.code NA} ",
+                "observed levels. Grouped estimates will have a single row."
+              )
+            ),
+            class = "surveycore_warning_single_level"
+          )
+        } else {
+          lvl_str <- as.character(uniq_lvls[[1L]])
+          cli::cli_warn(
+            c(
+              "!" = paste0(
+                "Grouping variable {.field {gv}} has only one observed level ",
+                "({.val {lvl_str}}). Grouped estimates will have a single row."
+              )
+            ),
+            class = "surveycore_warning_single_level"
+          )
+        }
       }
     }
   }
@@ -197,17 +214,9 @@ get_freqs <- function(
   # If no groups, group_combos is a data.frame with 0 columns and 1 row
   # (representing the single "all in-domain rows" group).
   if (length(group_vars) > 0L) {
-    domain_data   <- design@data[domain_mask, group_vars, drop = FALSE]
-    complete_idx  <- stats::complete.cases(domain_data)
-    group_combos  <- unique(domain_data[complete_idx, , drop = FALSE])
-    # Sort ascending by each group variable (leftmost first)
-    ord <- do.call(
-      order,
-      lapply(group_vars, function(gv) group_combos[[gv]])
-    )
-    group_combos <- group_combos[ord, , drop = FALSE]
-    rownames(group_combos) <- NULL
-    n_combos <- nrow(group_combos)
+    domain_data  <- design@data[domain_mask, group_vars, drop = FALSE]
+    group_combos <- .build_group_combos(domain_data, na.rm)
+    n_combos     <- nrow(group_combos)
   } else {
     group_combos <- data.frame()
     n_combos     <- 1L
@@ -287,12 +296,8 @@ get_freqs <- function(
       if (length(group_vars) > 0L) {
         # Build mask: domain AND all group variable values match this combo
         combo_row   <- group_combos[ci, , drop = FALSE]
-        group_match <- rep(TRUE, nrow(design@data))
-        for (gv in group_vars) {
-          gv_col <- design@data[[gv]]
-          cv     <- combo_row[[gv]]
-          group_match <- group_match & !is.na(gv_col) & (gv_col == cv)
-        }
+        data_cols   <- as.list(design@data[group_vars])
+        group_match <- .match_group_combo(data_cols, combo_row)
         active_mask <- domain_mask & group_match
       } else {
         active_mask <- domain_mask

--- a/changelog/phase-1/fix-group-na-rows.md
+++ b/changelog/phase-1/fix-group-na-rows.md
@@ -1,0 +1,62 @@
+# Changelog: NA Group Rows in Analysis Functions
+
+**Feature branch series:** `fix/group-na-rows-*`
+**PRs:** #33 (helpers), #TBD (freqs), #TBD (means/totals), #TBD (corr/quantiles), #TBD (ratios)
+
+## Summary
+
+Extends the `na.rm` argument in all six analysis functions to include rows
+where a **grouping variable** is `NA` in the output when `na.rm = FALSE`.
+Previously, observations where any group variable was `NA` were silently
+dropped regardless of `na.rm`. Now:
+
+- `na.rm = TRUE` (default): NA group rows are excluded (no change to existing
+  behavior).
+- `na.rm = FALSE`: observations where a group variable is `NA` are collected
+  into their own group row in the output, appearing after all non-`NA` group
+  rows.
+
+## Changes
+
+### Shared infrastructure (PR #33)
+
+- Added `.build_group_combos(domain_data, na.rm)` to `R/analysis-helpers.R`:
+  replaces three divergent patterns (Pattern A, B, C) across six functions.
+  When `na.rm = FALSE`, includes NA-valued combinations; sorts NA combos last.
+- Added `.match_group_combo(data_cols, combo_row)` to `R/analysis-helpers.R`:
+  replaces inline `!is.na(gv_col) & (gv_col == cv)` loop. Handles NA matching
+  correctly via `is.na()`.
+- Added `make_na_group_design()`, `make_all_na_group_design()`, and
+  `get_na_group_rows()` to `tests/testthat/helper-test-data.R` for shared
+  test fixtures.
+- Added `surveycore_error_na_rm_not_logical` to `.validate_shared_args()`:
+  rejects `na.rm = NA` or any non-logical value with a clear error.
+
+### `get_freqs()` (this PR)
+
+- Replaced Pattern A (complete.cases pre-filter) with `.build_group_combos()`.
+- Replaced inline group matching loop with `.match_group_combo()`.
+- Widened single-level group warning condition from `== 1L` to `< 2L` so
+  all-NA group vars (0 non-NA levels) also trigger the warning.
+- Added `na.rm = na.rm` to `.validate_shared_args()` call so `na.rm = NA`
+  is caught before any computation.
+- Updated `@param na.rm` documentation with the extended description.
+
+### `get_means()` and `get_totals()` (PRs TBD)
+
+See changelog update in those PRs.
+
+### `get_corr()` and `get_quantiles()` (PRs TBD)
+
+See changelog update in those PRs.
+
+### `get_ratios()` (PR TBD)
+
+See changelog update in that PR.
+
+## Error/Warning Classes
+
+- **New**: `surveycore_error_na_rm_not_logical` — fires when `na.rm` is not
+  `TRUE` or `FALSE`.
+- **Widened**: `surveycore_warning_single_level` — now fires when a group
+  variable has fewer than 2 non-NA unique values (previously: exactly 1).

--- a/man/get_freqs.Rd
+++ b/man/get_freqs.Rd
@@ -62,8 +62,12 @@ places. Default \code{NULL} (no rounding).}
 \code{surveycore_warning_small_cell} fires. Default \code{30L} (AAPOR guidance).}
 
 \item{na.rm}{Logical. If \code{TRUE} (default), \code{NA} values are excluded from
-all proportions; \code{NA} does not appear as a level. If \code{FALSE}, \code{NA}
-appears as its own last row and the denominator includes \code{NA} rows.}
+analysis: observations where the focal variable is \code{NA} are dropped from
+frequency counts, and observations where any group variable is \code{NA} are
+excluded from the output. If \code{FALSE}, \code{NA} values in the focal variable
+appear as a dedicated frequency row in the output (not merely counted),
+and observations where a group variable is \code{NA} are collected into their
+own group row (appearing after all non-\code{NA} group rows).}
 
 \item{label_values}{Logical. If \code{TRUE} (default), convert raw variable
 values to labels using metadata or \code{haven} attributes. Falls back to

--- a/plans/impl-group-na-rows.md
+++ b/plans/impl-group-na-rows.md
@@ -29,7 +29,7 @@ The shared helpers (`.build_group_combos()`, `.match_group_combo()`,
 `get_na_group_rows()`) live in PR 1; PRs 2–5 will fail to compile without them.
 
 - [x] PR 1: `fix/group-na-rows-helpers` — Add shared helpers and NA-group test fixtures
-- [ ] PR 2: `fix/group-na-rows-freqs` — Extend `get_freqs()` to include NA group rows
+- [x] PR 2: `fix/group-na-rows-freqs` — Extend `get_freqs()` to include NA group rows
 - [ ] PR 3: `fix/group-na-rows-means-totals` — Extend `get_means()` and `get_totals()`
 - [ ] PR 4: `fix/group-na-rows-corr-quantiles` — Extend `get_corr()` and `get_quantiles()`
 - [ ] PR 5: `fix/group-na-rows-ratios` — Extend `get_ratios()`

--- a/tests/testthat/_snaps/analysis-freqs.md
+++ b/tests/testthat/_snaps/analysis-freqs.md
@@ -52,3 +52,12 @@
       x `decimals` must be a non-negative whole number or `NULL`.
       i Got -1.
 
+# get_freqs() rejects na.rm = NA with surveycore_error_na_rm_not_logical
+
+    Code
+      get_freqs(d, y3, group = grp, na.rm = NA)
+    Condition
+      Error in `get_freqs()`:
+      x `na.rm` must be `TRUE` or `FALSE`.
+      i Got `NA`.
+

--- a/tests/testthat/test-analysis-freqs.R
+++ b/tests/testthat/test-analysis-freqs.R
@@ -916,3 +916,294 @@ test_that("get_freqs() group NA exclusion: pct sums to ~1 within each non-NA gro
   grp_sums <- as.numeric(tapply(r$pct, r$grp2, sum))
   expect_equal(grp_sums, rep(1, length(grp_sums)), tolerance = 1e-10)
 })
+
+
+# ── NA group rows (na.rm extension) — Test Blocks 1–10 + oracle ──────────────
+
+# Block 1: default na.rm = TRUE excludes NA group rows (regression guard)
+
+test_that("get_freqs() default (na.rm = TRUE) excludes group NA rows", {
+  d <- make_na_group_design()
+  r <- get_freqs(d, y3, group = grp)
+  expect_false(anyNA(r$grp))
+})
+
+# Block 2: na.rm = FALSE includes NA group row
+
+test_that("get_freqs() includes NA group row when na.rm = FALSE", {
+  d <- make_na_group_design()
+  r <- get_freqs(d, y3, group = grp, na.rm = FALSE)
+  expect_true(any(is.na(r$grp)))
+})
+
+# Block 3: NA group row is last
+
+test_that("get_freqs() places NA group row after non-NA rows", {
+  d      <- make_na_group_design()
+  r      <- get_freqs(d, y3, group = grp, na.rm = FALSE)
+  na_idx <- which(is.na(r$grp))
+  nn_idx <- which(!is.na(r$grp))
+  expect_true(all(na_idx > max(nn_idx)))
+})
+
+# Block 4: NA group row has finite pct estimate
+
+test_that("get_freqs() NA group row has finite pct estimate", {
+  d      <- make_na_group_design()
+  r      <- get_freqs(d, y3, group = grp, na.rm = FALSE)
+  na_row <- get_na_group_rows(r, "grp")
+  expect_true(all(is.finite(na_row$pct)))
+})
+
+# Block 5a: multi-group — NA in first group var
+
+test_that("get_freqs() handles NA in first of two group vars (na.rm = FALSE)", {
+  d <- make_na_group_design()  # grp has NAs; grp2 has none
+  r <- get_freqs(d, y3, group = c(grp, grp2), na.rm = FALSE)
+  expect_true(any(is.na(r$grp) & !is.na(r$grp2)))
+})
+
+# Block 5b: multi-group — NA in second group var (inline fixture)
+
+test_that("get_freqs() handles NA in second of two group vars (na.rm = FALSE)", {
+  df <- make_survey_data(n = 200L, seed = 42L)
+  set.seed(43L)
+  df$grp  <- sample(c("A", "B", "C"), 200L, replace = TRUE)
+  df$grp2 <- sample(c("X", "Y", NA_character_), 200L, replace = TRUE)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata,
+                 fpc = fpc, nest = TRUE)
+  r <- get_freqs(d, y3, group = c(grp, grp2), na.rm = FALSE)
+  expect_true(any(!is.na(r$grp) & is.na(r$grp2)))
+})
+
+# Block 6: all-NA group var — warning fires; all output rows have NA group;
+# pct sums to 1 and matches ungrouped result
+
+test_that("get_freqs() handles group var that is entirely NA (na.rm = FALSE)", {
+  d <- make_all_na_group_design()
+  expect_warning(
+    r <- get_freqs(d, y3, group = grp, na.rm = FALSE),
+    class = "surveycore_warning_single_level"
+  )
+  expect_true(all(is.na(r$grp)))
+  expect_true(all(is.finite(r$pct)))
+  expect_equal(sum(r$pct), 1, tolerance = 1e-8)
+  ungrouped <- get_freqs(d, y3)
+  expect_equal(r$pct, ungrouped$pct, tolerance = 1e-10)
+})
+
+# Block 7a: label_values = TRUE — regular NA group row remains NA in factor
+
+test_that("get_freqs() regular NA group row is NA in factor when label_values = TRUE", {
+  df <- make_survey_data(n = 200L, seed = 42L)
+  set.seed(43L)
+  df$grp <- sample(c(1L, 2L, NA_integer_), 200L, replace = TRUE)
+  attr(df$grp, "labels") <- c("GroupA" = 1L, "GroupB" = 2L)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata,
+                 fpc = fpc, nest = TRUE)
+  r <- get_freqs(d, y3, group = grp, na.rm = FALSE, label_values = TRUE)
+
+  expect_true(is.factor(r$grp))
+  na_row <- get_na_group_rows(r, "grp")
+  expect_true(nrow(na_row) > 0L)
+  expect_true(is.na(na_row$grp[[1L]]))
+})
+
+# Block 7b: label_values = TRUE — haven-tagged NA becomes a factor level
+
+test_that("get_freqs() haven-labeled NA group rows become factor levels when label_values = TRUE", {
+  skip_if_not_installed("haven")
+  df <- make_survey_data(n = 200L, seed = 42L)
+  set.seed(43L)
+  df$grp <- sample(c(1L, 2L), 200L, replace = TRUE)
+  df$grp <- as.double(df$grp)
+  df$grp[sample(200L, 40L)] <- haven::tagged_na("r")
+  attr(df$grp, "labels") <- c(
+    "GroupA"  = 1,
+    "GroupB"  = 2,
+    "Refused" = haven::tagged_na("r")
+  )
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata,
+                 fpc = fpc, nest = TRUE)
+  r <- get_freqs(d, y3, group = grp, na.rm = FALSE, label_values = TRUE)
+
+  expect_true(is.factor(r$grp))
+  expect_true("Refused" %in% levels(r$grp))
+  refused_row <- r[!is.na(r$grp) & r$grp == "Refused", ]
+  expect_true(nrow(refused_row) > 0L)
+})
+
+# Block 8: group_by() path — NA group rows appear with na.rm = FALSE
+
+test_that("get_freqs() includes NA group row when group set via group_by() and na.rm = FALSE", {
+  skip_if_not_installed("surveytidy")
+  d <- surveytidy::group_by(make_na_group_design(), grp)
+  r <- get_freqs(d, y3, na.rm = FALSE)
+  expect_true(anyNA(r$grp))
+})
+
+# Block 8b: group_by() path — NA group rows excluded by default
+
+test_that("get_freqs() excludes NA group rows by default when group set via group_by()", {
+  skip_if_not_installed("surveytidy")
+  d <- surveytidy::group_by(make_na_group_design(), grp)
+  r <- get_freqs(d, y3)
+  expect_false(anyNA(r$grp))
+})
+
+# Block 8c: na.rm = NA is rejected (dual pattern)
+
+test_that("get_freqs() rejects na.rm = NA with surveycore_error_na_rm_not_logical", {
+  d <- make_na_group_design()
+  expect_error(
+    get_freqs(d, y3, group = grp, na.rm = NA),
+    class = "surveycore_error_na_rm_not_logical"
+  )
+  expect_snapshot(
+    error = TRUE,
+    get_freqs(d, y3, group = grp, na.rm = NA)
+  )
+})
+
+# Block 10 (get_freqs()-only): focal-variable NA × group-variable NA
+
+test_that("get_freqs() includes both focal-NA row and NA-group row when na.rm = FALSE", {
+  df <- make_survey_data(n = 200L, seed = 42L)
+  set.seed(100L)
+  df$focal  <- sample(c(0L, 1L, NA_integer_), 200L, replace = TRUE)
+  df$grp_na <- sample(c("A", "B", NA_character_), 200L, replace = TRUE)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata,
+                 fpc = fpc, nest = TRUE)
+  r <- get_freqs(d, focal, group = grp_na, na.rm = FALSE)
+
+  expect_true(any(is.na(r$grp_na)))
+  na_group_rows <- get_na_group_rows(r, "grp_na")
+  expect_true(any(is.na(na_group_rows$focal)))
+})
+
+
+# ── Oracle tests: NA group row estimate matches filtered design ────────────────
+
+test_that("get_freqs() NA group row pct matches filtered taylor design [oracle]", {
+  df <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 42L)
+  set.seed(43L)
+  df$grp <- sample(c("A", "B", NA_character_), 100L, replace = TRUE)
+  design_oracle <- as_survey(df, ids = psu, weights = wt, strata = strata,
+                              fpc = fpc, nest = TRUE)
+  na_df     <- df[is.na(df$grp), ]
+  na_design <- as_survey(na_df, ids = psu, weights = wt, strata = strata,
+                          fpc = fpc, nest = TRUE)
+  expected <- get_freqs(na_design, y3, variance = "se")
+  result   <- get_freqs(design_oracle, y3, group = grp, na.rm = FALSE,
+                        variance = "se")
+  na_row   <- get_na_group_rows(result, "grp")
+  expect_equal(na_row$pct, expected$pct, tolerance = 1e-10)
+  expect_equal(na_row$se,  expected$se,  tolerance = 1e-8)
+  expect_equal(na_row$n,   expected$n)
+})
+
+test_that("get_freqs() NA group row pct matches filtered replicate design [oracle]", {
+  df_r <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L,
+                            design = "replicate", type = "brr", seed = 42L)
+  set.seed(43L)
+  df_r$grp   <- sample(c("A", "B", NA_character_), 100L, replace = TRUE)
+  repwt_cols <- grep("^repwt_", names(df_r), value = TRUE)
+  design_rep <- as_survey_rep(df_r, weights = wt,
+                               repweights = tidyselect::all_of(repwt_cols),
+                               type = "BRR")
+  na_df_r       <- df_r[is.na(df_r$grp), ]
+  repwt_cols_na <- grep("^repwt_", names(na_df_r), value = TRUE)
+  na_design_rep <- as_survey_rep(na_df_r, weights = wt,
+                                  repweights = tidyselect::all_of(repwt_cols_na),
+                                  type = "BRR")
+  expected <- get_freqs(na_design_rep, y3, variance = "se")
+  result   <- get_freqs(design_rep, y3, group = grp, na.rm = FALSE,
+                        variance = "se")
+  na_row   <- get_na_group_rows(result, "grp")
+  expect_equal(na_row$pct, expected$pct, tolerance = 1e-10)
+  expect_equal(na_row$se,  expected$se,  tolerance = 1e-8)
+  expect_equal(na_row$n,   expected$n)
+})
+
+test_that("get_freqs() NA group row pct matches filtered twophase design [oracle]", {
+  df_p <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L,
+                            design = "twophase", seed = 42L)
+  set.seed(43L)
+  df_p$grp       <- sample(c("A", "B", NA_character_), 100L, replace = TRUE)
+  phase1         <- as_survey(df_p, ids = psu, weights = wt, strata = strata,
+                               fpc = fpc, nest = TRUE)
+  design_twophase <- as_survey_twophase(phase1, subset = subset,
+                                        method = "approx")
+  na_df_p            <- df_p[is.na(df_p$grp), ]
+  na_phase1          <- as_survey(na_df_p, ids = psu, weights = wt,
+                                   strata = strata, fpc = fpc, nest = TRUE)
+  na_design_twophase <- as_survey_twophase(na_phase1, subset = subset,
+                                            method = "approx")
+  expected <- suppressWarnings(get_freqs(na_design_twophase, y3, variance = "se"))
+  result   <- suppressWarnings(
+    get_freqs(design_twophase, y3, group = grp, na.rm = FALSE, variance = "se")
+  )
+  na_row <- get_na_group_rows(result, "grp")
+  expect_equal(na_row$pct, expected$pct, tolerance = 1e-10)
+  # SE legitimately differs: two-phase variance correction depends on total
+  # sample structure; domain estimation (full design) != pre-filtered oracle.
+  expect_true(all(is.finite(na_row$se)))
+  expect_equal(na_row$n,   expected$n)
+})
+
+test_that("get_freqs() NA group row pct matches filtered calibrated design [oracle]", {
+  df_c <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 42L)
+  set.seed(43L)
+  df_c$grp   <- sample(c("A", "B", NA_character_), 100L, replace = TRUE)
+  design_cal <- as_survey_calibrated(df_c, weights = wt)
+  na_df_c       <- df_c[is.na(df_c$grp), ]
+  na_design_cal <- as_survey_calibrated(na_df_c, weights = wt)
+  expected <- get_freqs(na_design_cal, y3, variance = "se")
+  result   <- get_freqs(design_cal, y3, group = grp, na.rm = FALSE,
+                        variance = "se")
+  na_row   <- get_na_group_rows(result, "grp")
+  expect_equal(na_row$pct, expected$pct, tolerance = 1e-10)
+  # SE legitimately differs: calibrated variance depends on total sample size;
+  # domain estimation (full design, n=100) != pre-filtered oracle (n=~30).
+  expect_true(all(is.finite(na_row$se)))
+  expect_equal(na_row$n,   expected$n)
+})
+
+test_that("get_freqs() NA group row pct matches filtered srs design [oracle]", {
+  df_s <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 42L)
+  set.seed(43L)
+  df_s$grp   <- sample(c("A", "B", NA_character_), 100L, replace = TRUE)
+  design_srs <- as_survey_srs(df_s, weights = wt)
+  na_df_s       <- df_s[is.na(df_s$grp), ]
+  na_design_srs <- as_survey_srs(na_df_s, weights = wt)
+  expected <- get_freqs(na_design_srs, y3, variance = "se")
+  result   <- get_freqs(design_srs, y3, group = grp, na.rm = FALSE,
+                        variance = "se")
+  na_row   <- get_na_group_rows(result, "grp")
+  expect_equal(na_row$pct, expected$pct, tolerance = 1e-10)
+  expect_equal(na_row$se,  expected$se,  tolerance = 1e-8)
+  expect_equal(na_row$n,   expected$n)
+})
+
+test_that("get_freqs() multi-group NA row estimate matches filtered taylor design [oracle]", {
+  df <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 42L)
+  set.seed(43L)
+  df$grp  <- sample(c("A", "B", NA_character_), 100L, replace = TRUE)
+  df$grp2 <- sample(c("X", "Y"), 100L, replace = TRUE)
+  design_multi <- as_survey(df, ids = psu, weights = wt, strata = strata,
+                             fpc = fpc, nest = TRUE)
+  result <- suppressWarnings(
+    get_freqs(design_multi, y3, group = c(grp, grp2),
+              na.rm = FALSE, variance = "se")
+  )
+  oracle_df     <- df[is.na(df$grp) & df$grp2 == "X", ]
+  oracle_design <- as_survey(oracle_df, ids = psu, weights = wt,
+                              strata = strata, fpc = fpc, nest = TRUE)
+  expected  <- suppressWarnings(get_freqs(oracle_design, y3, variance = "se"))
+  na_x_rows <- result[is.na(result$grp) & result$grp2 == "X", ]
+  expect_equal(na_x_rows$pct, expected$pct, tolerance = 1e-10)
+  # SE legitimately differs: multi-group oracle cells are small (~5 rows);
+  # domain estimation uses full cluster/strata structure, oracle uses subset.
+  expect_true(all(is.finite(na_x_rows$se)))
+  expect_equal(na_x_rows$n,   expected$n)
+})


### PR DESCRIPTION
## Summary

Extends `get_freqs()` so that observations where a group variable is `NA`
appear in the output as a dedicated group row when `na.rm = FALSE`.
Previously, those observations were silently dropped regardless of `na.rm`.

- `na.rm = TRUE` (default): NA group rows are excluded — no change to existing behavior
- `na.rm = FALSE`: observations where a group variable is `NA` are collected
  into their own group row, appearing after all non-`NA` group rows

## Changes

**Core logic (`R/analysis-freqs.R`):**
- Replace `complete.cases` pre-filter with `.build_group_combos()` (shared helper from #33) so NA-valued group combinations are included when `na.rm = FALSE`
- Replace inline `!is.na(gv_col) & (gv_col == cv)` loop with `.match_group_combo()` for correct NA-equality semantics
- Widen single-level group warning from `== 1L` to `< 2L` so all-NA group vars (0 non-NA levels) also trigger `surveycore_warning_single_level`
- Pass `na.rm` to `.validate_shared_args()` so `na.rm = NA` is caught before any computation

**Documentation (`man/get_freqs.Rd`):**
- Updated `@param na.rm` with extended description of group-NA behaviour

**Tests (`tests/testthat/test-analysis-freqs.R`):**
- 18 new test blocks covering: default exclusion (regression guard), explicit inclusion, NA-row ordering, multi-group NA, all-NA group var, `label_values` paths (regular NA + haven-tagged NA), `group_by()` path, `na.rm = NA` error guard (dual pattern), focal-variable NA × group-NA intersection, and oracle tests comparing NA group row estimates against filtered designs for all 5 design types (taylor, replicate, twophase, calibrated, srs)

## Test plan

- [x] `devtools::test()` — 0 FAIL, 4972 PASS
- [x] `devtools::check()` — 0 errors, 0 warnings, 2 pre-existing notes

## Related

Part of the `fix/group-na-rows-*` series. Depends on #33 (shared helpers).
Next: `fix/group-na-rows-means-totals` — extends `get_means()` and `get_totals()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)