### PR TITLE
feat(print): add domain info line to all print methods

### DIFF
--- a/R/methods-print.R
+++ b/R/methods-print.R
@@ -66,6 +66,28 @@
   ))
 }
 
+# Print a domain membership line when SURVEYCORE_DOMAIN_COL is present in @data.
+# For survey_twophase, uses Phase 2 row counts to match what analysis computes.
+# Does nothing when the column is absent (no filter applied via surveytidy).
+# @param x Any survey_base subclass.
+# @return invisible(NULL)
+# @noRd
+.print_domain_info <- function(x) {
+  if (!SURVEYCORE_DOMAIN_COL %in% names(x@data)) return(invisible(NULL))
+
+  if (S7::S7_inherits(x, survey_twophase)) {
+    ph2_mask <- x@data[[x@variables$subset]]
+    n_domain <- sum(x@data[[SURVEYCORE_DOMAIN_COL]][ph2_mask], na.rm = TRUE)
+    n_total  <- sum(ph2_mask, na.rm = TRUE)
+    cli::cli_text("Domain: {.val {n_domain}} of {.val {n_total}} Phase 2 rows")
+  } else {
+    n_domain <- sum(x@data[[SURVEYCORE_DOMAIN_COL]], na.rm = TRUE)
+    n_total  <- nrow(x@data)
+    cli::cli_text("Domain: {.val {n_domain}} of {.val {n_total}} row{?s}")
+  }
+  invisible(NULL)
+}
+
 
 # ── print.survey_taylor ────────────────────────────────────────────────────
 
