### PR TITLE
feat(glm): implement marginaleffects extension interface for survey_glm_fit (#52)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,7 @@ Suggests:
     dplyr (>= 1.1.0),
     lifecycle (>= 1.0.0),
     broom (>= 1.0.0),
+    marginaleffects (>= 0.18.0),
     covr,
     knitr,
     rmarkdown

--- a/R/glm-marginaleffects.R
+++ b/R/glm-marginaleffects.R
@@ -1,0 +1,84 @@
+# R/glm-marginaleffects.R
+#
+# marginaleffects extension interface for survey_glm_fit.
+#
+# Implements the four S3 generics that marginaleffects dispatches through,
+# enabling avg_slopes(), avg_predictions(), and the full marginaleffects API
+# on survey_glm_fit objects.
+#
+# Spec reference: plans/spec-phase-2.md §VII
+# Registration: R/zzz.R (.onLoad, conditional on marginaleffects installed)
+#
+# None of the four methods are exported. All are registered dynamically via
+# registerS3method() in .onLoad(). Use #' @noRd to suppress .Rd generation.
+
+# ---------------------------------------------------------------------------
+# 7.3  get_coef.survey_glm_fit
+# ---------------------------------------------------------------------------
+
+#' @noRd
+get_coef.survey_glm_fit <- function(model, ...) {
+  model@coefficients
+}
+
+# ---------------------------------------------------------------------------
+# 7.4  set_coef.survey_glm_fit
+# ---------------------------------------------------------------------------
+#
+# Returns a modified copy with both @coefficients (S7 property) and
+# fit_$coefficients (internal stats::glm object) updated.
+#
+# Why both must be patched:
+#   predict.survey_glm_fit() delegates to stats::predict.glm(object@fit_).
+#   stats::predict.glm() reads coefficients from fit$coefficients, not from
+#   the S7 @coefficients property. Without patching fit_, predictions during
+#   marginaleffects' numerical gradient evaluation would ignore the perturbed
+#   coefficients and every AME would silently equal zero.
+
+#' @noRd
+set_coef.survey_glm_fit <- function(model, coefs, ...) {
+  model@coefficients <- coefs
+  if (!is.null(model@fit_)) {
+    model@fit_$coefficients <- coefs
+  }
+  model
+}
+
+# ---------------------------------------------------------------------------
+# 7.5  get_vcov.survey_glm_fit
+# ---------------------------------------------------------------------------
+#
+# Returns the design-based variance-covariance matrix (Binder 1983 sandwich).
+# AME standard errors produced by avg_slopes() are a hybrid: the variance of
+# β̂ is design-based (from @vcov), while the Jacobian is computed numerically
+# at a single point estimate via the delta method. This is methodologically
+# valid — equivalent to what survey::svyglm + marginaleffects produces.
+
+#' @noRd
+get_vcov.survey_glm_fit <- function(model, ...) {
+  model@vcov
+}
+
+# ---------------------------------------------------------------------------
+# 7.6  get_predict.survey_glm_fit
+# ---------------------------------------------------------------------------
+#
+# Returns predictions as a data frame with columns rowid (integer) and
+# estimate (numeric). marginaleffects always operates on the response scale.
+#
+# The argument is named `newdata` (not `new_data`) to match the marginaleffects
+# extension interface contract. predict.survey_glm_fit() uses `new_data`,
+# so the call maps new_data = newdata explicitly.
+#
+# Requires model@fit_ to be non-NULL. If fit_ is NULL (e.g. after
+# deserialization), errors with surveycore_error_predict_no_fit — the same
+# error class as predict.survey_glm_fit().
+
+#' @noRd
+get_predict.survey_glm_fit <- function(model, newdata, ...) {
+  pred <- stats::predict(model, new_data = newdata, type = "response")
+  data.frame(
+    rowid    = seq_len(nrow(newdata)),
+    estimate = as.numeric(pred)
+  )
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -65,5 +65,31 @@
                      tidy.survey_glm_fit,
                      envir = asNamespace("broom"))
   }
