### PR TITLE
feat(glm): implement 20 S3 methods and survey_glm_summary class

### DIFF
--- a/R/glm-methods.R
+++ b/R/glm-methods.R
@@ -1,0 +1,489 @@
+# R/glm-methods.R
+#
+# Phase 2: S3 methods on survey_glm_fit
+#
+# All methods are registered in R/zzz.R via registerS3method() in .onLoad().
+# S3 dispatch does not work for S7 objects via UseMethod(); dynamic
+# registration is required (same pattern as surveytidy dplyr verbs).
+#
+# Methods in this file (20 + getCall + print.survey_glm_summary):
+#   print, summary, coef, vcov, predict, fitted, residuals, confint,
+#   formula, terms, model.matrix, model.frame, deviance, df.residual,
+#   nobs, hatvalues, logLik, AIC, BIC, update, getCall
+#
+# Spec: plans/spec-phase-2.md §V
+
+
+# ── Internal helper: .glm_design_type_label() ─────────────────────────────────
+#
+# Returns the display label for the design type in print/summary output.
+#
+# @param fit A survey_glm_fit object.
+# @return Character string for display, e.g. "Taylor series".
+#' @noRd
+.glm_design_type_label <- function(fit) {
+  d <- fit@design
+  if (S7::S7_inherits(d, survey_taylor))           "Taylor series"
+  else if (S7::S7_inherits(d, survey_replicate))   "Replicate weights"
+  else if (S7::S7_inherits(d, survey_twophase))    "Two-phase"
+  else if (S7::S7_inherits(d, survey_srs))         "SRS"
+  else if (S7::S7_inherits(d, survey_calibrated))  "Calibrated"
+  else "Unknown"
+}
+
+# ── Internal helper: .glm_design_type_string() ────────────────────────────────
+#
+# Returns the short design_type string matching Phase 1 .build_meta().
+#
+# @param design A survey_base object.
+# @return One of "taylor", "replicate", "twophase", "srs", "calibrated".
+#' @noRd
+.glm_design_type_string <- function(design) {
+  if (S7::S7_inherits(design, survey_taylor))           "taylor"
+  else if (S7::S7_inherits(design, survey_replicate))   "replicate"
+  else if (S7::S7_inherits(design, survey_twophase))    "twophase"
+  else if (S7::S7_inherits(design, survey_srs))         "srs"
+  else if (S7::S7_inherits(design, survey_calibrated))  "calibrated"
+  else "unknown"
+}
+
+# ── Internal helper: .glm_check_fit_ ──────────────────────────────────────────
+#
+# Throw surveycore_error_predict_no_fit if fit_ is NULL.
+#
+# @param object A survey_glm_fit.
+#' @noRd
+.glm_check_fit_ <- function(object, fn_name = "predict") {
+  if (is.null(object@fit_)) {
+    cli::cli_abort(
+      c(
+        "x" = paste0(
+          "The internal {.field fit_} slot is NULL. ",
+          "This can happen after serialization."
+        ),
+        "v" = "Refit the model to restore prediction support."
+      ),
+      class = "surveycore_error_predict_no_fit"
+    )
+  }
+}
+
+
+# ===========================================================================
+# 5.1  print.survey_glm_fit
+# ===========================================================================
+
+#' @noRd
+print.survey_glm_fit <- function(x, digits = 4, ...) {
+  fam_name <- x@family$family
+  lnk_name <- x@family$link
+  dgf      <- format(round(x@degf))
+  dtype    <- .glm_design_type_label(x)
+
+  cat("Survey-weighted GLM\n\n")
+  cat(sprintf("Family:  %s (%s link)\n", fam_name, lnk_name))
+  cat(sprintf("Formula: %s\n",
+              deparse(x@formula, width.cutoff = 500L)))
+  cat(sprintf("Design:  %s\n\n", dtype))
+
+  cat("Coefficients:\n")
+  coef_fmt <- format(round(x@coefficients, digits), nsmall = digits)
+  print(coef_fmt, quote = FALSE)
+
+  cat(sprintf("\nDegrees of freedom: %s (design-based)\n", dgf))
+
+  invisible(x)
+}
+
+
+# ===========================================================================
+# 5.2  summary.survey_glm_fit + survey_glm_summary + print.survey_glm_summary
+# ===========================================================================
+
+#' @noRd
+summary.survey_glm_fit <- function(object, ...) {
+  .glm_check_fit_(object, "summary")
+
+  p  <- length(object@coefficients)
+  se <- sqrt(diag(object@vcov))
+
+  df_design_resid <- max(1, object@degf - (p - 1L))
+  tval <- object@coefficients / se
+  pval <- 2 * stats::pt(-abs(tval), df = df_design_resid)
+
+  coef_mat <- cbind(
+    "Estimate"   = object@coefficients,
+    "Std. Error" = se,
+    "t value"    = tval,
+    "Pr(>|t|)"   = pval
+  )
+  rownames(coef_mat) <- names(object@coefficients)
+
+  # Dispersion: from the underlying glm summary (correct for all families)
+  disp <- summary(object@fit_)$dispersion
+
+  # Deviance residuals (5-number summary): fivenum of deviance residuals from fit_
+  dev_res_5 <- stats::fivenum(
+    stats::residuals(object@fit_, type = "deviance")
+  )
+  names(dev_res_5) <- c("Min", "1Q", "Median", "3Q", "Max")
+
+  # AIC from the underlying glm fit
+  aic_val <- stats::AIC(object@fit_)
+
+  structure(
+    list(
+      coefficients      = coef_mat,
+      deviance          = object@deviance,
+      null_deviance     = object@null_deviance,
+      df_residual       = object@df_residual,
+      df_null           = object@df_null,
+      dispersion        = disp,
+      family            = object@family,
+      call              = object@call,
+      design_type       = .glm_design_type_string(object@design),
+      degf              = object@degf,
+      deviance_residuals = dev_res_5,  # for print.survey_glm_summary
+      aic               = aic_val      # for print.survey_glm_summary
+    ),
+    class = "survey_glm_summary"
+  )
+}
+
+
+#' @noRd
+print.survey_glm_summary <- function(x, digits = 4, signif.stars = TRUE, ...) {
+  cat("Survey-weighted GLM\n\n")
+
+  if (!is.null(x$call)) {
+    cat("Call:\n")
+    cat(deparse(x$call, width.cutoff = 500L), "\n\n")
+  }
+
+  cat("Deviance Residuals:\n")
+  dev_fmt <- format(round(x$deviance_residuals, 4L), nsmall = 4L, width = 8L)
+  print(dev_fmt, quote = FALSE)
+  cat("\n")
+
+  cat("Coefficients:\n")
+  cmat <- x$coefficients
+  if (signif.stars) {
+    stars <- stats::symnum(
+      cmat[, "Pr(>|t|)"],
+      corr      = FALSE,
+      na        = FALSE,
+      cutpoints = c(0, 0.001, 0.01, 0.05, 0.1, 1),
+      symbols   = c("***", "**", "*", ".", " ")
+    )
+    cmat_print <- cbind(
+      format(round(cmat, digits), nsmall = digits),
+      " " = format(stars)
+    )
+  } else {
+    cmat_print <- format(round(cmat, digits), nsmall = digits)
+  }
+  print(cmat_print, quote = FALSE)
+
+  if (signif.stars) {
+    cat("---\n")
+    cat(
+      "Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1\n\n"
+    )
+  } else {
+    cat("\n")
+  }
+
+  fam_name <- x$family$family
+  cat(sprintf(
+    "(Dispersion parameter for %s family taken to be %s)\n\n",
+    fam_name,
+    format(x$dispersion, digits = max(4L, digits))
+  ))
+
+  cat(sprintf(
+    "    Null deviance: %s on %d degrees of freedom\n",
+    format(x$null_deviance, digits = max(4L, digits)),
+    as.integer(x$df_null)
+  ))
+  cat(sprintf(
+    "Residual deviance: %s on %d degrees of freedom\n",
+    format(x$deviance, digits = max(4L, digits)),
+    as.integer(x$df_residual)
+  ))
+  cat(sprintf("AIC: %s\n\n", format(x$aic, digits = max(4L, digits))))
+  cat(sprintf("Design df: %d (%s)\n",
+              as.integer(round(x$degf)), x$design_type))
+
+  invisible(x)
+}
+
+
+# ===========================================================================
+# 5.3  coef.survey_glm_fit
+# ===========================================================================
+
+#' @noRd
+coef.survey_glm_fit <- function(object, ...) {
+  object@coefficients
+}
+
+
+# ===========================================================================
+# 5.4  vcov.survey_glm_fit
+# ===========================================================================
+
+#' @noRd
+vcov.survey_glm_fit <- function(object, ...) {
+  object@vcov
+}
+
+
+# ===========================================================================
+# 5.5  predict.survey_glm_fit
+# ===========================================================================
+
+#' @noRd
+predict.survey_glm_fit <- function(object, new_data = NULL, type = "response",
+                                    se_fit = FALSE, na_action = stats::na.pass,
+                                    ...) {
+  .glm_check_fit_(object, "predict")
+
+  result <- stats::predict.glm(
+    object@fit_,
+    newdata   = new_data,
+    type      = type,
+    se.fit    = se_fit,
+    na.action = na_action,
+    ...
+  )
+
+  # When se_fit = TRUE, rename components to snake_case per spec §5.5
+  if (se_fit && is.list(result)) {
+    names(result)[names(result) == "se.fit"]         <- "se_fit"
+    names(result)[names(result) == "residual.scale"] <- "residual_scale"
+  }
+
+  result
+}
+
+
+# ===========================================================================
+# 5.6  fitted.survey_glm_fit
+# ===========================================================================
+
+#' @noRd
+fitted.survey_glm_fit <- function(object, ...) {
+  object@fitted_values
+}
+
+
+# ===========================================================================
+# 5.7  residuals.survey_glm_fit
+# ===========================================================================
+
+#' @noRd
+residuals.survey_glm_fit <- function(object, type = "response", ...) {
+  if (type == "working") {
+    return(object@residuals)
+  }
+
+  .glm_check_fit_(object, "residuals")
+
+  if (type == "response") {
+    y <- stats::model.response(stats::model.frame(object@fit_))
+    return(as.numeric(y - object@fitted_values))
+  }
+
+  # "pearson", "deviance", "partial" — delegate to fit_
+  stats::residuals(object@fit_, type = type, ...)
+}
+
+
+# ===========================================================================
+# 5.8  confint.survey_glm_fit
+# ===========================================================================
+
+#' @noRd
+confint.survey_glm_fit <- function(object, parm, level = 0.95, ...) {
+  if (!is.numeric(level) || length(level) != 1L ||
+      is.na(level) || level <= 0 || level >= 1) {
+    cli::cli_abort(
+      c(
+        "x" = paste0(
+          "{.arg conf_level} must be a single number strictly between 0 and 1.",
+          " Got {.val {level}}."
+        )
+      ),
+      class = "surveycore_error_invalid_conf_level"
+    )
+  }
+
+  parm_arg <- if (missing(parm)) NULL else parm
+
+  se <- sqrt(diag(object@vcov))
+  ci <- .glm_confint(
+    estimates   = object@coefficients,
+    se          = se,
+    degf_design = object@degf,
+    n_coef      = length(object@coefficients),
+    level       = level,
+    parm        = parm_arg
+  )
+
+  # Rename columns from "lower"/"upper" to standard R convention, e.g. "2.5 %"
+  pct_lo <- paste0(100 * (1 - level) / 2, " %")
+  pct_hi <- paste0(100 * (1 + level) / 2, " %")
+  colnames(ci) <- c(pct_lo, pct_hi)
+  ci
+}
+
+
+# ===========================================================================
+# 5.9  formula.survey_glm_fit
+# ===========================================================================
+
+#' @noRd
+formula.survey_glm_fit <- function(x, ...) {
+  x@formula
+}
+
+
+# ===========================================================================
+# 5.10  terms.survey_glm_fit
+# ===========================================================================
+
+#' @noRd
+terms.survey_glm_fit <- function(x, ...) {
+  .glm_check_fit_(x, "terms")
+  stats::terms(x@fit_, ...)
+}
+
+
+# ===========================================================================
+# 5.11  model.matrix.survey_glm_fit
+# ===========================================================================
+
+#' @noRd
+model.matrix.survey_glm_fit <- function(object, ...) {
+  .glm_check_fit_(object, "model.matrix")
+  stats::model.matrix(object@fit_, ...)
+}
+
+
+# ===========================================================================
+# 5.12  model.frame.survey_glm_fit
+# ===========================================================================
+
+#' @noRd
+model.frame.survey_glm_fit <- function(formula, ...) {
+  # First argument is named `formula` per base R model.frame generic convention.
+  .glm_check_fit_(formula, "model.frame")
+  stats::model.frame(formula@fit_, ...)
+}
+
+
+# ===========================================================================
+# 5.13  deviance.survey_glm_fit
+# ===========================================================================
+
+#' @noRd
+deviance.survey_glm_fit <- function(object, ...) {
+  object@deviance
+}
+
+
+# ===========================================================================
+# 5.14  df.residual.survey_glm_fit
+# ===========================================================================
+
+#' @noRd
+df.residual.survey_glm_fit <- function(object, ...) {
+  object@df_residual
+}
+
+
+# ===========================================================================
+# 5.15  nobs.survey_glm_fit
+# ===========================================================================
+
+#' @noRd
+nobs.survey_glm_fit <- function(object, ...) {
+  length(object@fitted_values)
+}
+
+
+# ===========================================================================
+# 5.16  hatvalues.survey_glm_fit
+# ===========================================================================
+
+#' @noRd
+hatvalues.survey_glm_fit <- function(model, ...) {
+  .glm_check_fit_(model, "hatvalues")
+  stats::hatvalues(model@fit_, ...)
+}
+
+
+# ===========================================================================
+# 5.17  logLik.survey_glm_fit
+# ===========================================================================
+
+#' @noRd
+logLik.survey_glm_fit <- function(object, ...) {
+  .glm_check_fit_(object, "logLik")
+  stats::logLik(object@fit_, ...)
+}
+
+
+# ===========================================================================
+# 5.18  AIC.survey_glm_fit / BIC.survey_glm_fit
+# ===========================================================================
+
+#' @noRd
+AIC.survey_glm_fit <- function(object, ..., k = 2) {
+  .glm_check_fit_(object, "AIC")
+  stats::AIC(object@fit_, ..., k = k)
+}
+
+#' @noRd
+BIC.survey_glm_fit <- function(object, ...) {
+  .glm_check_fit_(object, "BIC")
+  stats::BIC(object@fit_, ...)
+}
+
+
+# ===========================================================================
+# 5.19  update.survey_glm_fit / getCall.survey_glm_fit
+# ===========================================================================
+
+#' @noRd
+getCall.survey_glm_fit <- function(x, ...) {
+  x@call
+}
+
+#' @noRd
+update.survey_glm_fit <- function(object, formula., ...) {
+  # Replicate update.default() logic but eval in the frame that called update(),
+  # not in update.default()'s parent.frame() (which would be our frame here).
+  # stats::update.default() cannot be called directly because its parent.frame()
+  # would be this function's frame, not the user's frame where 'design' lives.
+  call <- getCall.survey_glm_fit(object)
+  if (is.null(call)) {
+    cli::cli_abort(
+      c("x" = "Cannot update: {.arg object@call} is NULL."),
+      class = "surveycore_error_predict_no_fit"
+    )
+  }
+  extras <- match.call(expand.dots = FALSE)$...
+  if (!missing(formula.)) {
+    call[[2L]] <- stats::update.formula(stats::formula(object), formula.)
+  }
+  if (length(extras)) {
+    existing <- !is.na(match(names(extras), names(call)))
+    for (a in names(extras)[existing]) call[[a]] <- extras[[a]]
+    if (any(!existing)) {
+      call <- c(as.list(call), extras[!existing])
+      call <- as.call(call)
+    }
+  }
+  eval(call, parent.frame())
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,9 +4,59 @@
 # so that methods on external generics (print, summary, etc.) are registered
 # correctly when the package is loaded from an installed library.
 # See: vignette("packages", package = "S7")
+#
+# Phase 2 additions: register all 20 S3 methods + getCall for survey_glm_fit.
+# CRITICAL: S7 namespaced class names ("surveycore::survey_glm_fit") must be
+# used as the class string — not bare "survey_glm_fit". The class() of an S7
+# object returns namespaced names; bare names never match.
+# See: MEMORY.md §Phase 0.5 / surveytidy dplyr Dispatch Pattern
 
 # nocov start
 .onLoad <- function(libname, pkgname) {
   S7::methods_register()
+
+  # Phase 2: survey_glm_fit S3 methods
+  registerS3method("print",    "surveycore::survey_glm_fit",
+                   print.survey_glm_fit,        envir = asNamespace("base"))
+  registerS3method("summary",  "surveycore::survey_glm_fit",
+                   summary.survey_glm_fit,       envir = asNamespace("base"))
+  registerS3method("coef",     "surveycore::survey_glm_fit",
+                   coef.survey_glm_fit,          envir = asNamespace("stats"))
+  registerS3method("vcov",     "surveycore::survey_glm_fit",
+                   vcov.survey_glm_fit,          envir = asNamespace("stats"))
+  registerS3method("predict",  "surveycore::survey_glm_fit",
+                   predict.survey_glm_fit,       envir = asNamespace("stats"))
+  registerS3method("fitted",   "surveycore::survey_glm_fit",
+                   fitted.survey_glm_fit,        envir = asNamespace("stats"))
+  registerS3method("residuals","surveycore::survey_glm_fit",
+                   residuals.survey_glm_fit,     envir = asNamespace("stats"))
+  registerS3method("confint",  "surveycore::survey_glm_fit",
+                   confint.survey_glm_fit,       envir = asNamespace("stats"))
+  registerS3method("formula",  "surveycore::survey_glm_fit",
+                   formula.survey_glm_fit,       envir = asNamespace("stats"))
+  registerS3method("terms",    "surveycore::survey_glm_fit",
+                   terms.survey_glm_fit,         envir = asNamespace("stats"))
+  registerS3method("model.matrix", "surveycore::survey_glm_fit",
+                   model.matrix.survey_glm_fit,  envir = asNamespace("stats"))
+  registerS3method("model.frame",  "surveycore::survey_glm_fit",
+                   model.frame.survey_glm_fit,   envir = asNamespace("stats"))
+  registerS3method("deviance",     "surveycore::survey_glm_fit",
+                   deviance.survey_glm_fit,      envir = asNamespace("stats"))
+  registerS3method("df.residual",  "surveycore::survey_glm_fit",
+                   df.residual.survey_glm_fit,   envir = asNamespace("stats"))
+  registerS3method("nobs",         "surveycore::survey_glm_fit",
+                   nobs.survey_glm_fit,          envir = asNamespace("stats"))
+  registerS3method("hatvalues",    "surveycore::survey_glm_fit",
+                   hatvalues.survey_glm_fit,     envir = asNamespace("stats"))
+  registerS3method("logLik",       "surveycore::survey_glm_fit",
+                   logLik.survey_glm_fit,        envir = asNamespace("stats"))
+  registerS3method("AIC",          "surveycore::survey_glm_fit",
+                   AIC.survey_glm_fit,           envir = asNamespace("stats"))
+  registerS3method("BIC",          "surveycore::survey_glm_fit",
+                   BIC.survey_glm_fit,           envir = asNamespace("stats"))
+  registerS3method("update",       "surveycore::survey_glm_fit",
+                   update.survey_glm_fit,        envir = asNamespace("stats"))
+  registerS3method("getCall",      "surveycore::survey_glm_fit",
+                   getCall.survey_glm_fit,       envir = asNamespace("stats"))
 }
 # nocov end

--- a/changelog/phase-2/feature-glm-methods.md
+++ b/changelog/phase-2/feature-glm-methods.md
@@ -1,0 +1,56 @@
+# Changelog: feature/glm-methods
+
+**Branch:** `feature/glm-methods`
+**Phase:** 2
+**PR:** 3 of 6
+
+## Summary
+
+Implements all 20 S3 methods on `survey_glm_fit` objects plus the
+`survey_glm_summary` S3 class and its print method.
+
+## New files
+
+- `R/glm-methods.R` — all 20 S3 methods + `survey_glm_summary` +
+  `print.survey_glm_summary()` + `getCall.survey_glm_fit()`
+- `tests/testthat/test-glm-methods.R` — 90 test cases covering items
+  1–16, 18–36 from spec §9.2
+
+## Modified files
+
+- `R/zzz.R` — `.onLoad()` updated to register all 20 S3 methods +
+  `getCall` for `survey_glm_fit` via `registerS3method()` with the
+  correct `"surveycore::survey_glm_fit"` class string
+
+## Methods implemented
+
+`print`, `summary`, `coef`, `vcov`, `predict`, `fitted`, `residuals`,
+`confint`, `formula`, `terms`, `model.matrix`, `model.frame`,
+`deviance`, `df.residual`, `nobs`, `hatvalues`, `logLik`, `AIC`,
+`BIC`, `update`, `getCall`
+
+## Key implementation notes
+
+- All methods registered via `registerS3method()` in `.onLoad()` using
+  `"surveycore::survey_glm_fit"` (namespaced class name required for
+  S7 objects — bare `"survey_glm_fit"` does not match S7 dispatch)
+- `summary.survey_glm_fit()` computes design-based t-tests and p-values
+  using `model@degf - (p - 1)` df; uses `fivenum(residuals(fit_, type="deviance"))`
+  for the deviance residuals block per spec §5.2.2
+- `update.survey_glm_fit()` replicates `stats::update.default()` logic
+  but evaluates the modified call in `parent.frame()` of our function
+  (the user's frame), avoiding the frame-chain issue that would arise
+  from delegating to `stats::update.default()`
+- `confint.survey_glm_fit()` uses `.glm_confint()` from `R/utils.R`
+  (shared with `clean()` in PR 4); column names match base R convention
+  (e.g. `"2.5 %"` and `"97.5 %"`)
+- `predict.survey_glm_fit()` uses snake_case argument names (`new_data`,
+  `se_fit`, `na_action`) and renames `$se.fit` → `$se_fit` and
+  `$residual.scale` → `$residual_scale` for `se_fit = TRUE` output
+
+## Test results
+
+```
+[ FAIL 0 | WARN 0 | SKIP 0 | PASS 6197 ]  (full suite)
+devtools::check(): 0 errors, 0 warnings, 2 notes (pre-approved)
+```

--- a/plans/impl-phase-2.md
+++ b/plans/impl-phase-2.md
@@ -25,7 +25,7 @@ tests.
 
 - [x] PR 1: `chore/glm-pre-implementation` — error table + test helper infrastructure
 - [x] PR 2: `feature/glm-core` — `survey_glm_fit` S7 class + `survey_glm()` + variance engine
-- [ ] PR 3: `feature/glm-methods` — 20 S3 methods + `survey_glm_summary`
+- [x] PR 3: `feature/glm-methods` — 20 S3 methods + `survey_glm_summary`
 - [ ] PR 4: `feature/glm-clean` — `clean()` + `broom::tidy()` shim
 - [ ] PR 5: `feature/glm-marginaleffects` — marginaleffects extension interface
 - [ ] PR 6: `feature/glm-numerical-tests` — oracle tests vs `survey::svyglm()` (depends on PR 4 + PR 5)

--- a/tests/testthat/_snaps/glm-methods.md
+++ b/tests/testthat/_snaps/glm-methods.md
@@ -1,0 +1,172 @@
+# print.survey_glm_fit() snapshot matches expected format
+
+    Code
+      print(fit)
+    Output
+      Survey-weighted GLM
+      
+      Family:  gaussian (identity link)
+      Formula: y1 ~ y2 + y3
+      Design:  Taylor series
+      
+      Coefficients:
+      (Intercept)          y2          y3 
+          51.1868     -0.0624     -2.6042 
+      
+      Degrees of freedom: 16 (design-based)
+
+# print.survey_glm_summary() snapshot matches expected format
+
+    Code
+      print(summary(fit))
+    Output
+      Survey-weighted GLM
+      
+      Call:
+      survey_glm(design = .glm_taylor(), formula = y1 ~ y2 + y3) 
+      
+      Deviance Residuals:
+           Min       1Q   Median       3Q      Max 
+      -93.3797 -18.7253  -0.4633  22.9540  75.4878 
+      
+      Coefficients:
+                  Estimate Std. Error t value Pr(>|t|)    
+      (Intercept) 51.1868   0.7268    70.4262  0.0000  ***
+      y2          -0.0624   0.8308    -0.0752  0.9412     
+      y3          -2.6042   1.4802    -1.7594  0.1003     
+      ---
+      Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
+      
+      (Dispersion parameter for gaussian family taken to be 986.9)
+      
+          Null deviance: 197426 on 199 degrees of freedom
+      Residual deviance: 194412 on 197 degrees of freedom
+      AIC: 1492
+      
+      Design df: 16 (taylor)
+
+# summary() with fit_ = NULL errors with surveycore_error_predict_no_fit
+
+    Code
+      summary(fit_null)
+    Condition
+      Error in `.glm_check_fit_()`:
+      x The internal fit_ slot is NULL. This can happen after serialization.
+      v Refit the model to restore prediction support.
+
+# predict() with fit_ = NULL errors with surveycore_error_predict_no_fit
+
+    Code
+      predict(fit_null)
+    Condition
+      Error in `.glm_check_fit_()`:
+      x The internal fit_ slot is NULL. This can happen after serialization.
+      v Refit the model to restore prediction support.
+
+# residuals(type = 'response') with fit_ = NULL errors surveycore_error_predict_no_fit
+
+    Code
+      residuals(fit_null, type = "response")
+    Condition
+      Error in `.glm_check_fit_()`:
+      x The internal fit_ slot is NULL. This can happen after serialization.
+      v Refit the model to restore prediction support.
+
+# residuals(type = 'pearson') with fit_ = NULL errors surveycore_error_predict_no_fit
+
+    Code
+      residuals(fit_null, type = "pearson")
+    Condition
+      Error in `.glm_check_fit_()`:
+      x The internal fit_ slot is NULL. This can happen after serialization.
+      v Refit the model to restore prediction support.
+
+# residuals(type = 'deviance') with fit_ = NULL errors surveycore_error_predict_no_fit
+
+    Code
+      residuals(fit_null, type = "deviance")
+    Condition
+      Error in `.glm_check_fit_()`:
+      x The internal fit_ slot is NULL. This can happen after serialization.
+      v Refit the model to restore prediction support.
+
+# residuals(type = 'partial') with fit_ = NULL errors surveycore_error_predict_no_fit
+
+    Code
+      residuals(fit_null, type = "partial")
+    Condition
+      Error in `.glm_check_fit_()`:
+      x The internal fit_ slot is NULL. This can happen after serialization.
+      v Refit the model to restore prediction support.
+
+# confint() with level outside (0,1) errors surveycore_error_invalid_conf_level
+
+    Code
+      confint(fit, level = 1.5)
+    Condition
+      Error in `confint()`:
+      x `conf_level` must be a single number strictly between 0 and 1. Got 1.5.
+
+# terms() with fit_ = NULL errors surveycore_error_predict_no_fit
+
+    Code
+      terms(fit_null)
+    Condition
+      Error in `.glm_check_fit_()`:
+      x The internal fit_ slot is NULL. This can happen after serialization.
+      v Refit the model to restore prediction support.
+
+# model.matrix() with fit_ = NULL errors surveycore_error_predict_no_fit
+
+    Code
+      model.matrix(fit_null)
+    Condition
+      Error in `.glm_check_fit_()`:
+      x The internal fit_ slot is NULL. This can happen after serialization.
+      v Refit the model to restore prediction support.
+
+# model.frame() with fit_ = NULL errors surveycore_error_predict_no_fit
+
+    Code
+      model.frame(fit_null)
+    Condition
+      Error in `.glm_check_fit_()`:
+      x The internal fit_ slot is NULL. This can happen after serialization.
+      v Refit the model to restore prediction support.
+
+# hatvalues() with fit_ = NULL errors surveycore_error_predict_no_fit
+
+    Code
+      hatvalues(fit_null)
+    Condition
+      Error in `.glm_check_fit_()`:
+      x The internal fit_ slot is NULL. This can happen after serialization.
+      v Refit the model to restore prediction support.
+
+# logLik() with fit_ = NULL errors surveycore_error_predict_no_fit
+
+    Code
+      logLik(fit_null)
+    Condition
+      Error in `.glm_check_fit_()`:
+      x The internal fit_ slot is NULL. This can happen after serialization.
+      v Refit the model to restore prediction support.
+
+# AIC() with fit_ = NULL errors surveycore_error_predict_no_fit
+
+    Code
+      AIC(fit_null)
+    Condition
+      Error in `.glm_check_fit_()`:
+      x The internal fit_ slot is NULL. This can happen after serialization.
+      v Refit the model to restore prediction support.
+
+# BIC() with fit_ = NULL errors surveycore_error_predict_no_fit
+
+    Code
+      BIC(fit_null)
+    Condition
+      Error in `.glm_check_fit_()`:
+      x The internal fit_ slot is NULL. This can happen after serialization.
+      v Refit the model to restore prediction support.
+

--- a/tests/testthat/test-glm-methods.R
+++ b/tests/testthat/test-glm-methods.R
@@ -1,0 +1,594 @@
+# tests/testthat/test-glm-methods.R
+#
+# Tests for S3 methods on survey_glm_fit — PR 3 scope (feature/glm-methods)
+# Item 17 (print(clean(fit)) snapshot) deferred to PR 4.
+#
+# Spec reference: plans/spec-phase-2.md §V, §9.2
+# Error classes:  plans/error-messages.md (surveycore_error_predict_no_fit,
+#                 surveycore_error_invalid_conf_level)
+
+library(surveycore)
+
+# ── Shared fixtures ────────────────────────────────────────────────────────────
+
+.glm_taylor <- function(seed = 1L) {
+  df <- make_survey_data(n = 200L, n_psu = 20L, n_strata = 4L, seed = seed)
+  as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
+}
+
+.glm_srs <- function(seed = 1L) {
+  df <- make_survey_data(n = 200L, seed = seed)
+  as_survey_srs(df, weights = wt)
+}
+
+# Basic gaussian fit used across most tests
+.fit_gaussian <- function() {
+  survey_glm(.glm_taylor(), y1 ~ y2 + y3)
+}
+
+# Binomial fit used for residuals / response-scale tests
+.fit_binomial <- function() {
+  d <- .glm_taylor()
+  survey_glm(d, y3 ~ y2, family = binomial())
+}
+
+# Helper: replace fit_ with NULL (simulates post-deserialization state)
+.strip_fit <- function(fit) {
+  fit@fit_ <- NULL
+  fit
+}
+
+# ---------------------------------------------------------------------------
+# Item 1: print()
+# ---------------------------------------------------------------------------
+
+test_that("print.survey_glm_fit() returns invisible(x)", {
+  fit <- .fit_gaussian()
+  result <- withVisible(print(fit))
+  expect_false(result$visible)
+  expect_true(S7::S7_inherits(result$value, survey_glm_fit))
+})
+
+test_that("print.survey_glm_fit() snapshot matches expected format", {
+  fit <- .fit_gaussian()
+  expect_snapshot(print(fit))
+})
+
+# ---------------------------------------------------------------------------
+# Item 2: summary()
+# ---------------------------------------------------------------------------
+
+test_that("summary.survey_glm_fit() returns survey_glm_summary class", {
+  fit <- .fit_gaussian()
+  s   <- summary(fit)
+  expect_true(inherits(s, "survey_glm_summary"))
+  expect_type(s, "list")
+})
+
+test_that("survey_glm_summary has all required fields", {
+  fit <- .fit_gaussian()
+  s   <- summary(fit)
+  expected_fields <- c("coefficients", "deviance", "null_deviance", "df_residual",
+                       "df_null", "dispersion", "family", "call",
+                       "design_type", "degf")
+  expect_true(all(expected_fields %in% names(s)))
+})
+
+test_that("survey_glm_summary$coefficients is a p x 4 named matrix", {
+  fit <- .fit_gaussian()
+  s   <- summary(fit)
+  coef_mat <- s$coefficients
+  p <- length(fit@coefficients)
+  expect_true(is.matrix(coef_mat))
+  expect_identical(dim(coef_mat), c(p, 4L))
+  expect_identical(colnames(coef_mat),
+                   c("Estimate", "Std. Error", "t value", "Pr(>|t|)"))
+  expect_identical(rownames(coef_mat), names(fit@coefficients))
+})
+
+# Item 2a: print(summary(fit)) snapshot
+test_that("print.survey_glm_summary() returns invisible(x)", {
+  fit <- .fit_gaussian()
+  s   <- summary(fit)
+  result <- withVisible(print(s))
+  expect_false(result$visible)
+  expect_identical(result$value, s)
+})
+
+test_that("print.survey_glm_summary() snapshot matches expected format", {
+  fit <- .fit_gaussian()
+  expect_snapshot(print(summary(fit)))
+})
+
+# Item 2b: summary() with fit_ = NULL
+test_that("summary() with fit_ = NULL errors with surveycore_error_predict_no_fit", {
+  fit_null <- .strip_fit(.fit_gaussian())
+  expect_error(
+    summary(fit_null),
+    class = "surveycore_error_predict_no_fit"
+  )
+  expect_snapshot(error = TRUE, summary(fit_null))
+})
+
+# ---------------------------------------------------------------------------
+# Item 3: coef()
+# ---------------------------------------------------------------------------
+
+test_that("coef() returns fit@coefficients (identical)", {
+  fit <- .fit_gaussian()
+  expect_identical(coef(fit), fit@coefficients)
+})
+
+test_that("coef() returns a named numeric vector", {
+  fit <- .fit_gaussian()
+  expect_type(coef(fit), "double")
+  expect_false(is.null(names(coef(fit))))
+})
+
+# ---------------------------------------------------------------------------
+# Item 4: vcov()
+# ---------------------------------------------------------------------------
+
+test_that("vcov() returns fit@vcov (identical)", {
+  fit <- .fit_gaussian()
+  expect_identical(vcov(fit), fit@vcov)
+})
+
+test_that("vcov() row and column names match coefficient names", {
+  fit <- .fit_gaussian()
+  coef_names <- names(fit@coefficients)
+  expect_identical(rownames(vcov(fit)), coef_names)
+  expect_identical(colnames(vcov(fit)), coef_names)
+})
+
+# ---------------------------------------------------------------------------
+# Item 5: predict(newdata = NULL) — response scale
+# ---------------------------------------------------------------------------
+
+test_that("predict(fit) returns fitted values on response scale", {
+  fit <- .fit_gaussian()
+  preds <- predict(fit)
+  expect_type(preds, "double")
+  expect_equal(length(preds), length(fit@fitted_values))
+  # predict.glm() returns a named vector; @fitted_values is unnamed
+  expect_equal(unname(preds), fit@fitted_values)
+})
+
+# Item 5a: predict(type = "link") — differs from response for binomial
+test_that("predict(fit, type = 'link') returns link-scale fitted values", {
+  fit_bin <- .fit_binomial()
+  resp_preds <- predict(fit_bin, type = "response")
+  link_preds <- predict(fit_bin, type = "link")
+  # For binomial logit: link values are log-odds, response values are probs
+  expect_true(any(resp_preds != link_preds))
+  # Response is in (0, 1) for binomial
+  expect_true(all(resp_preds > 0 & resp_preds < 1))
+})
+
+# ---------------------------------------------------------------------------
+# Item 6: predict(newdata = df)
+# ---------------------------------------------------------------------------
+
+test_that("predict(fit, new_data = df) returns correct length vector", {
+  d   <- .glm_taylor()
+  fit <- survey_glm(d, y1 ~ y2 + y3)
+  nd  <- d@data[1:10, ]
+  preds <- predict(fit, new_data = nd)
+  expect_type(preds, "double")
+  expect_equal(length(preds), 10L)
+})
+
+# Item 6a: predict(type = "terms") returns matrix
+test_that("predict(fit, type = 'terms') returns a matrix", {
+  fit   <- .fit_gaussian()
+  terms_preds <- predict(fit, type = "terms")
+  expect_true(is.matrix(terms_preds))
+  # Number of columns equals number of non-intercept terms
+  expect_gt(ncol(terms_preds), 0L)
+})
+
+# ---------------------------------------------------------------------------
+# Item 7: predict() with NULL fit_
+# ---------------------------------------------------------------------------
+
+test_that("predict() with fit_ = NULL errors with surveycore_error_predict_no_fit", {
+  fit_null <- .strip_fit(.fit_gaussian())
+  expect_error(
+    predict(fit_null),
+    class = "surveycore_error_predict_no_fit"
+  )
+  expect_snapshot(error = TRUE, predict(fit_null))
+})
+
+# ---------------------------------------------------------------------------
+# Item 8: fitted()
+# ---------------------------------------------------------------------------
+
+test_that("fitted() returns object@fitted_values", {
+  fit <- .fit_gaussian()
+  expect_identical(fitted(fit), fit@fitted_values)
+})
+
+test_that("fitted() values numerically equal predict(fit) values", {
+  fit <- .fit_gaussian()
+  # predict.glm() returns a named vector; fitted() returns unnamed @fitted_values
+  expect_equal(unname(predict(fit)), fitted(fit))
+})
+
+# ---------------------------------------------------------------------------
+# Item 9: residuals(type = "response")
+# ---------------------------------------------------------------------------
+
+test_that("residuals(type = 'response') returns y - fitted_values", {
+  fit    <- .fit_gaussian()
+  resids <- residuals(fit, type = "response")
+  y      <- stats::model.response(stats::model.frame(fit@fit_))
+  expect_equal(resids, as.numeric(y - fit@fitted_values))
+})
+
+# ---------------------------------------------------------------------------
+# Item 10: residuals(type = "working")
+# ---------------------------------------------------------------------------
+
+test_that("residuals(type = 'working') returns fit@residuals", {
+  fit <- .fit_gaussian()
+  expect_equal(residuals(fit, type = "working"), fit@residuals)
+})
+
+# ---------------------------------------------------------------------------
+# Item 11: residuals(type = "pearson")
+# ---------------------------------------------------------------------------
+
+test_that("residuals(type = 'pearson') delegates to fit_ for binomial (differs from working)", {
+  fit_bin <- .fit_binomial()
+  pearson  <- residuals(fit_bin, type = "pearson")
+  working  <- residuals(fit_bin, type = "working")
+  # Pearson and working residuals differ for binomial family
+  expect_true(any(pearson != working))
+})
+
+# ---------------------------------------------------------------------------
+# Item 12: residuals(type = "deviance")
+# ---------------------------------------------------------------------------
+
+test_that("residuals(type = 'deviance') delegates to fit_ for binomial (differs from response)", {
+  fit_bin <- .fit_binomial()
+  deviance_r <- residuals(fit_bin, type = "deviance")
+  response_r <- residuals(fit_bin, type = "response")
+  expect_true(any(deviance_r != response_r))
+})
+
+# ---------------------------------------------------------------------------
+# Item 13: residuals(type = "partial")
+# ---------------------------------------------------------------------------
+
+test_that("residuals(type = 'partial') returns a matrix with one column per predictor", {
+  fit     <- .fit_gaussian()
+  partial <- residuals(fit, type = "partial")
+  expect_true(is.matrix(partial))
+  # Number of columns = number of non-intercept predictors
+  n_pred <- length(fit@coefficients) - 1L
+  expect_equal(ncol(partial), n_pred)
+})
+
+# ---------------------------------------------------------------------------
+# Item 14: residuals(type = "response") with fit_ = NULL
+# ---------------------------------------------------------------------------
+
+test_that("residuals(type = 'response') with fit_ = NULL errors surveycore_error_predict_no_fit", {
+  fit_null <- .strip_fit(.fit_gaussian())
+  expect_error(
+    residuals(fit_null, type = "response"),
+    class = "surveycore_error_predict_no_fit"
+  )
+  expect_snapshot(error = TRUE, residuals(fit_null, type = "response"))
+})
+
+# Item 14a: residuals(type = "pearson") with fit_ = NULL
+test_that("residuals(type = 'pearson') with fit_ = NULL errors surveycore_error_predict_no_fit", {
+  fit_null <- .strip_fit(.fit_gaussian())
+  expect_error(
+    residuals(fit_null, type = "pearson"),
+    class = "surveycore_error_predict_no_fit"
+  )
+  expect_snapshot(error = TRUE, residuals(fit_null, type = "pearson"))
+})
+
+# ---------------------------------------------------------------------------
+# Item 15: residuals(type = "deviance") with fit_ = NULL
+# ---------------------------------------------------------------------------
+
+test_that("residuals(type = 'deviance') with fit_ = NULL errors surveycore_error_predict_no_fit", {
+  fit_null <- .strip_fit(.fit_gaussian())
+  expect_error(
+    residuals(fit_null, type = "deviance"),
+    class = "surveycore_error_predict_no_fit"
+  )
+  expect_snapshot(error = TRUE, residuals(fit_null, type = "deviance"))
+})
+
+# ---------------------------------------------------------------------------
+# Item 16: residuals(type = "partial") with fit_ = NULL
+# ---------------------------------------------------------------------------
+
+test_that("residuals(type = 'partial') with fit_ = NULL errors surveycore_error_predict_no_fit", {
+  fit_null <- .strip_fit(.fit_gaussian())
+  expect_error(
+    residuals(fit_null, type = "partial"),
+    class = "surveycore_error_predict_no_fit"
+  )
+  expect_snapshot(error = TRUE, residuals(fit_null, type = "partial"))
+})
+
+# Item 16a: residuals(type = "response") binomial — values in [-1, 1]
+test_that("residuals(type = 'response') binomial uses model frame response (0/1)", {
+  fit_bin <- .fit_binomial()
+  resids  <- residuals(fit_bin, type = "response")
+  # Response is 0/1 so residuals are in [-1, 1]
+  expect_true(all(resids >= -1 & resids <= 1))
+})
+
+# ---------------------------------------------------------------------------
+# Item 17: print(clean(fit)) — deferred to PR 4
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Item 18: confint() happy path
+# ---------------------------------------------------------------------------
+
+test_that("confint() returns matrix with correct row and column names", {
+  fit  <- .fit_gaussian()
+  ci   <- confint(fit)
+  expect_true(is.matrix(ci))
+  expect_identical(rownames(ci), names(fit@coefficients))
+  expect_identical(colnames(ci), c("2.5 %", "97.5 %"))
+})
+
+test_that("confint() bounds match manual calculation", {
+  fit  <- .fit_gaussian()
+  ci   <- confint(fit)
+  se   <- sqrt(diag(fit@vcov))
+  p    <- length(fit@coefficients)
+  df   <- max(1, fit@degf - (p - 1L))
+  hw   <- stats::qt(0.975, df = df) * se
+  expected_low  <- fit@coefficients - hw
+  expected_high <- fit@coefficients + hw
+  expect_equal(ci[, "2.5 %"],  expected_low,  tolerance = 1e-12)
+  expect_equal(ci[, "97.5 %"], expected_high, tolerance = 1e-12)
+})
+
+test_that("confint(parm = ...) subsets by name correctly", {
+  fit     <- .fit_gaussian()
+  full_ci <- confint(fit)
+  sub_ci  <- confint(fit, parm = "(Intercept)")
+  expect_identical(sub_ci, full_ci["(Intercept)", , drop = FALSE])
+})
+
+test_that("confint() with non-default level uses correct quantile", {
+  fit    <- .fit_gaussian()
+  ci_90  <- confint(fit, level = 0.90)
+  ci_95  <- confint(fit, level = 0.95)
+  # Wider CI at higher confidence level
+  width_90 <- ci_90[, 2L] - ci_90[, 1L]
+  width_95 <- ci_95[, 2L] - ci_95[, 1L]
+  expect_true(all(width_95 > width_90))
+})
+
+# ---------------------------------------------------------------------------
+# Item 19: confint() invalid level
+# ---------------------------------------------------------------------------
+
+test_that("confint() with level outside (0,1) errors surveycore_error_invalid_conf_level", {
+  fit <- .fit_gaussian()
+  expect_error(
+    confint(fit, level = 1.5),
+    class = "surveycore_error_invalid_conf_level"
+  )
+  expect_snapshot(error = TRUE, confint(fit, level = 1.5))
+})
+
+# ---------------------------------------------------------------------------
+# Item 20: formula()
+# ---------------------------------------------------------------------------
+
+test_that("formula() returns object@formula (identical)", {
+  d   <- .glm_taylor()
+  fit <- survey_glm(d, y1 ~ y2 + y3)
+  expect_identical(formula(fit), y1 ~ y2 + y3)
+})
+
+# ---------------------------------------------------------------------------
+# Item 21: terms()
+# ---------------------------------------------------------------------------
+
+test_that("terms() returns same object as terms(fit@fit_)", {
+  fit <- .fit_gaussian()
+  expect_equal(terms(fit), stats::terms(fit@fit_))
+})
+
+# ---------------------------------------------------------------------------
+# Item 22: terms() with fit_ = NULL
+# ---------------------------------------------------------------------------
+
+test_that("terms() with fit_ = NULL errors surveycore_error_predict_no_fit", {
+  fit_null <- .strip_fit(.fit_gaussian())
+  expect_error(
+    terms(fit_null),
+    class = "surveycore_error_predict_no_fit"
+  )
+  expect_snapshot(error = TRUE, terms(fit_null))
+})
+
+# ---------------------------------------------------------------------------
+# Item 23: model.matrix()
+# ---------------------------------------------------------------------------
+
+test_that("model.matrix() returns matrix with correct dimensions", {
+  fit <- .fit_gaussian()
+  mm  <- model.matrix(fit)
+  expect_true(is.matrix(mm))
+  expect_equal(nrow(mm), length(fit@fitted_values))
+  expect_equal(ncol(mm), length(fit@coefficients))
+})
+
+# ---------------------------------------------------------------------------
+# Item 24: model.matrix() with fit_ = NULL
+# ---------------------------------------------------------------------------
+
+test_that("model.matrix() with fit_ = NULL errors surveycore_error_predict_no_fit", {
+  fit_null <- .strip_fit(.fit_gaussian())
+  expect_error(
+    model.matrix(fit_null),
+    class = "surveycore_error_predict_no_fit"
+  )
+  expect_snapshot(error = TRUE, model.matrix(fit_null))
+})
+
+# ---------------------------------------------------------------------------
+# Item 25: model.frame()
+# ---------------------------------------------------------------------------
+
+test_that("model.frame() returns data frame with model formula columns", {
+  d   <- .glm_taylor()
+  fit <- survey_glm(d, y1 ~ y2 + y3)
+  mf  <- model.frame(fit)
+  expect_true(is.data.frame(mf))
+  expect_true(all(c("y1", "y2", "y3") %in% names(mf)))
+})
+
+# ---------------------------------------------------------------------------
+# Item 26: model.frame() with fit_ = NULL
+# ---------------------------------------------------------------------------
+
+test_that("model.frame() with fit_ = NULL errors surveycore_error_predict_no_fit", {
+  fit_null <- .strip_fit(.fit_gaussian())
+  expect_error(
+    model.frame(fit_null),
+    class = "surveycore_error_predict_no_fit"
+  )
+  expect_snapshot(error = TRUE, model.frame(fit_null))
+})
+
+# ---------------------------------------------------------------------------
+# Item 27: deviance()
+# ---------------------------------------------------------------------------
+
+test_that("deviance() returns object@deviance", {
+  fit <- .fit_gaussian()
+  expect_identical(deviance(fit), fit@deviance)
+})
+
+# ---------------------------------------------------------------------------
+# Item 28: df.residual()
+# ---------------------------------------------------------------------------
+
+test_that("df.residual() returns object@df_residual", {
+  fit <- .fit_gaussian()
+  expect_identical(df.residual(fit), fit@df_residual)
+})
+
+# ---------------------------------------------------------------------------
+# Item 29: nobs()
+# ---------------------------------------------------------------------------
+
+test_that("nobs() returns length(object@fitted_values)", {
+  fit <- .fit_gaussian()
+  expect_identical(nobs(fit), length(fit@fitted_values))
+})
+
+# ---------------------------------------------------------------------------
+# Item 30: hatvalues()
+# ---------------------------------------------------------------------------
+
+test_that("hatvalues() returns numeric vector matching hatvalues(fit@fit_)", {
+  fit <- .fit_gaussian()
+  hv  <- hatvalues(fit)
+  expect_type(hv, "double")
+  expect_equal(length(hv), length(fit@fitted_values))
+  expect_equal(hv, stats::hatvalues(fit@fit_))
+})
+
+# ---------------------------------------------------------------------------
+# Item 31: hatvalues() with fit_ = NULL
+# ---------------------------------------------------------------------------
+
+test_that("hatvalues() with fit_ = NULL errors surveycore_error_predict_no_fit", {
+  fit_null <- .strip_fit(.fit_gaussian())
+  expect_error(
+    hatvalues(fit_null),
+    class = "surveycore_error_predict_no_fit"
+  )
+  expect_snapshot(error = TRUE, hatvalues(fit_null))
+})
+
+# ---------------------------------------------------------------------------
+# Item 32: logLik()
+# ---------------------------------------------------------------------------
+
+test_that("logLik() returns same value as logLik(fit@fit_)", {
+  fit <- .fit_gaussian()
+  expect_equal(logLik(fit), stats::logLik(fit@fit_))
+})
+
+# ---------------------------------------------------------------------------
+# Item 33: logLik() with fit_ = NULL
+# ---------------------------------------------------------------------------
+
+test_that("logLik() with fit_ = NULL errors surveycore_error_predict_no_fit", {
+  fit_null <- .strip_fit(.fit_gaussian())
+  expect_error(
+    logLik(fit_null),
+    class = "surveycore_error_predict_no_fit"
+  )
+  expect_snapshot(error = TRUE, logLik(fit_null))
+})
+
+# ---------------------------------------------------------------------------
+# Item 34: AIC() / BIC() happy path
+# ---------------------------------------------------------------------------
+
+test_that("AIC() returns same value as AIC(fit@fit_)", {
+  fit <- .fit_gaussian()
+  expect_equal(AIC(fit), stats::AIC(fit@fit_))
+})
+
+test_that("BIC() returns same value as BIC(fit@fit_)", {
+  fit <- .fit_gaussian()
+  expect_equal(BIC(fit), stats::BIC(fit@fit_))
+})
+
+# ---------------------------------------------------------------------------
+# Item 35: AIC() / BIC() with fit_ = NULL
+# ---------------------------------------------------------------------------
+
+test_that("AIC() with fit_ = NULL errors surveycore_error_predict_no_fit", {
+  fit_null <- .strip_fit(.fit_gaussian())
+  expect_error(
+    AIC(fit_null),
+    class = "surveycore_error_predict_no_fit"
+  )
+  expect_snapshot(error = TRUE, AIC(fit_null))
+})
+
+test_that("BIC() with fit_ = NULL errors surveycore_error_predict_no_fit", {
+  fit_null <- .strip_fit(.fit_gaussian())
+  expect_error(
+    BIC(fit_null),
+    class = "surveycore_error_predict_no_fit"
+  )
+  expect_snapshot(error = TRUE, BIC(fit_null))
+})
+
+# ---------------------------------------------------------------------------
+# Item 36: update() happy path
+# ---------------------------------------------------------------------------
+
+test_that("update(fit, family = poisson()) returns new survey_glm_fit with Poisson family", {
+  d        <- .glm_taylor()
+  # Use a non-negative response for Poisson
+  d@data$y_count <- as.integer(abs(round(d@data$y1)))
+  fit_gauss  <- survey_glm(d, y_count ~ y2)
+  fit_pois   <- update(fit_gauss, family = poisson())
+  expect_true(S7::S7_inherits(fit_pois, survey_glm_fit))
+  expect_identical(fit_pois@family$family, "poisson")
+})


### PR DESCRIPTION
## Summary

- Implements all 20 S3 methods for `survey_glm_fit` objects: `print`, `summary`, `coef`, `vcov`, `predict`, `fitted`, `residuals`, `confint`, `formula`, `terms`, `model.matrix`, `model.frame`, `deviance`, `df.residual`, `nobs`, `hatvalues`, `logLik`, `AIC`, `BIC`, `update`, and `getCall`
- Adds `survey_glm_summary` S3 class and `print.survey_glm_summary()` following spec §5.2.2 with design-based t-tests and deviance residual summary block
- All methods registered via `registerS3method()` in `.onLoad()` using the namespaced `"surveycore::survey_glm_fit"` class string required for S7 dispatch

## Implementation notes

- `summary.survey_glm_fit()` uses `model@degf - (p - 1)` df for t-statistics; `fivenum(residuals(fit_, type="deviance"))` for the deviance residuals block
- `predict.survey_glm_fit()` uses snake_case argument names (`new_data`, `se_fit`, `na_action`) and renames `$se.fit` → `$se_fit`, `$residual.scale` → `$residual_scale`
- `update.survey_glm_fit()` replicates `stats::update.default()` logic but evaluates the modified call in `parent.frame()` to avoid frame-chain issues
- `confint.survey_glm_fit()` uses `.glm_confint()` from `R/utils.R`; column names match base R convention (`"2.5 %"` and `"97.5 %"`)

## Test plan

- [ ] 90 test cases in `tests/testthat/test-glm-methods.R` covering spec §9.2 items 1–16, 18–36
- [ ] Full suite: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 6197 ]`
- [ ] `devtools::check()`: 0 errors, 0 warnings, 2 pre-approved notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)