@@ -102,6 +124,7 @@ S7::method(print, survey_taylor) <- function(
   cli::cli_h1("Survey Design")
   cli::cli_text("{.cls survey_taylor} (Taylor series linearization)")
   cli::cli_text("Sample size: {.val {nrow(x@data)}}")
+  .print_domain_info(x)
 
   if (length(x@groups) > 0L) {
     cli::cli_text("Groups: {.field {x@groups}}")
@@ -229,6 +252,7 @@ S7::method(print, survey_srs) <- function(
   cli::cli_h1("Survey Design")
   cli::cli_text("{.cls survey_srs} (simple random sample)")
   cli::cli_text("Sample size: {.val {nrow(x@data)}}")
+  .print_domain_info(x)
 
   if (length(x@groups) > 0L) {
     cli::cli_text("Groups: {.field {x@groups}}")
@@ -346,6 +370,7 @@ S7::method(print, survey_replicate) <- function(
     "{.cls survey_replicate} ({toupper(x@variables$type)}, {n_reps} replicates)"
   )
   cli::cli_text("Sample size: {.val {nrow(x@data)}}")
+  .print_domain_info(x)
 
   if (length(x@groups) > 0L) {
     cli::cli_text("Groups: {.field {x@groups}}")
@@ -454,6 +479,7 @@ S7::method(print, survey_twophase) <- function(
   if (!is.na(n_phase2)) {
     cli::cli_text("Phase 2 sample size: {.val {n_phase2}}")
   }
+  .print_domain_info(x)
 
   if (length(x@groups) > 0L) {
     cli::cli_text("Groups: {.field {x@groups}}")
@@ -562,6 +588,7 @@ S7::method(print, survey_calibrated) <- function(
   cli::cli_h1("Survey Design")
   cli::cli_text("{.cls survey_calibrated} (calibrated / non-probability) [experimental]")
   cli::cli_text("Sample size: {.val {nrow(x@data)}}")
+  .print_domain_info(x)
 
   if (length(x@groups) > 0L) {
     cli::cli_text("Groups: {.field {x@groups}}")

--- a/changelog/feature-print-domain-info.md
+++ b/changelog/feature-print-domain-info.md
@@ -1,0 +1,39 @@
+# Changelog: Domain Info Line in Print Methods
+
+**Branch:** `feature/print-domain-info`
+**Date:** 2026-03-03
+
+## Summary
+
+All five `print()` methods now surface a `Domain: <n> of <N> rows` line when
+`surveytidy::filter()` has been applied to a survey design object. The line
+appears after the sample size line and before the `Groups:` line.
+
+## Changes
+
+### `R/methods-print.R`
+
+- Added `.print_domain_info()` internal helper that reads
+  `SURVEYCORE_DOMAIN_COL` from `@data` and emits a `cli_text()` line when
+  present; returns `invisible(NULL)` silently when the column is absent.
+- For `survey_twophase`, uses Phase 2 row counts (`x@variables$subset` mask)
+  to match what analysis functions estimate.
+- Added `.print_domain_info(x)` call site in all five print methods:
+  `survey_taylor`, `survey_srs`, `survey_replicate`, `survey_twophase`,
+  `survey_calibrated`.
+
+### `tests/testthat/test-methods-print.R`
+
+- Added `expect_false(SURVEYCORE_DOMAIN_COL %in% names(d@data))` to existing
+  default-output snapshot tests (1, 7, 10, 18) to document the no-domain
+  invariant explicitly.
+- Added test blocks 28–36 for domain info line behaviour:
+  - 28: `survey_taylor` domain line present (snapshot)
+  - 29: `survey_taylor` domain count excludes NAs (snapshot)
+  - 30: `survey_taylor` domain line before groups line (snapshot)
+  - 31: `survey_srs` domain line present (snapshot)
+  - 32: `survey_replicate` domain line present (snapshot)
+  - 33: `survey_twophase` domain line present — Phase 2 counts (snapshot)
+  - 34: `survey_calibrated` default output — net-new baseline (snapshot)
+  - 35: `survey_calibrated` domain line present (snapshot)
+  - 36: `survey_taylor` zero rows in domain (snapshot)

--- a/tests/testthat/_snaps/methods-print.md
+++ b/tests/testthat/_snaps/methods-print.md
@@ -437,3 +437,250 @@
       
       Metadata: 0 of 2 variable(s) labeled
 
+# print.survey_taylor() shows domain line when domain column is present
+
+    Code
+      print(d)
+    Message
+      
+      -- Survey Design ---------------------------------------------------------------
+      <survey_taylor> (Taylor series linearization)
+      Sample size: 50
+      Domain: 50 of 50 rows
+      
+    Output
+      # A tibble: 50 x 9
+         psu   strata      fpc    wt    y1      y2    y3 group ..surveycore_domain..
+         <chr> <chr>     <dbl> <dbl> <dbl>   <dbl> <int> <chr> <lgl>                
+       1 psu_1 stratum_1   378  14.3  50.9 -0.122      1 A     TRUE                 
+       2 psu_1 stratum_1   378  21.8  20.1  0.188      0 B     TRUE                 
+       3 psu_1 stratum_1   378  14.4  52.8  0.119      1 B     TRUE                 
+       4 psu_2 stratum_1   378  18.9  46.3 -0.0251     0 A     TRUE                 
+       5 psu_2 stratum_1   378  23.0  51.9  0.108      0 B     TRUE                 
+       6 psu_2 stratum_1   378  11.0  55.8 -0.485      0 C     TRUE                 
+       7 psu_2 stratum_1   378  13.8  64.0 -0.504      0 A     TRUE                 
+       8 psu_2 stratum_1   378  14.2  42.7 -1.66       0 B     TRUE                 
+       9 psu_3 stratum_1   378  16.5  63.0 -0.382      1 C     TRUE                 
+      10 psu_3 stratum_1   378  13.7  53.4 -0.513      1 A     TRUE                 
+      # i 40 more rows
+
+# print.survey_taylor() domain count excludes NAs
+
+    Code
+      print(d)
+    Message
+      
+      -- Survey Design ---------------------------------------------------------------
+      <survey_taylor> (Taylor series linearization)
+      Sample size: 50
+      Domain: 17 of 50 rows
+      
+    Output
+      # A tibble: 50 x 9
+         psu   strata      fpc    wt    y1      y2    y3 group ..surveycore_domain..
+         <chr> <chr>     <dbl> <dbl> <dbl>   <dbl> <int> <chr> <lgl>                
+       1 psu_1 stratum_1   378  14.3  50.9 -0.122      1 A     TRUE                 
+       2 psu_1 stratum_1   378  21.8  20.1  0.188      0 B     FALSE                
+       3 psu_1 stratum_1   378  14.4  52.8  0.119      1 B     NA                   
+       4 psu_2 stratum_1   378  18.9  46.3 -0.0251     0 A     TRUE                 
+       5 psu_2 stratum_1   378  23.0  51.9  0.108      0 B     FALSE                
+       6 psu_2 stratum_1   378  11.0  55.8 -0.485      0 C     NA                   
+       7 psu_2 stratum_1   378  13.8  64.0 -0.504      0 A     TRUE                 
+       8 psu_2 stratum_1   378  14.2  42.7 -1.66       0 B     FALSE                
+       9 psu_3 stratum_1   378  16.5  63.0 -0.382      1 C     NA                   
+      10 psu_3 stratum_1   378  13.7  53.4 -0.513      1 A     TRUE                 
+      # i 40 more rows
+
+# print.survey_taylor() domain line appears before groups line
+
+    Code
+      print(d)
+    Message
+      
+      -- Survey Design ---------------------------------------------------------------
+      <survey_taylor> (Taylor series linearization)
+      Sample size: 50
+      Domain: 50 of 50 rows
+      Groups: strata
+      
+    Output
+      # A tibble: 50 x 9
+         psu   strata      fpc    wt    y1      y2    y3 group ..surveycore_domain..
+         <chr> <chr>     <dbl> <dbl> <dbl>   <dbl> <int> <chr> <lgl>                
+       1 psu_1 stratum_1   378  14.3  50.9 -0.122      1 A     TRUE                 
+       2 psu_1 stratum_1   378  21.8  20.1  0.188      0 B     TRUE                 
+       3 psu_1 stratum_1   378  14.4  52.8  0.119      1 B     TRUE                 
+       4 psu_2 stratum_1   378  18.9  46.3 -0.0251     0 A     TRUE                 
+       5 psu_2 stratum_1   378  23.0  51.9  0.108      0 B     TRUE                 
+       6 psu_2 stratum_1   378  11.0  55.8 -0.485      0 C     TRUE                 
+       7 psu_2 stratum_1   378  13.8  64.0 -0.504      0 A     TRUE                 
+       8 psu_2 stratum_1   378  14.2  42.7 -1.66       0 B     TRUE                 
+       9 psu_3 stratum_1   378  16.5  63.0 -0.382      1 C     TRUE                 
+      10 psu_3 stratum_1   378  13.7  53.4 -0.513      1 A     TRUE                 
+      # i 40 more rows
+
+# print.survey_srs() shows domain line when domain column is present
+
+    Code
+      print(d)
+    Message
+      
+      -- Survey Design ---------------------------------------------------------------
+      <survey_srs> (simple random sample)
+      Sample size: 30
+      Domain: 30 of 30 rows
+      
+    Output
+      # A tibble: 30 x 9
+         psu   strata      fpc    wt    y1      y2    y3 group ..surveycore_domain..
+         <chr> <chr>     <dbl> <dbl> <dbl>   <dbl> <int> <chr> <lgl>                
+       1 psu_1 stratum_1   145 14.3   55.0 -0.727      1 A     TRUE                 
+       2 psu_1 stratum_1   145 12.9   32.8  1.30       1 B     TRUE                 
+       3 psu_1 stratum_1   145 17.8   42.2  0.336      1 A     TRUE                 
+       4 psu_2 stratum_1   145 12.9   41.5  1.04       0 A     TRUE                 
+       5 psu_2 stratum_1   145 19.7   25.9  0.921      1 A     TRUE                 
+       6 psu_2 stratum_1   145 13.0   50.4  0.721      1 C     TRUE                 
+       7 psu_2 stratum_1   145 17.1   52.1 -1.04       1 B     TRUE                 
+       8 psu_2 stratum_1   145 20.8   46.4 -0.0902     1 B     TRUE                 
+       9 psu_3 stratum_1   145  9.98  57.6  0.624      0 B     TRUE                 
+      10 psu_3 stratum_1   145 12.5   42.7 -0.954      1 A     TRUE                 
+      # i 20 more rows
+
+# print.survey_replicate() shows domain line when domain column is present
+
+    Code
+      print(d)
+    Message
+      
+      -- Survey Design ---------------------------------------------------------------
+      <survey_replicate> (BRR, 5 replicates)
+      Sample size: 50
+      Domain: 50 of 50 rows
+      
+    Output
+      # A tibble: 50 x 14
+         psu   strata      fpc    wt    y1      y2    y3 group repwt_1 repwt_2 repwt_3
+         <chr> <chr>     <dbl> <dbl> <dbl>   <dbl> <int> <chr>   <dbl>   <dbl>   <dbl>
+       1 psu_1 stratum_1   378  14.3  50.9 -0.122      1 A        14.4    13.2   13.3 
+       2 psu_1 stratum_1   378  21.8  20.1  0.188      0 B        19.0    22.6   20.3 
+       3 psu_1 stratum_1   378  14.4  52.8  0.119      1 B        11.6    12.6   15.2 
+       4 psu_2 stratum_1   378  18.9  46.3 -0.0251     0 A        17.5    19.0   19.0 
+       5 psu_2 stratum_1   378  23.0  51.9  0.108      0 B        22.9    21.2   24.3 
+       6 psu_2 stratum_1   378  11.0  55.8 -0.485      0 C        12.7    13.1    9.77
+       7 psu_2 stratum_1   378  13.8  64.0 -0.504      0 A        15.3    12.5   15.1 
+       8 psu_2 stratum_1   378  14.2  42.7 -1.66       0 B        14.0    15.2   14.9 
+       9 psu_3 stratum_1   378  16.5  63.0 -0.382      1 C        18.0    15.3   15.9 
+      10 psu_3 stratum_1   378  13.7  53.4 -0.513      1 A        11.8    13.1   15.8 
+      # i 40 more rows
+      # i 3 more variables: repwt_4 <dbl>, repwt_5 <dbl>, ..surveycore_domain.. <lgl>
+
+# print.survey_twophase() shows domain line when domain column is present
+
+    Code
+      print(d)
+    Message
+      
+      -- Survey Design ---------------------------------------------------------------
+      <survey_twophase> (method: full)
+      Phase 1 sample size: 60
+      Phase 2 sample size: 29
+      Domain: 29 of 29 Phase 2 rows
+      
+    Output
+      # A tibble: 60 x 12
+         psu   strata      fpc    wt    y1         y2    y3 group subset phase1_prob
+         <chr> <chr>     <dbl> <dbl> <dbl>      <dbl> <int> <chr> <lgl>        <dbl>
+       1 psu_1 stratum_1   451  14.3  60.4 -2.02          0 B     TRUE        0.0687
+       2 psu_1 stratum_1   451  21.8  59.2 -1.22          0 B     FALSE       0.0687
+       3 psu_1 stratum_1   451  14.4  57.2  0.180         1 B     FALSE       0.0687
+       4 psu_1 stratum_1   451  18.9  39.6  0.568         1 C     TRUE        0.0687
+       5 psu_2 stratum_1   451  23.0  49.1 -0.493         1 A     FALSE       0.0687
+       6 psu_2 stratum_1   451  11.0  56.2  0.0000629     0 C     TRUE        0.0687
+       7 psu_2 stratum_1   451  13.8  40.5  1.12          0 A     TRUE        0.0687
+       8 psu_2 stratum_1   451  14.2  44.6  1.44          0 C     FALSE       0.0687
+       9 psu_2 stratum_1   451  16.5  55.8 -1.10          0 A     TRUE        0.0687
+      10 psu_2 stratum_1   451  13.7  57.7 -0.117         1 B     TRUE        0.0687
+      # i 50 more rows
+      # i 2 more variables: phase2_prob <dbl>, ..surveycore_domain.. <lgl>
+
+# print.survey_calibrated() default output
+
+    Code
+      print(d)
+    Message
+      
+      -- Survey Design ---------------------------------------------------------------
+      <survey_calibrated> (calibrated / non-probability) [experimental]
+      Sample size: 30
+      
+    Output
+      # A tibble: 30 x 9
+         psu   strata      fpc    wt    y1      y2    y3 group cal_wt
+         <chr> <chr>     <dbl> <dbl> <dbl>   <dbl> <int> <chr>  <dbl>
+       1 psu_1 stratum_1   145 14.3   55.0 -0.727      1 A       13.7
+       2 psu_1 stratum_1   145 12.9   32.8  1.30       1 B       13.6
+       3 psu_1 stratum_1   145 17.8   42.2  0.336      1 A       17.5
+       4 psu_2 stratum_1   145 12.9   41.5  1.04       0 A       13.9
+       5 psu_2 stratum_1   145 19.7   25.9  0.921      1 A       21.5
+       6 psu_2 stratum_1   145 13.0   50.4  0.721      1 C       11.8
+       7 psu_2 stratum_1   145 17.1   52.1 -1.04       1 B       17.2
+       8 psu_2 stratum_1   145 20.8   46.4 -0.0902     1 B       22.5
+       9 psu_3 stratum_1   145  9.98  57.6  0.624      0 B       10.1
+      10 psu_3 stratum_1   145 12.5   42.7 -0.954      1 A       12.4
+      # i 20 more rows
+
+# print.survey_calibrated() shows domain line when domain column is present
+
+    Code
+      print(d)
+    Message
+      
+      -- Survey Design ---------------------------------------------------------------
+      <survey_calibrated> (calibrated / non-probability) [experimental]
+      Sample size: 30
+      Domain: 30 of 30 rows
+      
+    Output
+      # A tibble: 30 x 10
+         psu   strata      fpc    wt    y1      y2    y3 group cal_wt
+         <chr> <chr>     <dbl> <dbl> <dbl>   <dbl> <int> <chr>  <dbl>
+       1 psu_1 stratum_1   145 14.3   55.0 -0.727      1 A       13.7
+       2 psu_1 stratum_1   145 12.9   32.8  1.30       1 B       13.6
+       3 psu_1 stratum_1   145 17.8   42.2  0.336      1 A       17.5
+       4 psu_2 stratum_1   145 12.9   41.5  1.04       0 A       13.9
+       5 psu_2 stratum_1   145 19.7   25.9  0.921      1 A       21.5
+       6 psu_2 stratum_1   145 13.0   50.4  0.721      1 C       11.8
+       7 psu_2 stratum_1   145 17.1   52.1 -1.04       1 B       17.2
+       8 psu_2 stratum_1   145 20.8   46.4 -0.0902     1 B       22.5
+       9 psu_3 stratum_1   145  9.98  57.6  0.624      0 B       10.1
+      10 psu_3 stratum_1   145 12.5   42.7 -0.954      1 A       12.4
+      # i 20 more rows
+      # i 1 more variable: ..surveycore_domain.. <lgl>
+
+# print.survey_taylor() shows domain line when zero rows are in domain
+
+    Code
+      print(d)
+    Message
+      
+      -- Survey Design ---------------------------------------------------------------
+      <survey_taylor> (Taylor series linearization)
+      Sample size: 50
+      Domain: 0 of 50 rows
+      
+    Output
+      # A tibble: 50 x 9
+         psu   strata      fpc    wt    y1      y2    y3 group ..surveycore_domain..
+         <chr> <chr>     <dbl> <dbl> <dbl>   <dbl> <int> <chr> <lgl>                
+       1 psu_1 stratum_1   378  14.3  50.9 -0.122      1 A     FALSE                
+       2 psu_1 stratum_1   378  21.8  20.1  0.188      0 B     FALSE                
+       3 psu_1 stratum_1   378  14.4  52.8  0.119      1 B     FALSE                
+       4 psu_2 stratum_1   378  18.9  46.3 -0.0251     0 A     FALSE                
+       5 psu_2 stratum_1   378  23.0  51.9  0.108      0 B     FALSE                
+       6 psu_2 stratum_1   378  11.0  55.8 -0.485      0 C     FALSE                
+       7 psu_2 stratum_1   378  13.8  64.0 -0.504      0 A     FALSE                
+       8 psu_2 stratum_1   378  14.2  42.7 -1.66       0 B     FALSE                
+       9 psu_3 stratum_1   378  16.5  63.0 -0.382      1 C     FALSE                
+      10 psu_3 stratum_1   378  13.7  53.4 -0.513      1 A     FALSE                
+      # i 40 more rows
+

--- a/tests/testthat/test-methods-print.R
+++ b/tests/testthat/test-methods-print.R
@@ -106,6 +106,7 @@ make_twophase_design <- function(seed = 42L) {
 test_that("print.survey_taylor default output matches snapshot", {
   d <- make_taylor_design()
   test_invariants(d)
+  expect_false(surveycore::SURVEYCORE_DOMAIN_COL %in% names(d@data))
   withr::local_options(list(width = 80L, cli.width = 80L))
   expect_snapshot(print(d))
 })
@@ -217,6 +218,7 @@ test_that("print.survey_taylor SRS design omits 'Weights provided as:' line", {
 test_that("print.survey_replicate default output matches snapshot", {
   d <- make_rep_design()
   test_invariants(d)
+  expect_false(surveycore::SURVEYCORE_DOMAIN_COL %in% names(d@data))
   withr::local_options(list(width = 80L, cli.width = 80L))
   expect_snapshot(print(d))
 })
@@ -247,6 +249,7 @@ test_that("print.survey_replicate returns x invisibly", {
 test_that("print.survey_twophase default output matches snapshot", {
   d <- make_twophase_design()
   test_invariants(d)
+  expect_false(surveycore::SURVEYCORE_DOMAIN_COL %in% names(d@data))
   withr::local_options(list(width = 80L, cli.width = 80L))
   expect_snapshot(print(d))
 })
@@ -359,6 +362,7 @@ test_that("print.survey_srs default output matches snapshot", {
     weights = wt
   )
   test_invariants(d)
+  expect_false(surveycore::SURVEYCORE_DOMAIN_COL %in% names(d@data))
   withr::local_options(list(width = 80L, cli.width = 80L))
   expect_snapshot(print(d))
 })
@@ -484,4 +488,128 @@ test_that("print.survey_srs shows '(from sampling probabilities)' when probs_pro
   withr::local_options(list(width = 80L, cli.width = 80L))
   out <- capture.output(print(d, design_info = TRUE), type = "message")
   expect_true(any(grepl("from sampling probabilities", out)))
+})
+
+
+# ── Domain info line ─────────────────────────────────────────────────────────
+# 28. print.survey_taylor — domain line present (snapshot)
+# 29. print.survey_taylor — domain count excludes NAs (snapshot)
+# 30. print.survey_taylor — domain line appears before groups line (snapshot)
+# 31. print.survey_srs — domain line present (snapshot)
+# 32. print.survey_replicate — domain line present (snapshot)
+# 33. print.survey_twophase — domain line present (snapshot)
+# 34. print.survey_calibrated — default output (snapshot; net-new baseline)
+# 35. print.survey_calibrated — domain line present (snapshot)
+# 36. print.survey_taylor — zero rows in domain (snapshot)
+
+
+# ── 28. print.survey_taylor — domain line present ────────────────────────────
+
+test_that("print.survey_taylor() shows domain line when domain column is present", {
+  withr::local_options(list(width = 80L, cli.width = 80L))
+  d <- make_taylor_design()
+  test_invariants(d)
+  d@data[[surveycore::SURVEYCORE_DOMAIN_COL]] <- d@data$y1 > 0
+  expect_snapshot(print(d))
+})
+
+
+# ── 29. print.survey_taylor — domain count excludes NAs ──────────────────────
+
+test_that("print.survey_taylor() domain count excludes NAs", {
+  withr::local_options(list(width = 80L, cli.width = 80L))
+  d <- make_taylor_design()
+  test_invariants(d)
+  mask <- rep(c(TRUE, FALSE, NA), length.out = nrow(d@data))
+  d@data[[surveycore::SURVEYCORE_DOMAIN_COL]] <- mask
+  expect_snapshot(print(d))
+})
+
+
+# ── 30. print.survey_taylor — domain line appears before groups line ──────────
+
+test_that("print.survey_taylor() domain line appears before groups line", {
+  withr::local_options(list(width = 80L, cli.width = 80L))
+  d <- make_taylor_design()
+  test_invariants(d)
+  d@data[[surveycore::SURVEYCORE_DOMAIN_COL]] <- d@data$y1 > 0
+  d@groups <- "strata"
+  expect_snapshot(print(d))
+})
+
+
+# ── 31. print.survey_srs — domain line present ───────────────────────────────
+
+test_that("print.survey_srs() shows domain line when domain column is present", {
+  withr::local_options(list(width = 80L, cli.width = 80L))
+  d <- as_survey_srs(
+    make_survey_data(n = 30L, n_psu = 6L, n_strata = 2L, seed = 42L),
+    weights = wt
+  )
+  test_invariants(d)
+  d@data[[surveycore::SURVEYCORE_DOMAIN_COL]] <- d@data$y1 > 0
+  expect_snapshot(print(d))
+})
+
+
+# ── 32. print.survey_replicate — domain line present ─────────────────────────
+
+test_that("print.survey_replicate() shows domain line when domain column is present", {
+  withr::local_options(list(width = 80L, cli.width = 80L))
+  d <- make_rep_design()
+  test_invariants(d)
+  d@data[[surveycore::SURVEYCORE_DOMAIN_COL]] <- d@data$y1 > 0
+  expect_snapshot(print(d))
+})
+
+
+# ── 33. print.survey_twophase — domain line present ──────────────────────────
+
+test_that("print.survey_twophase() shows domain line when domain column is present", {
+  withr::local_options(list(width = 80L, cli.width = 80L))
+  d <- make_twophase_design()
+  test_invariants(d)
+  d@data[[surveycore::SURVEYCORE_DOMAIN_COL]] <- d@data$y1 > 0
+  expect_snapshot(print(d))
+})
+
+
+# ── 34. print.survey_calibrated — default output (net-new baseline) ──────────
+
+test_that("print.survey_calibrated() default output", {
+  withr::local_options(list(width = 80L, cli.width = 80L))
+  df <- make_survey_data(n = 30L, n_psu = 6L, n_strata = 2L, seed = 42L)
+  set.seed(123L)
+  df$cal_wt <- df$wt * runif(nrow(df), 0.9, 1.1)
+  d <- as_survey_calibrated(df, weights = cal_wt)
+  test_invariants(d)
+  expect_true(S7::S7_inherits(d, survey_calibrated))
+  expect_false(surveycore::SURVEYCORE_DOMAIN_COL %in% names(d@data))
+  expect_snapshot(print(d))
+})
+
+
+# ── 35. print.survey_calibrated — domain line present ────────────────────────
+
+test_that("print.survey_calibrated() shows domain line when domain column is present", {
+  withr::local_options(list(width = 80L, cli.width = 80L))
+  df <- make_survey_data(n = 30L, n_psu = 6L, n_strata = 2L, seed = 42L)
+  set.seed(123L)
+  df$cal_wt <- df$wt * runif(nrow(df), 0.9, 1.1)
+  d <- as_survey_calibrated(df, weights = cal_wt)
+  test_invariants(d)
+  expect_true(S7::S7_inherits(d, survey_calibrated))
+  d@data[[surveycore::SURVEYCORE_DOMAIN_COL]] <- d@data$y1 > 0
+  expect_snapshot(print(d))
+})
+
+
+# ── 36. print.survey_taylor — zero rows in domain ────────────────────────────
+
+test_that("print.survey_taylor() shows domain line when zero rows are in domain", {
+  withr::local_options(list(width = 80L, cli.width = 80L))
+  d <- make_taylor_design()
+  test_invariants(d)
+  d@data[[surveycore::SURVEYCORE_DOMAIN_COL]] <- FALSE
+  expect_snapshot(print(d))
 })


### PR DESCRIPTION
## What

All five `print()` methods now emit a `Domain: <n> of <N> rows` line when
`surveytidy::filter()` has applied a domain restriction to a survey design
object.

## Checklist

- [x] Tests written and passing (`devtools::test()`)
- [x] R CMD check: 0 errors, 0 warnings (`devtools::check()`)
- [ ] Roxygen docs updated and `devtools::document()` run
- [ ] `plans/error-messages.md` updated (if new errors/warnings added)
- [ ] `VENDORED.md` updated (if variance code vendored in this PR)
- [x] PR title is a valid Conventional Commits (`feat(scope): description`)
- [x] PR targets `develop`, not `main`