+
+  # Phase 2: marginaleffects extension (conditional)
+  if (requireNamespace("marginaleffects", quietly = TRUE)) {
+    registerS3method("get_coef",    "surveycore::survey_glm_fit",
+                     get_coef.survey_glm_fit,
+                     envir = asNamespace("marginaleffects"))
+    registerS3method("set_coef",    "surveycore::survey_glm_fit",
+                     set_coef.survey_glm_fit,
+                     envir = asNamespace("marginaleffects"))
+    registerS3method("get_vcov",    "surveycore::survey_glm_fit",
+                     get_vcov.survey_glm_fit,
+                     envir = asNamespace("marginaleffects"))
+    registerS3method("get_predict", "surveycore::survey_glm_fit",
+                     get_predict.survey_glm_fit,
+                     envir = asNamespace("marginaleffects"))
+    # Register class in marginaleffects supported-class list.
+    # marginaleffects ≥ 0.25 requires classes to be listed in
+    # getOption("marginaleffects_model_classes") in addition to implementing
+    # the extension interface methods. Without this, avg_slopes() / avg_predictions()
+    # reject the model with "class not supported". Existing entries are preserved.
+    existing <- getOption("marginaleffects_model_classes", default = NULL)
+    if (!"surveycore::survey_glm_fit" %in% existing) {
+      options(marginaleffects_model_classes =
+                c(existing, "surveycore::survey_glm_fit"))
+    }
+  }
 }
 # nocov end

--- a/changelog/phase-2/feature-glm-marginaleffects.md
+++ b/changelog/phase-2/feature-glm-marginaleffects.md
@@ -1,0 +1,48 @@
+# Changelog: feature/glm-marginaleffects
+
+**PR 5 of Phase 2 — marginaleffects extension interface**
+**Branch:** `feature/glm-marginaleffects`
+**Depends on:** PR 3 (`feature/glm-methods`)
+
+## Summary
+
+Implements the four S3 generics from the marginaleffects extension interface,
+enabling `marginaleffects::avg_slopes()`, `marginaleffects::avg_predictions()`,
+and the full marginaleffects API on `survey_glm_fit` objects.
+
+## New Files
+
+- `R/glm-marginaleffects.R` — `get_coef.survey_glm_fit`, `set_coef.survey_glm_fit`,
+  `get_vcov.survey_glm_fit`, `get_predict.survey_glm_fit`; none exported; all
+  registered dynamically in `.onLoad()`
+- `tests/testthat/test-glm-marginaleffects.R` — 10 test items from spec §7.7; all
+  blocks gated with `skip_if_not_installed("marginaleffects")`
+
+## Modified Files
+
+- `R/zzz.R` — conditional marginaleffects method registration block added to
+  `.onLoad()`; also sets `options(marginaleffects_model_classes)` to register the
+  class string required by marginaleffects ≥ 0.25 `sanity_model_supported_class`
+  check
+- `DESCRIPTION` — added `marginaleffects (>= 0.18.0)` to `Suggests`
+
+## Key Implementation Notes
+
+- `set_coef.survey_glm_fit` patches both `@coefficients` (S7 property) and
+  `@fit_$coefficients` (internal `stats::glm` object). Without patching `fit_`,
+  `stats::predict.glm()` reads stale coefficients and all AMEs silently equal zero.
+- `get_predict.survey_glm_fit` uses argument name `newdata` (marginaleffects
+  contract) while forwarding to `stats::predict(model, new_data = newdata)` to
+  match `predict.survey_glm_fit`'s `new_data =` argument name.
+- marginaleffects ≥ 0.25 requires `options(marginaleffects_model_classes)` to
+  include the class string `"surveycore::survey_glm_fit"` in addition to the
+  extension interface methods. This is set in `.onLoad()` alongside the
+  `registerS3method()` calls.
+- All four methods are registered conditionally: when marginaleffects is not
+  installed, none are registered and all core `survey_glm_fit` functionality
+  remains fully usable.
+
+## Test Results
+
+- `devtools::test()`: 6547 expectations pass, 0 failures
+- `devtools::check()`: 0 errors, 0 warnings, 3 pre-existing notes

--- a/plans/impl-phase-2.md
+++ b/plans/impl-phase-2.md
@@ -27,7 +27,7 @@ tests.
 - [x] PR 2: `feature/glm-core` — `survey_glm_fit` S7 class + `survey_glm()` + variance engine
 - [x] PR 3: `feature/glm-methods` — 20 S3 methods + `survey_glm_summary`
 - [x] PR 4: `feature/glm-clean` — `clean()` + `broom::tidy()` shim
-- [ ] PR 5: `feature/glm-marginaleffects` — marginaleffects extension interface
+- [x] PR 5: `feature/glm-marginaleffects` — marginaleffects extension interface
 - [ ] PR 6: `feature/glm-numerical-tests` — oracle tests vs `survey::svyglm()` (depends on PR 4 + PR 5)
 
 ---

