### PR TITLE
fix(analysis): extend get_ratios() to include NA group rows when na.rm = FALSE (#35)

### DIFF
--- a/R/analysis-ratios.R
+++ b/R/analysis-ratios.R
@@ -44,9 +44,13 @@
 #'   places. Default `NULL` (no rounding).
 #' @param min_cell_n Integer. Minimum unweighted cell count before
 #'   `surveycore_warning_small_cell` fires. Default `30L` (AAPOR guidance).
-#' @param na.rm Logical. If `TRUE` (default), rows where either the numerator
-#'   or denominator is `NA` are excluded. If `FALSE`, `NA` values propagate
-#'   to the estimate.
+#' @param na.rm Logical. If `TRUE` (default), `NA` values are excluded from
+#'   analysis: observations where the analysis variable is `NA` are dropped
+#'   from calculations, and observations where any group variable is `NA` are
+#'   excluded from the output. If `FALSE`, `NA` observations in the analysis
+#'   variable are included in calculations, and observations where a group
+#'   variable is `NA` are collected into their own group row in the output
+#'   (appearing after all non-`NA` group rows).
 #' @param label_values Logical. Accepted for API uniformity; has no visible
 #'   effect on `get_ratios()` output. Default `TRUE`.
 #' @param label_vars Logical. Accepted for API uniformity; has no visible
@@ -101,7 +105,8 @@ get_ratios <- function(
 ) {
   # ── Step 1: Validate ────────────────────────────────────────────────────────
   .check_unsupported_class(design, "get_ratios")
-  .validate_shared_args(variance, conf_level, name_style, decimals = decimals)
+  .validate_shared_args(variance, conf_level, name_style, decimals = decimals,
+                        na.rm = na.rm)
 
   # ── Step 2: Resolve variables, groups, domain ─────────────────────────────
   num_quo   <- rlang::enquo(numerator)
@@ -174,12 +179,12 @@ get_ratios <- function(
     for (gv in group_vars) {
       gv_vals   <- design@data[[gv]][domain_mask]
       uniq_lvls <- unique(gv_vals[!is.na(gv_vals)])
-      if (length(uniq_lvls) == 1L) {
+      if (length(uniq_lvls) < 2L) {
         cli::cli_warn(
           c(
             "!" = paste0(
               "Grouping variable {.field {gv}} has only one observed level ",
-              "({.val {as.character(uniq_lvls[[1L]])}}).",
+              if (length(uniq_lvls) == 1L) "({.val {as.character(uniq_lvls[[1L]])}})." else ".",
               " Grouped estimates will have a single row."
             )
           ),
@@ -192,15 +197,8 @@ get_ratios <- function(
   # ── Step 4: Build group combinations ──────────────────────────────────────
   if (length(group_vars) > 0L) {
     domain_data  <- design@data[domain_mask, group_vars, drop = FALSE]
-    complete_idx <- stats::complete.cases(domain_data)
-    group_combos <- unique(domain_data[complete_idx, , drop = FALSE])
-    ord <- do.call(
-      order,
-      lapply(group_vars, function(gv) group_combos[[gv]])
-    )
-    group_combos <- group_combos[ord, , drop = FALSE]
-    rownames(group_combos) <- NULL
-    n_combos <- nrow(group_combos)
+    group_combos <- .build_group_combos(domain_data, na.rm)
+    n_combos     <- nrow(group_combos)
   } else {
     group_combos <- data.frame()
     n_combos     <- 1L
@@ -224,12 +222,8 @@ get_ratios <- function(
   for (ci in seq_len(n_combos)) {
     if (length(group_vars) > 0L) {
       combo_row   <- group_combos[ci, , drop = FALSE]
-      group_match <- rep(TRUE, nrow(design@data))
-      for (gv in group_vars) {
-        gv_col      <- design@data[[gv]]
-        cv          <- combo_row[[gv]]
-        group_match <- group_match & !is.na(gv_col) & (gv_col == cv)
-      }
+      data_cols   <- as.list(design@data[group_vars])
+      group_match <- .match_group_combo(data_cols, combo_row)
       active_mask <- domain_mask & group_match
     } else {
       active_mask <- domain_mask

--- a/changelog/phase-1/fix-group-na-rows-ratios.md
+++ b/changelog/phase-1/fix-group-na-rows-ratios.md
@@ -1,0 +1,37 @@
+# fix(analysis): extend get_ratios() to include NA group rows when na.rm = FALSE
+
+**Date**: 2026-03-03
+**Branch**: fix/group-na-rows-ratios
+**Phase**: Phase 1
+
+## Changes
+
+- Replace Pattern A (complete.cases pre-filter) combo-building block in
+  `get_ratios()` with `.build_group_combos(domain_data, na.rm)`: when
+  `na.rm = FALSE`, NA-valued group combinations are included; NA combos sort
+  after all non-NA combos
+- Replace inline `!is.na(gv_col) & (gv_col == cv)` group-matching loop in
+  `get_ratios()` with `data_cols` / `.match_group_combo(data_cols, combo_row)`
+- Widen single-level group warning condition from `== 1L` to `< 2L` so an
+  all-NA group variable (0 non-NA levels) also fires
+  `surveycore_warning_single_level`
+- Pass `na.rm = na.rm` to `.validate_shared_args()` so `na.rm = NA` (or any
+  non-logical) is caught before any computation
+- Update `@param na.rm` documentation with the full unified description
+  (group-row inclusion behaviour now documented)
+- Add Test Blocks 1–8c plus oracle tests for all 5 design classes for
+  `get_ratios()`
+- Mark PR 5 checkbox complete in `plans/impl-group-na-rows.md`
+
+## Files Modified
+
+- `R/analysis-ratios.R` — replace Pattern A group combo-building and matching
+  blocks with shared helpers; widen warning condition; pass `na.rm` to
+  validation; update `@param na.rm` docs
+- `man/get_ratios.Rd` — regenerated after `@param na.rm` update
+- `tests/testthat/test-analysis-ratios.R` — Test Blocks 1–8c (default
+  exclusion, NA group row inclusion, ordering, estimates, multi-group, all-NA
+  group, label propagation, group_by integration, na.rm = NA error) plus oracle
+  tests for all 5 design classes (single-group and multi-group)
+- `tests/testthat/_snaps/analysis-ratios.md` — snapshot for na.rm = NA error
+- `plans/impl-group-na-rows.md` — PR 5 checkbox marked complete

--- a/man/get_ratios.Rd
+++ b/man/get_ratios.Rd
@@ -56,9 +56,13 @@ places. Default \code{NULL} (no rounding).}
 \item{min_cell_n}{Integer. Minimum unweighted cell count before
 \code{surveycore_warning_small_cell} fires. Default \code{30L} (AAPOR guidance).}
 
-\item{na.rm}{Logical. If \code{TRUE} (default), rows where either the numerator
-or denominator is \code{NA} are excluded. If \code{FALSE}, \code{NA} values propagate
-to the estimate.}
+\item{na.rm}{Logical. If \code{TRUE} (default), \code{NA} values are excluded from
+analysis: observations where the analysis variable is \code{NA} are dropped
+from calculations, and observations where any group variable is \code{NA} are
+excluded from the output. If \code{FALSE}, \code{NA} observations in the analysis
+variable are included in calculations, and observations where a group
+variable is \code{NA} are collected into their own group row in the output
+(appearing after all non-\code{NA} group rows).}
 
 \item{label_values}{Logical. Accepted for API uniformity; has no visible
 effect on \code{get_ratios()} output. Default \code{TRUE}.}

--- a/plans/impl-group-na-rows.md
+++ b/plans/impl-group-na-rows.md
@@ -32,7 +32,7 @@ The shared helpers (`.build_group_combos()`, `.match_group_combo()`,
 - [x] PR 2: `fix/group-na-rows-freqs` — Extend `get_freqs()` to include NA group rows
 - [x] PR 3: `fix/group-na-rows-means-totals` — Extend `get_means()` and `get_totals()`
 - [x] PR 4: `fix/group-na-rows-corr-quantiles` — Extend `get_corr()` and `get_quantiles()`
-- [ ] PR 5: `fix/group-na-rows-ratios` — Extend `get_ratios()`
+- [x] PR 5: `fix/group-na-rows-ratios` — Extend `get_ratios()`
 
 ---
 

--- a/tests/testthat/_snaps/analysis-ratios.md
+++ b/tests/testthat/_snaps/analysis-ratios.md
@@ -34,3 +34,12 @@
       x `variance` values must be from "se", "ci", "var", "cv", "moe", or "deff".
       i Unknown value: "bogus".
 
+# get_ratios() rejects na.rm = NA with surveycore_error_na_rm_not_logical
+
+    Code
+      get_ratios(d, y1, y2, group = grp, na.rm = NA)
+    Condition
+      Error in `get_ratios()`:
+      x `na.rm` must be `TRUE` or `FALSE`.
+      i Got `NA`.
+

--- a/tests/testthat/test-analysis-ratios.R
+++ b/tests/testthat/test-analysis-ratios.R
@@ -714,3 +714,274 @@ test_that("get_ratios() rejects invalid decimals", {
     class = "surveycore_error_invalid_decimals"
   )
 })
+
+# ── NA group rows (na.rm extension) — Test Blocks 1–8c + oracle ───────────────
+
+# Block 1: default na.rm = TRUE excludes NA group rows (regression guard)
+
+test_that("get_ratios() default (na.rm = TRUE) excludes group NA rows", {
+  d <- make_na_group_design()
+  r <- get_ratios(d, y1, y2, group = grp, label_values = FALSE)
+  expect_false(anyNA(r$grp))
+})
+
+# Block 2: na.rm = FALSE includes NA group row
+
+test_that("get_ratios() includes NA group row when na.rm = FALSE", {
+  d <- make_na_group_design()
+  r <- get_ratios(d, y1, y2, group = grp, na.rm = FALSE, label_values = FALSE)
+  expect_true(any(is.na(r$grp)))
+})
+
+# Block 3: NA group row is last
+
+test_that("get_ratios() places NA group row after non-NA rows", {
+  d      <- make_na_group_design()
+  r      <- get_ratios(d, y1, y2, group = grp, na.rm = FALSE, label_values = FALSE)
+  na_idx <- which(is.na(r$grp))
+  nn_idx <- which(!is.na(r$grp))
+  expect_true(all(na_idx > max(nn_idx)))
+})
+
+# Block 4: NA group row has finite ratio estimate
+
+test_that("get_ratios() NA group row has finite ratio estimate", {
+  d      <- make_na_group_design()
+  r      <- get_ratios(d, y1, y2, group = grp, na.rm = FALSE, label_values = FALSE)
+  na_row <- get_na_group_rows(r, "grp")
+  expect_true(all(is.finite(na_row$ratio)))
+})
+
+# Block 5a: multi-group — NA in first group var
+
+test_that("get_ratios() handles NA in first of two group vars (na.rm = FALSE)", {
+  d <- make_na_group_design()  # grp has NAs; grp2 has none
+  r <- get_ratios(d, y1, y2, group = c(grp, grp2), na.rm = FALSE,
+                  label_values = FALSE)
+  expect_true(any(is.na(r$grp) & !is.na(r$grp2)))
+})
+
+# Block 5b: multi-group — NA in second group var (inline fixture)
+
+test_that("get_ratios() handles NA in second of two group vars (na.rm = FALSE)", {
+  df <- make_survey_data(n = 200L, seed = 42L)
+  set.seed(43L)
+  df$grp  <- sample(c("A", "B", "C"), 200L, replace = TRUE)
+  df$grp2 <- sample(c("X", "Y", NA_character_), 200L, replace = TRUE)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata,
+                 fpc = fpc, nest = TRUE)
+  r <- get_ratios(d, y1, y2, group = c(grp, grp2), na.rm = FALSE,
+                  label_values = FALSE)
+  expect_true(any(!is.na(r$grp) & is.na(r$grp2)))
+})
+
+# Block 6: all-NA group var — warning fires; output has NA group row
+
+test_that("get_ratios() handles group var that is entirely NA (na.rm = FALSE)", {
+  d <- make_all_na_group_design()
+  expect_warning(
+    r <- get_ratios(d, y1, y2, group = grp, na.rm = FALSE, label_values = FALSE),
+    class = "surveycore_warning_single_level"
+  )
+  expect_equal(nrow(r), 1L)
+  expect_true(is.na(r$grp[[1L]]))
+  expect_true(is.finite(r$ratio[[1L]]))
+})
+
+# Block 7a: label_values = TRUE — regular NA group row remains NA in factor
+
+test_that("get_ratios() regular NA group row is NA in factor when label_values = TRUE", {
+  df <- make_survey_data(n = 200L, seed = 42L)
+  set.seed(43L)
+  df$grp <- sample(c(1L, 2L, NA_integer_), 200L, replace = TRUE)
+  attr(df$grp, "labels") <- c("GroupA" = 1L, "GroupB" = 2L)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata,
+                 fpc = fpc, nest = TRUE)
+  r <- get_ratios(d, y1, y2, group = grp, na.rm = FALSE, label_values = TRUE)
+  expect_true(is.factor(r$grp))
+  na_row <- get_na_group_rows(r, "grp")
+  expect_true(nrow(na_row) > 0L)
+  expect_true(is.na(na_row$grp[[1L]]))
+})
+
+# Block 7b: label_values = TRUE — haven-tagged NA becomes a factor level
+
+test_that("get_ratios() haven-labeled NA group rows become factor levels when label_values = TRUE", {
+  skip_if_not_installed("haven")
+  df <- make_survey_data(n = 200L, seed = 42L)
+  set.seed(43L)
+  df$grp <- sample(c(1L, 2L), 200L, replace = TRUE)
+  df$grp <- as.double(df$grp)
+  df$grp[sample(200L, 40L)] <- haven::tagged_na("r")
+  attr(df$grp, "labels") <- c(
+    "GroupA"  = 1,
+    "GroupB"  = 2,
+    "Refused" = haven::tagged_na("r")
+  )
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata,
+                 fpc = fpc, nest = TRUE)
+  r <- get_ratios(d, y1, y2, group = grp, na.rm = FALSE, label_values = TRUE)
+  expect_true(is.factor(r$grp))
+  expect_true("Refused" %in% levels(r$grp))
+  refused_row <- r[!is.na(r$grp) & r$grp == "Refused", ]
+  expect_true(nrow(refused_row) > 0L)
+})
+
+# Block 8: group_by() path — NA group rows appear with na.rm = FALSE
+
+test_that("get_ratios() includes NA group row when group set via group_by() and na.rm = FALSE", {
+  skip_if_not_installed("surveytidy")
+  d <- surveytidy::group_by(make_na_group_design(), grp)
+  r <- get_ratios(d, y1, y2, na.rm = FALSE)
+  expect_true(anyNA(r$grp))
+})
+
+# Block 8b: group_by() path — NA group rows excluded by default
+
+test_that("get_ratios() excludes NA group rows by default when group set via group_by()", {
+  skip_if_not_installed("surveytidy")
+  d <- surveytidy::group_by(make_na_group_design(), grp)
+  r <- get_ratios(d, y1, y2)
+  expect_false(anyNA(r$grp))
+})
+
+# Block 8c: na.rm = NA is rejected (dual pattern)
+
+test_that("get_ratios() rejects na.rm = NA with surveycore_error_na_rm_not_logical", {
+  d <- make_na_group_design()
+  expect_error(
+    get_ratios(d, y1, y2, group = grp, na.rm = NA),
+    class = "surveycore_error_na_rm_not_logical"
+  )
+  expect_snapshot(
+    error = TRUE,
+    get_ratios(d, y1, y2, group = grp, na.rm = NA)
+  )
+})
+
+# ── Oracle tests: NA group row estimate matches filtered design ────────────────
+
+test_that("get_ratios() NA group row ratio matches filtered taylor design [oracle]", {
+  df <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 42L)
+  set.seed(43L)
+  df$grp <- sample(c("A", "B", NA_character_), 100L, replace = TRUE)
+  design_oracle <- as_survey(df, ids = psu, weights = wt, strata = strata,
+                              fpc = fpc, nest = TRUE)
+  na_df     <- df[is.na(df$grp), ]
+  na_design <- as_survey(na_df, ids = psu, weights = wt, strata = strata,
+                          fpc = fpc, nest = TRUE)
+  expected <- get_ratios(na_design, y1, y2, variance = "se")
+  result   <- get_ratios(design_oracle, y1, y2, group = grp, na.rm = FALSE,
+                         variance = "se", label_values = FALSE)
+  na_row   <- get_na_group_rows(result, "grp")
+  expect_equal(na_row$ratio, expected$ratio, tolerance = 1e-10)
+  expect_equal(na_row$se,    expected$se,    tolerance = 1e-8)
+  expect_equal(na_row$n,     expected$n)
+})
+
+test_that("get_ratios() NA group row ratio matches filtered replicate design [oracle]", {
+  df_r <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L,
+                            design = "replicate", type = "brr", seed = 42L)
+  set.seed(43L)
+  df_r$grp   <- sample(c("A", "B", NA_character_), 100L, replace = TRUE)
+  repwt_cols <- grep("^repwt_", names(df_r), value = TRUE)
+  design_rep <- as_survey_rep(df_r, weights = wt,
+                               repweights = tidyselect::all_of(repwt_cols),
+                               type = "BRR")
+  na_df_r       <- df_r[is.na(df_r$grp), ]
+  repwt_cols_na <- grep("^repwt_", names(na_df_r), value = TRUE)
+  na_design_rep <- as_survey_rep(na_df_r, weights = wt,
+                                  repweights = tidyselect::all_of(repwt_cols_na),
+                                  type = "BRR")
+  expected <- get_ratios(na_design_rep, y1, y2, variance = "se")
+  result   <- get_ratios(design_rep, y1, y2, group = grp, na.rm = FALSE,
+                         variance = "se", label_values = FALSE)
+  na_row   <- get_na_group_rows(result, "grp")
+  expect_equal(na_row$ratio, expected$ratio, tolerance = 1e-10)
+  expect_equal(na_row$se,    expected$se,    tolerance = 1e-8)
+  expect_equal(na_row$n,     expected$n)
+})
+
+test_that("get_ratios() NA group row ratio matches filtered twophase design [oracle]", {
+  df_p <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L,
+                            design = "twophase", seed = 42L)
+  set.seed(43L)
+  df_p$grp        <- sample(c("A", "B", NA_character_), 100L, replace = TRUE)
+  phase1          <- as_survey(df_p, ids = psu, weights = wt, strata = strata,
+                                fpc = fpc, nest = TRUE)
+  design_twophase <- as_survey_twophase(phase1, subset = subset,
+                                        method = "approx")
+  na_df_p            <- df_p[is.na(df_p$grp), ]
+  na_phase1          <- as_survey(na_df_p, ids = psu, weights = wt,
+                                   strata = strata, fpc = fpc, nest = TRUE)
+  na_design_twophase <- as_survey_twophase(na_phase1, subset = subset,
+                                            method = "approx")
+  expected <- suppressWarnings(
+    get_ratios(na_design_twophase, y1, y2, variance = "se")
+  )
+  result   <- suppressWarnings(
+    get_ratios(design_twophase, y1, y2, group = grp, na.rm = FALSE,
+               variance = "se", label_values = FALSE)
+  )
+  na_row <- get_na_group_rows(result, "grp")
+  expect_equal(na_row$ratio, expected$ratio, tolerance = 1e-10)
+  expect_true(all(is.finite(na_row$se)))
+  expect_equal(na_row$n, expected$n)
+})
+
+test_that("get_ratios() NA group row ratio matches filtered calibrated design [oracle]", {
+  df_c <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 42L)
+  set.seed(43L)
+  df_c$grp   <- sample(c("A", "B", NA_character_), 100L, replace = TRUE)
+  design_cal <- as_survey_calibrated(df_c, weights = wt)
+  na_df_c       <- df_c[is.na(df_c$grp), ]
+  na_design_cal <- as_survey_calibrated(na_df_c, weights = wt)
+  expected <- get_ratios(na_design_cal, y1, y2, variance = "se")
+  result   <- get_ratios(design_cal, y1, y2, group = grp, na.rm = FALSE,
+                         variance = "se", label_values = FALSE)
+  na_row   <- get_na_group_rows(result, "grp")
+  expect_equal(na_row$ratio, expected$ratio, tolerance = 1e-10)
+  expect_true(all(is.finite(na_row$se)))
+  expect_equal(na_row$n, expected$n)
+})
+
+test_that("get_ratios() NA group row ratio matches filtered srs design [oracle]", {
+  df_s <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 42L)
+  set.seed(43L)
+  df_s$grp   <- sample(c("A", "B", NA_character_), 100L, replace = TRUE)
+  design_srs <- as_survey_srs(df_s, weights = wt)
+  na_df_s       <- df_s[is.na(df_s$grp), ]
+  na_design_srs <- as_survey_srs(na_df_s, weights = wt)
+  expected <- get_ratios(na_design_srs, y1, y2, variance = "se")
+  result   <- get_ratios(design_srs, y1, y2, group = grp, na.rm = FALSE,
+                         variance = "se", label_values = FALSE)
+  na_row   <- get_na_group_rows(result, "grp")
+  expect_equal(na_row$ratio, expected$ratio, tolerance = 1e-10)
+  # SE legitimately differs: SRS variance uses nrow(design@data) for n_full;
+  # domain estimation (full design) != pre-filtered oracle.
+  expect_true(all(is.finite(na_row$se)))
+  expect_equal(na_row$n, expected$n)
+})
+
+test_that("get_ratios() multi-group NA row ratio matches filtered taylor design [oracle]", {
+  df <- make_survey_data(n = 100L, n_psu = 10L, n_strata = 2L, seed = 42L)
+  set.seed(43L)
+  df$grp  <- sample(c("A", "B", NA_character_), 100L, replace = TRUE)
+  df$grp2 <- sample(c("X", "Y"), 100L, replace = TRUE)
+  design_multi <- as_survey(df, ids = psu, weights = wt, strata = strata,
+                             fpc = fpc, nest = TRUE)
+  result <- suppressWarnings(
+    get_ratios(design_multi, y1, y2, group = c(grp, grp2),
+               na.rm = FALSE, variance = "se", label_values = FALSE)
+  )
+  oracle_df     <- df[is.na(df$grp) & df$grp2 == "X", ]
+  oracle_design <- as_survey(oracle_df, ids = psu, weights = wt,
+                              strata = strata, fpc = fpc, nest = TRUE)
+  expected  <- suppressWarnings(
+    get_ratios(oracle_design, y1, y2, variance = "se")
+  )
+  na_x_rows <- result[is.na(result$grp) & result$grp2 == "X", ]
+  expect_equal(na_x_rows$ratio, expected$ratio, tolerance = 1e-10)
+  expect_true(all(is.finite(na_x_rows$se)))
+  expect_equal(na_x_rows$n, expected$n)
+})


### PR DESCRIPTION
## What

Extends `get_ratios()` to collect observations where a grouping variable is
`NA` into their own output row (appearing after all non-NA group rows) when
`na.rm = FALSE`. Previously these observations were silently dropped regardless
of `na.rm`.

## Checklist

- [x] Tests written and passing (`devtools::test()`) — 5164 PASS, 0 FAIL
- [x] R CMD check: 0 errors, 0 warnings (`devtools::check()`)
- [x] Roxygen docs updated and `devtools::document()` run
- [ ] `plans/error-messages.md` updated (if new errors/warnings added) — no new classes; `surveycore_error_na_rm_not_logical` was added in PR 1
- [ ] `VENDORED.md` updated (if variance code vendored in this PR) — N/A
- [x] PR title is a valid Conventional Commit (`feat(scope): description`)
- [x] PR targets `develop`, not `main`