### PR TITLE
feat(methods): add names() S7 method for IDE column name autocomplete

### DIFF
--- a/R/methods-compat.R
+++ b/R/methods-compat.R
@@ -1,0 +1,24 @@
+# R/methods-compat.R
+#
+# S7 methods that enable IDE compatibility features.
+#
+# These methods make survey design objects behave like data frames for the
+# purposes of column name autocomplete in RStudio and Positron. When a
+# survey object is the left-hand side of a pipe, IDEs call names() to
+# discover column names and offer them as completions in tidy-select
+# arguments of analysis functions like get_means(), get_freqs(), etc.
+#
+# Class defined in R/core-classes.R
+
+
+# names() for survey design objects
+#
+# Returns the column names of the underlying data frame, enabling IDE
+# column name completion in analysis functions. IDEs inspect the first
+# argument of a pipe chain via names() to build the completion list for
+# tidy-select arguments in downstream calls like get_means() or get_freqs().
+#
+# @param x A survey design object.
+# @return A character vector of column names from x@data.
+# Class defined in R/core-classes.R
+S7::method(names, survey_base) <- function(x) names(x@data)

--- a/changelog/phase-1/feature-survey-names-completion.md
+++ b/changelog/phase-1/feature-survey-names-completion.md
@@ -1,0 +1,19 @@
+# feat(methods): add names() method for survey objects to enable IDE autocomplete
+
+**Date**: 2026-03-03
+**Branch**: feature/survey-names-completion
+**Phase**: Phase 1
+
+## Changes
+
+- Add `S7::method(names, survey_base)` that delegates to `names(x@data)`, enabling
+  column name autocomplete in RStudio and Positron when a survey design object is
+  the left-hand side of a pipe (e.g., `design |> get_means(`)
+- Add tests covering `names()` for all five design types: `survey_taylor`,
+  `survey_replicate`, `survey_twophase`, `survey_srs`, and consistency with
+  `survey_data()`
+
+## Files Modified
+
+- `R/methods-compat.R` — new file with `S7::method(names, survey_base)` for IDE compatibility
+- `tests/testthat/test-methods-compat.R` — 5 tests covering all design types

--- a/tests/testthat/test-methods-compat.R
+++ b/tests/testthat/test-methods-compat.R
@@ -1,0 +1,52 @@
+# tests/testthat/test-methods-compat.R
+#
+# Tests for IDE-compatibility methods on survey design objects.
+# Source: R/methods-compat.R
+#
+# Test structure:
+#   1. names() — survey_taylor returns @data column names
+#   2. names() — survey_replicate returns @data column names
+#   3. names() — survey_twophase returns @data column names
+#   4. names() — survey_srs returns @data column names
+#   5. names() — consistent with names(survey_data(design))
+
+
+test_that("names() returns @data column names for survey_taylor", {
+  df <- make_survey_data(n = 100, seed = 1)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  expect_identical(names(d), names(df))
+})
+
+test_that("names() returns @data column names for survey_replicate", {
+  df <- make_survey_data(n = 100, design = "replicate", seed = 2)
+  d  <- as_survey_rep(
+    df,
+    weights    = wt,
+    repweights = starts_with("repwt_"),
+    type       = "BRR"
+  )
+  expect_identical(names(d), names(df))
+})
+
+test_that("names() returns @data column names for survey_twophase", {
+  df     <- make_survey_data(n = 200, design = "twophase", seed = 3)
+  phase1 <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  d      <- as_survey_twophase(
+    phase1,
+    probs2  = phase2_prob,
+    subset  = subset
+  )
+  expect_identical(names(d), names(df))
+})
+
+test_that("names() returns @data column names for survey_srs", {
+  df <- data.frame(y = 1:10, grp = letters[1:10], w = rep(1, 10))
+  d  <- as_survey_srs(df, weights = w)
+  expect_identical(names(d), names(df))
+})
+
+test_that("names() is consistent with names(survey_data(design))", {
+  df <- make_survey_data(n = 100, seed = 4)
+  d  <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  expect_identical(names(d), names(survey_data(d)))
+})


### PR DESCRIPTION
## Summary

- Registers `S7::method(names, survey_base)` delegating to `names(x@data)`, so IDEs can discover column names when a survey design object enters a pipe
- Enables column name completions in RStudio and Positron for all analysis functions (`get_means()`, `get_freqs()`, etc.) when used as `design |> fn(`
- Covers all five design classes via `survey_base` inheritance: `survey_taylor`, `survey_replicate`, `survey_twophase`, `survey_srs`, `survey_calibrated`

## Test plan

- [x] `names()` returns `names(@data)` for `survey_taylor`
- [x] `names()` returns `names(@data)` for `survey_replicate`
- [x] `names()` returns `names(@data)` for `survey_twophase`
- [x] `names()` returns `names(@data)` for `survey_srs`
- [x] `names()` is consistent with `names(survey_data(design))`
- [x] `devtools::check()` — 0 errors, 0 warnings (3 pre-existing notes)
- [x] Full test suite — 5169 pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)