--- a/tests/testthat/test-glm-marginaleffects.R
+++ b/tests/testthat/test-glm-marginaleffects.R
@@ -1,0 +1,163 @@
+# tests/testthat/test-glm-marginaleffects.R
+#
+# Tests for marginaleffects extension interface — PR 5 scope
+#
+# Spec reference: plans/spec-phase-2.md §7.7
+# All 10 test items from spec §7.7. Every block gated with
+# skip_if_not_installed("marginaleffects").
+
+library(surveycore)
+
+# ── Shared test fixtures ───────────────────────────────────────────────────────
+
+.me_taylor_gaussian <- function(seed = 1L) {
+  df  <- make_survey_data(n = 200L, n_psu = 20L, n_strata = 4L, seed = seed)
+  d   <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
+  survey_glm(d, y1 ~ y2)
+}
+
+.me_taylor_binomial <- function(seed = 1L) {
+  df       <- make_survey_data(n = 200L, n_psu = 20L, n_strata = 4L, seed = seed)
+  df$y_bin <- as.integer(df$y1 > median(df$y1))
+  d        <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
+  survey_glm(d, y_bin ~ y2, family = binomial("logit"))
+}
+
+# Helper: strip fit_ to simulate post-deserialization state
+.me_strip_fit <- function(fit) {
+  fit@fit_ <- NULL
+  fit
+}
+
+# ---------------------------------------------------------------------------
+# Item 1: get_coef() returns fit@coefficients (expect_identical)
+# ---------------------------------------------------------------------------
+
+test_that("get_coef() returns fit@coefficients exactly", {
+  skip_if_not_installed("marginaleffects")
+  fit    <- .me_taylor_gaussian()
+  result <- marginaleffects::get_coef(fit)
+  expect_identical(result, fit@coefficients)
+})
+
+# ---------------------------------------------------------------------------
+# Item 2: get_vcov() returns fit@vcov (expect_identical)
+# ---------------------------------------------------------------------------
+
+test_that("get_vcov() returns fit@vcov exactly", {
+  skip_if_not_installed("marginaleffects")
+  fit    <- .me_taylor_gaussian()
+  result <- marginaleffects::get_vcov(fit)
+  expect_identical(result, fit@vcov)
+})
+
+# ---------------------------------------------------------------------------
+# Item 3: set_coef() — S7 @coefficients property updated
+# ---------------------------------------------------------------------------
+
+test_that("set_coef() updates @coefficients in the returned object", {
+  skip_if_not_installed("marginaleffects")
+  fit       <- .me_taylor_gaussian()
+  new_coefs <- fit@coefficients * 2
+  modified  <- marginaleffects::set_coef(fit, new_coefs)
+  expect_identical(modified@coefficients, new_coefs)
+})
+
+# ---------------------------------------------------------------------------
+# Item 4: set_coef() — fit_$coefficients patched
+# ---------------------------------------------------------------------------
+
+test_that("set_coef() patches fit_$coefficients in the returned object", {
+  skip_if_not_installed("marginaleffects")
+  fit       <- .me_taylor_gaussian()
+  new_coefs <- fit@coefficients * 2
+  modified  <- marginaleffects::set_coef(fit, new_coefs)
+  expect_identical(modified@fit_$coefficients, new_coefs)
+})
+
+# ---------------------------------------------------------------------------
+# Item 5: set_coef() — original object is unmodified (copy-on-modify)
+# ---------------------------------------------------------------------------
+
+test_that("set_coef() does not modify the original fit object", {
+  skip_if_not_installed("marginaleffects")
+  fit            <- .me_taylor_gaussian()
+  original_coefs <- fit@coefficients
+  new_coefs      <- fit@coefficients * 2
+  marginaleffects::set_coef(fit, new_coefs)
+  expect_identical(fit@coefficients, original_coefs)
+})
+
+# ---------------------------------------------------------------------------
+# Item 6: get_predict() — correct structure and row count
+# ---------------------------------------------------------------------------
+
+test_that("get_predict() returns data frame with rowid and estimate; nrow matches newdata", {
+  skip_if_not_installed("marginaleffects")
+  fit     <- .me_taylor_gaussian()
+  newdata <- fit@fit_$model[1:10, , drop = FALSE]
+  result  <- marginaleffects::get_predict(fit, newdata = newdata)
+  expect_s3_class(result, "data.frame")
+  expect_true("rowid"    %in% names(result))
+  expect_true("estimate" %in% names(result))
+  expect_equal(nrow(result), 10L)
+  expect_type(result$rowid,    "integer")
+  expect_type(result$estimate, "double")
+})
+
+# ---------------------------------------------------------------------------
+# Item 7: avg_slopes() — Gaussian — AME matches OLS coefficient within 1e-6
+# ---------------------------------------------------------------------------
+
+test_that("avg_slopes() Gaussian: AME for continuous predictor matches coefficient within 1e-6", {
+  skip_if_not_installed("marginaleffects")
+  fit    <- .me_taylor_gaussian()
+  slopes <- marginaleffects::avg_slopes(fit, variables = "y2")
+  ame    <- slopes$estimate
+  coef   <- coef(fit)[["y2"]]
+  expect_equal(ame, coef, tolerance = 1e-6)
+})
+
+# ---------------------------------------------------------------------------
+# Item 8: avg_slopes() — binomial — on probability scale, differs from logit coef
+# ---------------------------------------------------------------------------
+
+test_that("avg_slopes() binomial: AME is on probability scale and differs from log-odds coef", {
+  skip_if_not_installed("marginaleffects")
+  fit    <- .me_taylor_binomial()
+  slopes <- marginaleffects::avg_slopes(fit, variables = "y2")
+  ame    <- slopes$estimate
+  logit_coef <- coef(fit)[["y2"]]
+  # AME should be in (-1, 1) — probability scale
+  expect_true(all(abs(ame) < 1))
+  # AME differs from log-odds coefficient (they live on different scales)
+  expect_false(isTRUE(all.equal(ame, logit_coef, tolerance = 1e-6)))
+})
+
+# ---------------------------------------------------------------------------
+# Item 9: avg_predictions() — binomial — estimates in [0, 1]
+# ---------------------------------------------------------------------------
+
+test_that("avg_predictions() binomial: estimate values are in [0, 1]", {
+  skip_if_not_installed("marginaleffects")
+  fit   <- .me_taylor_binomial()
+  preds <- marginaleffects::avg_predictions(fit)
+  expect_s3_class(preds, "data.frame")
+  expect_true("estimate" %in% names(preds))
+  expect_true(all(preds$estimate >= 0))
+  expect_true(all(preds$estimate <= 1))
+})
+
+# ---------------------------------------------------------------------------
+# Item 10: get_predict() with fit_ = NULL errors with surveycore_error_predict_no_fit
+# ---------------------------------------------------------------------------
+
+test_that("get_predict() with fit_ = NULL errors with surveycore_error_predict_no_fit", {
+  skip_if_not_installed("marginaleffects")
+  fit     <- .me_strip_fit(.me_taylor_gaussian())
+  newdata <- make_survey_data(n = 5L, seed = 99L)
+  expect_error(
+    marginaleffects::get_predict(fit, newdata = newdata),
+    class = "surveycore_error_predict_no_fit"
+  )
+})


### PR DESCRIPTION
## What

Implements the four S3 generics required by the marginaleffects extension
interface (`get_coef`, `set_coef`, `get_vcov`, `get_predict`) on
`survey_glm_fit`, enabling `avg_slopes()`, `avg_predictions()`, and the full
marginaleffects API with survey-corrected variance.

## Checklist

- [x] Tests written and passing (`devtools::test()`) — 6547 pass, 0 fail
- [x] R CMD check: 0 errors, 0 warnings (`devtools::check()`) — 2 pre-existing notes
- [x] Roxygen docs updated and `devtools::document()` run
- [ ] `plans/error-messages.md` updated (if new errors/warnings added) — N/A (no new error classes)
- [ ] `VENDORED.md` updated (if variance code vendored in this PR) — N/A
- [x] PR title is a valid Conventional Commit (`feat(scope): description`)
- [x] PR targets `develop`, not `main`

## Key implementation notes

- `set_coef.survey_glm_fit` patches both `@coefficients` (S7 property) and
  `@fit_$coefficients` (internal glm object); without the latter, `stats::predict.glm()`
  reads stale coefficients and all AMEs silently equal zero.
- `get_predict.survey_glm_fit` uses `newdata` (marginaleffects contract) forwarded
  to `predict.survey_glm_fit`'s `new_data` argument.
- marginaleffects ≥ 0.25 requires `options(marginaleffects_model_classes)` to include
  the class string `"surveycore::survey_glm_fit"`. Set in `.onLoad()` alongside
  `registerS3method()` calls.
- All four methods registered conditionally — when marginaleffects is not installed,
  all core `survey_glm_fit` functionality remains fully usable.