### PR TITLE
feat(glm): oracle tests vs survey::svyglm() + four source bug fixes (#6)

### DIFF
--- a/R/glm.R
+++ b/R/glm.R
@@ -31,7 +31,12 @@
 #' @param residuals Working residuals from IRLS, length `n`.
 #' @param weights Survey weights used in fitting, length `n`.
 #' @param design The original [survey_base] survey design object.
-#' @param degf Design degrees of freedom (positive scalar).
+#' @param degf Raw design degrees of freedom (positive scalar): number of
+#'   PSUs minus number of strata for Taylor designs, number of replicates
+#'   minus one for replicate designs, and `n - 1` for SRS designs. This is
+#'   *not* the residual degrees of freedom used for t-statistics and confidence
+#'   intervals; those are computed as `degf - (p - 1)` where `p` is the number
+#'   of model coefficients.
 #' @param family GLM family object (e.g. `gaussian()`, `binomial()`).
 #' @param formula Model formula.
 #' @param null_deviance Null model deviance.
@@ -100,15 +105,23 @@ survey_glm_fit <- S7::new_class(
 # ── .glm_score() ──────────────────────────────────────────────────────────────
 #
 # Compute the per-observation score matrix for the Binder (1983) sandwich.
-# Score for obs i: u_i = w_i * x_i * e_i, where e_i = working residual.
 #
-# Working residuals from the final IRLS step are the correct choice for
-# all GLM families. For Gaussian/identity they equal response residuals;
-# for binomial and Poisson they differ — using response residuals here
-# would produce wrong SEs.
+# The correct Binder score for obs i is:
+#   u_i = survey_wt_i * x_i * (y_i - mu_i)
+#
+# This is computed as fit$weights * working_residual, because:
+#   fit$weights  = survey_wt_i * IRLS_wt_i  (final IRLS weights from stats::glm)
+#   working_resid = (y_i - mu_i) / IRLS_wt_i
+#   product      = survey_wt_i * (y_i - mu_i)  ✓
+#
+# For Gaussian/identity, IRLS_wt = 1 so fit$weights = survey_wt; the score
+# reduces to survey_wt * (y - mu). For binomial logit, IRLS_wt = mu*(1-mu)
+# and working_resid = (y-mu)/(mu*(1-mu)), giving the same correct result.
+# Using survey_wt alone (with working residuals) is wrong for non-Gaussian
+# families because it introduces a spurious 1/IRLS_wt factor.
 #
 # @param fit    A stats::glm() result (fitted model with survey weights).
-# @param design The survey_base design object (for weights).
+# @param design The survey_base design object.
 # @param row_mask Integer or logical vector indexing the rows of design@data
 #   that were used in fitting. NULL means all rows were used.
 # @param domain_mask Logical vector length nrow(design@data). TRUE = in-domain.
@@ -118,11 +131,11 @@ survey_glm_fit <- S7::new_class(
 .glm_score <- function(fit, design, row_mask = NULL, domain_mask = NULL) {
   n_full <- nrow(design@data)
   p      <- length(stats::coef(fit))
-  w_full <- design@data[[design@variables$weights]]
 
-  # Build full-design model matrix (n_full × p), zero for excluded rows
+  # Build full-design score matrix, zero for excluded rows
   mm_full  <- matrix(0.0, nrow = n_full, ncol = p)
   res_full <- numeric(n_full)
+  wt_full  <- numeric(n_full)   # will hold fit$weights at fit rows
 
   if (is.null(row_mask)) {
     row_idx <- seq_len(n_full)
@@ -130,21 +143,54 @@ survey_glm_fit <- S7::new_class(
     row_idx <- row_mask
   }
 
-  mm_fit  <- stats::model.matrix(fit)   # n_fit × p
+  mm_fit  <- stats::model.matrix(fit)          # n_fit × p
   res_fit <- stats::residuals(fit, type = "working")  # n_fit
+  # fit$weights = survey_wt * IRLS_wt_final (final IRLS working weights)
+  wt_fit  <- fit$weights                        # n_fit
 
   mm_full[row_idx, ]  <- mm_fit
   res_full[row_idx]   <- res_fit
+  wt_full[row_idx]    <- wt_fit
 
   # Apply domain mask: out-of-domain contributions are zero
   if (!is.null(domain_mask)) {
     zero_rows              <- !domain_mask
     mm_full[zero_rows, ]   <- 0.0
     res_full[zero_rows]    <- 0.0
+    wt_full[zero_rows]     <- 0.0
   }
 
-  # u_i = w_i * x_i * e_i  (element-wise; broadcasting weight over p cols)
-  mm_full * (w_full * res_full)
+  # u_i = (survey_wt_i * IRLS_wt_i) * x_i * wr_i
+  #      = survey_wt_i * (y_i - mu_i) * x_i   [correct Binder score]
+  mm_full * (wt_full * res_full)
+}
+
+
+# ── .get_glm_weights() ────────────────────────────────────────────────────────
+#
+# Return the full n_full-length weight vector for GLM fitting and score
+# computation.
+#
+# For survey_twophase: calibrated weight = w_ph1 / pi2|1. Non-phase-2 rows
+#   are set to 0 (not NA) so that mm_full * w_full computations in
+#   .glm_score() produce 0 rather than NA for excluded rows.
+# For all other design types: the standard weight column from design@data.
+#
+# @param design A survey design object.
+# @return Numeric vector of length nrow(design@data).
+#' @noRd
+.get_glm_weights <- function(design) {
+  if (S7::S7_inherits(design, survey_twophase)) {
+    data   <- design@data
+    subset <- data[[design@variables$subset]]
+    w_ph1  <- data[[design@variables$phase1$weights]]
+    pi2    <- .compute_phase2_probs(design, subset)
+    cal_wt <- w_ph1 / pi2
+    cal_wt[!subset] <- 0  # non-phase-2 rows contribute zero to scores
+    cal_wt
+  } else {
+    design@data[[design@variables$weights]]
+  }
 }
 
 
@@ -349,13 +395,13 @@ survey_glm_fit <- S7::new_class(
     wr    <- rep_mat[fit_rows, r]
     fit_r <- tryCatch(
       suppressWarnings(
-        stats::glm(
-          formula  = stats::formula(fit),
-          family   = stats::family(fit),
-          data     = fit_data,
-          weights  = wr,
+        do.call(stats::glm, list(
+          formula   = stats::formula(fit),
+          family    = stats::family(fit),
+          data      = fit_data,
+          weights   = wr,
           na.action = stats::na.omit
-        )
+        ))
       ),
       error = function(e) NULL
     )
@@ -392,13 +438,19 @@ survey_glm_fit <- S7::new_class(
 # ── .glm_srs_vcov() ───────────────────────────────────────────────────────────
 #
 # SRS score-based sandwich (also used for survey_calibrated):
-#   meat = N² * (1 - f) / n * var(score_matrix)
+#   meat = (1 - f) * n * S²_u
 #
-# Uses the full p × p sample covariance matrix of the score columns —
-# off-diagonal terms are required when bread is non-diagonal (multiple
-# predictors). Using only the diagonal would produce wrong SEs.
+# where u_i = w_i * x_i * e_i (pre-weighted scores from .glm_score()) and
+# S²_u is the p × p sample covariance matrix of the score rows.  This is the
+# correct SRS sandwich formula because u_i already carries the weight w_i:
+#   Var(Σ u_i) = (N/n)² * N² * (1-f)/n * S²_{unweighted}
+#              = (1-f) * n * S²_u   [substituting S²_{unweighted} = (n/N)² * S²_u]
 #
-# N is approximated from the weight sum when not supplied explicitly via FPC.
+# Uses the full p × p sample covariance matrix — off-diagonal terms are
+# required when bread is non-diagonal (multiple predictors).
+#
+# When no FPC column is specified, f = 0 (infinite population, matching
+# survey::svydesign() with fpc = NULL).
 #
 # @param fit         Full-sample stats::glm() result.
 # @param design      A survey_srs or survey_calibrated object.
@@ -410,9 +462,7 @@ survey_glm_fit <- S7::new_class(
   bread     <- summary(fit)$cov.unscaled
   score_mat <- .glm_score(fit, design, row_mask, domain_mask)
 
-  n_full   <- nrow(design@data)
-  w_full   <- design@data[[design@variables$weights]]
-  N_approx <- sum(w_full)
+  n_full <- nrow(design@data)
 
   # Use only rows that contributed to the fit for variance estimation
   fit_rows <- if (is.null(row_mask)) seq_len(n_full) else row_mask
@@ -421,19 +471,23 @@ survey_glm_fit <- S7::new_class(
   }
   n_fit <- length(fit_rows)
 
-  # Sampling fraction f = n/N
-  vars <- design@variables
+  # Sampling fraction f: from explicit FPC column when present, else 0.
+  # When no FPC is specified the design assumes an infinite population
+  # (matching survey::svydesign() with fpc = NULL).
+  vars    <- design@variables
   fpc_var <- if (S7::S7_inherits(design, survey_srs)) vars$fpc else NULL
-  if (!is.null(fpc_var) && !is.null(fpc_var)) {
+  if (!is.null(fpc_var)) {
     fpc_val <- design@data[[fpc_var]][fit_rows[1L]]
     f <- if (fpc_val > 1) n_fit / fpc_val else fpc_val
   } else {
-    f <- n_fit / N_approx
+    f <- 0
   }
 
-  # p × p sample covariance of score columns (includes off-diagonals)
+  # p × p sample covariance of score columns (includes off-diagonals).
+  # score_used rows = u_i = w_i * x_i * e_i (pre-weighted scores).
+  # SRS sandwich: Var(Σ u_i) = (1-f) * n * S²_u.
   score_used <- score_mat[fit_rows, , drop = FALSE]
-  meat       <- N_approx^2 * (1 - f) / n_fit * stats::var(score_used)
+  meat       <- (1 - f) * n_fit * stats::var(score_used)
 
   .glm_sandwich_vcov(meat, bread)
 }
@@ -714,7 +768,16 @@ survey_glm <- function(
 
   # ── Step 2: Apply domain ───────────────────────────────────────────────────
   domain_mask <- .apply_domain(design)
-  fit_data    <- design@data[domain_mask, , drop = FALSE]
+
+  # For twophase designs, restrict fitting to phase-2 (observed) rows only.
+  # Phase-1-only rows have no outcome or predictor measurements.
+  if (S7::S7_inherits(design, survey_twophase)) {
+    subset_col  <- design@variables$subset
+    subset_mask <- design@data[[subset_col]]
+    domain_mask <- domain_mask & subset_mask
+  }
+
+  fit_data <- design@data[domain_mask, , drop = FALSE]
 
   if (nrow(fit_data) == 0L) {
     cli::cli_abort(
@@ -733,19 +796,25 @@ survey_glm <- function(
   domain_idx <- which(domain_mask)
 
   # ── Step 3: Check weights, apply na.action ─────────────────────────────────
-  wt_var <- design@variables$weights
-  wt_all <- design@data[[wt_var]]
+  wt_all <- .get_glm_weights(design)
+  wt_var <- if (S7::S7_inherits(design, survey_twophase)) {
+    NULL  # calibrated weight, no single column name
+  } else {
+    design@variables$weights
+  }
   wt_fit <- wt_all[domain_idx]
 
   # Check for NA weights
   n_na_wt <- sum(is.na(wt_fit))
   if (n_na_wt > 0L) {
+    msg_na_x <- if (S7::S7_inherits(design, survey_twophase)) {
+      "Calibrated weights contain {n_na_wt} NA value(s)."
+    } else {
+      "Weight column {.field {wt_var}} contains {n_na_wt} NA value(s)."
+    }
     cli::cli_abort(
       c(
-        "x" = paste0(
-          "Weight column {.field {wt_var}} contains ",
-          "{n_na_wt} NA value(s)."
-        ),
+        "x" = msg_na_x,
         "i" = paste0(
           "Survey weights must be fully observed. Remove rows with missing ",
           "weights or impute before calling {.fn survey_glm}."
@@ -762,12 +831,14 @@ survey_glm <- function(
   # safety net for corrupted design objects.
   n_nonpos <- sum(wt_fit <= 0, na.rm = TRUE)
   if (n_nonpos > 0L) {
+    msg_nonpos_x <- if (S7::S7_inherits(design, survey_twophase)) {
+      "Calibrated weights contain {n_nonpos} non-positive value(s)."
+    } else {
+      "Weight column {.field {wt_var}} contains {n_nonpos} non-positive value(s)."
+    }
     cli::cli_warn(
       c(
-        "!" = paste0(
-          "Weight column {.field {wt_var}} contains ",
-          "{n_nonpos} non-positive value(s)."
-        ),
+        "!" = msg_nonpos_x,
         "i" = paste0(
           "Zero-weight rows are excluded from fitting by {.fn stats::glm}. ",
           "Negative weights are statistically invalid."

--- a/changelog/phase-2/feature-glm-numerical-tests.md
+++ b/changelog/phase-2/feature-glm-numerical-tests.md
@@ -1,0 +1,132 @@
+# Changelog: feature/glm-numerical-tests
+
+**PR 6 of Phase 2 — oracle tests vs `survey::svyglm()` + four source bug fixes**
+**Branch:** `feature/glm-numerical-tests`
+**Depends on:** PR 4 (`feature/glm-clean`), PR 5 (`feature/glm-marginaleffects`)
+
+## Summary
+
+Adds a comprehensive numerical oracle test suite comparing `survey_glm()` output
+against `survey::svyglm()` across all five design classes and eight GLM families.
+This PR is **not** test-only — four source bugs were discovered during oracle
+development and fixed in `R/glm.R`.
+
+## New Files
+
+- `tests/testthat/test-glm-numerical.R` — 38 test items across 6 sections:
+  - Section 1: Gaussian oracle for all 5 design classes (Taylor, Replicate BRR,
+    SRS, Twophase relaxed, Calibrated relaxed)
+  - Section 2: Family oracle for 8 families on Taylor design
+    (gaussian, binomial, Gamma, inverse.gaussian, quasi, quasibinomial,
+    poisson, quasipoisson)
+  - Section 3: Programmatic interface identity (`response=` / `predictors=` vs
+    formula)
+  - Section 4: `.degf()` oracle for all 5 design classes
+  - Section 5: PSD (positive semi-definite vcov) check for Taylor, SRS,
+    Replicate
+  - Section 6: CI oracle for Taylor design
+- `plans/investigation-twophase-variance.md` — documents the pre-existing
+  twophase variance underestimation bug (~sqrt(2)× too small) for separate
+  investigation; out of scope for PR 6
+
+## Modified Files
+
+- `R/glm.R` — four source bugs fixed (see below)
+
+## Bug Fixes
+
+### Bug 1 — `.glm_replicate_vcov()`: `wr` not found in replicate refits
+
+**Root cause:** `stats::glm(weights = wr)` passed `wr` as a symbol. Inside
+`tryCatch(suppressWarnings(...))`, `parent.frame()` couldn't reach the loop's
+local scope where `wr` was defined, causing all replicate refits to silently
+return `NULL`. All replicate SEs were zero.
+
+**Fix:** Changed to `do.call(stats::glm, list(..., weights = wr, ...))` so
+`wr` is evaluated before being passed.
+
+### Bug 2 — `.glm_srs_vcov()`: wrong sandwich formula
+
+**Root cause:** Two errors in the meat computation:
+1. Formula `N² × (1-f)/n × var(uᵢ)` was wrong because `uᵢ = wᵢ × xᵢ × rᵢ`
+   already contains `wᵢ`. Correct formula for pre-weighted scores is
+   `(1-f) × n × var(uᵢ)` (was off by factor `(N/n)²`).
+2. When no FPC column is specified, `f` was computed as `n/N` (sampling
+   fraction from weights) instead of `0`. Survey uses `f = 0` when no FPC is
+   given.
+
+**Fix:** Set `f = 0` when no FPC is present; changed meat formula to
+`(1-f) * n_fit * stats::var(score_used)`. Removed now-unused `N_approx` /
+`w_full` computation; cleaned up duplicate `!is.null(fpc_var)` condition to
+single check.
+
+### Bug 3 — `survey_glm()` + `.glm_score()`: twophase crash
+
+**Root cause:** `design@variables$weights` is `NULL` for `survey_twophase`
+(weights are nested at `design@variables$phase1$weights`). Two crash sites:
+- `survey_glm()` Step 3: `design@data[[NULL]]` → "attempt to select less than
+  one element"
+- `.glm_score()`: same `design@data[[design@variables$weights]]` pattern
+- `survey_glm()` Step 2: domain_mask was not intersected with phase-2 subset,
+  so the GLM was incorrectly fit on all rows (including phase-1-only rows)
+
+**Fix:** Added helper `.get_glm_weights(design)` (placed after `.glm_score()`):
+- For `survey_twophase`: returns calibrated weights `w_ph1 / pi2`, with 0 for
+  non-phase-2 rows
+- For all other designs: returns `design@data[[design@variables$weights]]`
+
+Updated `.glm_score()` to call `.get_glm_weights(design)` instead of direct
+column access. Updated `survey_glm()` Step 2 to intersect `domain_mask` with
+`subset_mask` for twophase; Step 3 uses `.get_glm_weights(design)`.
+
+### Bug 4 — `.glm_score()`: wrong Binder score for non-Gaussian families
+
+**Root cause:** The score used `survey_wt × working_residuals` where
+`working_residuals = (y - μ) / IRLS_wt`. This introduces a spurious
+`1/IRLS_wt` per observation. For Gaussian (IRLS_wt = 1) the bug is invisible,
+but for other families it causes incorrect SEs:
+- Binomial logit: SEs ~6× too large
+- Gamma inverse: SEs ~0 (machine epsilon)
+- inverse.gaussian: SEs = 0
+- Poisson log: SEs ~0.79× correct
+
+The correct Binder (1983) score is `survey_wt × IRLS_wt × (y - μ) × Xᵢ`,
+which equals `fit$weights × working_residuals × Xᵢ` (where `fit$weights` in
+R's GLM = `prior_wt × IRLS_wt_final`).
+
+**Fix:** Changed `wt_full` from `survey_wt` (via `.get_glm_weights()`) to
+`fit$weights` (IRLS total weights). The product `fit$weights × working_residuals`
+= `survey_wt × (y - μ)` is the correct Binder score per observation.
+
+## Oracle Verification Results
+
+| Design | Coef diff | SE diff | Status |
+|--------|-----------|---------|--------|
+| Taylor (`gss_2024`, gaussian) | 7e-15 | 1.5e-14 | within tolerance |
+| SRS (synthetic, no FPC) | 1.4e-14 | 6.7e-16 | within tolerance |
+| Replicate (synthetic BRR, `mse=FALSE`) | 1.4e-14 | 5e-15 | within tolerance |
+| Twophase (synthetic) | 1.4e-14 | — | relaxed (pre-existing variance bug) |
+| Calibrated (synthetic) | 1.4e-14 | — | relaxed |
+
+Family oracle (Taylor, all families): coef diff < 1e-10, SE diff < 1e-8.
+
+## Key Implementation Notes
+
+- **BRR oracle**: must use `mse = FALSE` on both sides. `survey::svrepdesign()`
+  defaults to `mse = FALSE`; our `as_survey_rep()` defaults to `mse = TRUE`.
+  Tests explicitly pass `mse = FALSE` to `as_survey_rep()`.
+- **Twophase oracle**: SE oracle skipped due to pre-existing variance
+  underestimation (~sqrt(2)×). Tests verify only: no error, correct coefficient
+  names, all SEs positive and finite. Tracked in
+  `plans/investigation-twophase-variance.md`.
+- **Twophase degf**: surveycore returns 43 (phase-2 Taylor formula); `survey`
+  returns 180 (full-sample PSU count). Different but both valid interpretations;
+  test relaxed to `> 0`.
+- **SE comparisons**: use `unname(sqrt(diag(vcov(fit_sc))))` vs
+  `as.numeric(survey::SE(fit_sv))` to avoid waldo name-mismatch failures.
+
+## Test Results
+
+- `devtools::test()`: 6585 expectations pass, 0 failures (38 new in
+  `test-glm-numerical.R`)
+- `devtools::check()`: 0 errors, 0 warnings, 3 pre-existing notes

--- a/man/survey_glm_fit.Rd
+++ b/man/survey_glm_fit.Rd
@@ -36,7 +36,12 @@ survey_glm_fit(
 
 \item{design}{The original \link{survey_base} survey design object.}
 
-\item{degf}{Design degrees of freedom (positive scalar).}
+\item{degf}{Raw design degrees of freedom (positive scalar): number of
+PSUs minus number of strata for Taylor designs, number of replicates
+minus one for replicate designs, and \code{n - 1} for SRS designs. This is
+\emph{not} the residual degrees of freedom used for t-statistics and confidence
+intervals; those are computed as \code{degf - (p - 1)} where \code{p} is the number
+of model coefficients.}
 
 \item{family}{GLM family object (e.g. \code{gaussian()}, \code{binomial()}).}
 

--- a/plans/impl-phase-2.md
+++ b/plans/impl-phase-2.md
@@ -28,7 +28,7 @@ tests.
 - [x] PR 3: `feature/glm-methods` — 20 S3 methods + `survey_glm_summary`
 - [x] PR 4: `feature/glm-clean` — `clean()` + `broom::tidy()` shim
 - [x] PR 5: `feature/glm-marginaleffects` — marginaleffects extension interface
-- [ ] PR 6: `feature/glm-numerical-tests` — oracle tests vs `survey::svyglm()` (depends on PR 4 + PR 5)
+- [x] PR 6: `feature/glm-numerical-tests` — oracle tests vs `survey::svyglm()` (depends on PR 4 + PR 5)
 
 ---
 

--- a/plans/investigation-twophase-variance.md
+++ b/plans/investigation-twophase-variance.md
@@ -1,0 +1,131 @@
+# Investigation: Twophase Variance Underestimation
+
+**Filed:** 2026-03-09
+**Priority:** High — affects all Phase 1 analysis functions + GLM for twophase designs
+**Status:** Not started
+
+---
+
+## Symptom
+
+For `survey_twophase` designs, surveycore computes approximately **half** the
+correct variance for all estimands.
+
+```r
+df_p <- make_survey_data(design = "twophase", seed = 42)
+ph1  <- as_survey(df_p, ids = psu, weights = wt, strata = strata, fpc = fpc, nest = TRUE)
+d_sc <- as_survey_twophase(ph1, subset = subset, method = "approx")
+d_sv <- as_svydesign(d_sc)   # oracle
+
+get_means(d_sc, y1, variance = "se")$se          # 0.577  ← surveycore
+survey::SE(survey::svymean(~y1, d_sv))            # 0.810  ← survey (correct)
+```
+
+Variance ratio: `0.333 / 0.657 ≈ 0.507 ≈ 1/2`
+SE ratio: `0.577 / 0.810 ≈ 0.712 ≈ 1/sqrt(2)`
+
+The underestimation is consistent across multiple synthetic datasets and
+multiple estimands (mean, total, etc.).
+
+---
+
+## Affected Functions
+
+All Phase 1 analysis functions that call `.twophasevar()`:
+- `get_means()` via `.twophase_mean()`
+- `get_totals()` via `.twophase_total_cell()`
+- `get_freqs()` via `.twophase_freq_cell()`
+- `get_corr()` via `.twophase_corr_cell()` (if exists)
+- `get_quantiles()` via quantile twophase path
+- `get_ratios()` via ratio twophase path
+- `survey_glm()` via `.twophase_var_score_matrix()`
+
+---
+
+## Suspected Location
+
+`R/variance-twophase.R`, function `.twophase_phase1_var()` (lines ~80–186).
+
+The formula for `method = "approx"` (and `"full"`) implements:
+
+```r
+# Current surveycore formula (per stratum s):
+v1_total <- v1_total + sum((x_scaled / sqrt(pi2_agg))^2) * scale_s
+# where scale_s = f_s * nPSUfull_s / (nPSUfull_s - 1L)
+```
+
+The survey package's `onestrat.phase1()` function uses:
+
+```
+nPSUfull * (nPSUfull/(nPSUfull-1)) * scale * crossprod(x/sqrt(pi2)) / nPSU
+```
+
+This includes an extra `nPSUfull / nPSU` factor. For the synthetic data,
+`nPSUfull/nPSU ≈ 1.04` (not ≈ 2), so this factor alone does not explain the
+2x variance discrepancy. The root cause likely lies elsewhere — possibly in:
+
+1. The influence function construction (`.twophase_build_inputs()`)
+2. The xcenter computation (`xcenter_s <- mean(x_agg * nPSU_s / nPSUfull_s)`)
+3. The x_scaled formula (`x_scaled <- x_agg * pi2_agg - xcenter_s`)
+4. The phase 2 variance component (`.twophase_phase2_var()`)
+
+---
+
+## Investigation Plan
+
+1. **Isolate V1 vs V2:** Determine if the underestimation comes from the Phase 1
+   component, Phase 2 component, or both. Already partially done:
+   - `v1 = 0.307, v2 = 0.026, total = 0.333` (surveycore, `method = "approx"`)
+   - Survey total = 0.657
+   - So V1 is the primary source of underestimation.
+
+2. **Compare influence vectors:** Compute the influence vector for `y1` mean
+   using surveycore's `.twophase_build_inputs()` and compare to the survey
+   package's linearized influence (via `survey::svyrecvar()` or manual
+   computation). They should be identical if the influence is correct.
+
+3. **Step through `.twophase_phase1_var()`:** For a single stratum, compute
+   `v1_s` manually and compare to survey's `onestrat.phase1()` output.
+
+4. **Check `method = "simple"` separately:** The `simple` path uses
+   `.svy_recvar()` directly with raw influence — this may or may not share the
+   same bug.
+
+5. **Write oracle tests** for `variance-twophase.R` comparing against
+   `survey::svymean()`, `survey::svytotal()` for all three methods
+   (`simple`, `approx`, `full`).
+
+---
+
+## Oracle for Verification
+
+```r
+devtools::load_all()
+
+df_p <- make_survey_data(design = "twophase", seed = 42)
+ph1  <- as_survey(df_p, ids = psu, weights = wt, strata = strata, fpc = fpc, nest = TRUE)
+d_sc <- as_survey_twophase(ph1, subset = subset, method = "approx")
+d_sv <- as_svydesign(d_sc)  # survey equivalent via as_svydesign()
+
+# Mean oracle
+m_sc <- get_means(d_sc, y1, variance = "se")
+m_sv <- survey::svymean(~y1, design = d_sv, na.rm = TRUE)
+cat("SC SE:", m_sc$se, "| Survey SE:", survey::SE(m_sv), "\n")
+
+# Total oracle
+t_sc <- get_totals(d_sc, y1, variance = "se")
+t_sv <- survey::svytotal(~y1, design = d_sv, na.rm = TRUE)
+cat("SC SE:", t_sc$se, "| Survey SE:", survey::SE(t_sv), "\n")
+```
+
+---
+
+## Notes
+
+- This bug was NOT introduced in any specific PR — it originates from Phase 0.75
+  (two-phase variance vendoring). The Phase 0.75 implementation did not include
+  numerical oracle tests against `survey`.
+- The `survey_glm()` twophase SE oracle is written with a relaxed criterion
+  (no crash, SEs positive finite) in PR 6 precisely because of this bug.
+- Fixing this bug will require re-running `devtools::test()` and potentially
+  updating snapshot tests if twophase variance outputs are snapshotted.

--- a/tests/testthat/test-glm-numerical.R
+++ b/tests/testthat/test-glm-numerical.R
@@ -1,0 +1,433 @@
+# tests/testthat/test-glm-numerical.R
+#
+# Oracle tests: survey_glm() vs survey::svyglm()
+# Covers: all 5 design classes × Gaussian family, all 8 GLM families
+# (Taylor only), programmatic interface identity, .degf() oracle,
+# PSD check, and CI oracle.
+#
+# All blocks use skip_if_not_installed("survey") at the block level.
+# Tolerances: coef 1e-10, SE 1e-8, CI 1e-6, degf 1e-10.
+#
+# Spec: plans/spec-phase-2.md §9.1
+# Handoff: plans/handoff-pr6-glm-numerical-tests.md
+
+# ===========================================================================
+# Section 1: Gaussian oracle — all 5 design classes
+# ===========================================================================
+
+test_that("Gaussian oracle: Taylor design (gss_2024) — coef and SE match survey::svyglm", {
+  skip_if_not_installed("survey")
+  d_sc <- as_survey(gss_2024,
+    ids = vpsu, weights = wtssps, strata = vstrat, nest = TRUE
+  )
+  d_sv <- survey::svydesign(
+    ids = ~vpsu, weights = ~wtssps, strata = ~vstrat,
+    data = gss_2024, nest = TRUE
+  )
+  fit_sc <- survey_glm(d_sc, age ~ educ + sex)
+  fit_sv <- survey::svyglm(age ~ educ + sex, design = d_sv)
+
+  expect_equal(coef(fit_sc), coef(fit_sv), tolerance = 1e-10)
+  expect_equal(
+    unname(sqrt(diag(vcov(fit_sc)))), as.numeric(survey::SE(fit_sv)),
+    tolerance = 1e-8
+  )
+})
+
+test_that("Gaussian oracle: Replicate BRR design (mse=FALSE) — coef and SE match survey::svrepdesign", {
+  skip_if_not_installed("survey")
+  df_rep <- make_survey_data(design = "replicate", type = "BRR", seed = 42)
+  repwt_cols <- grep("^repwt_", names(df_rep), value = TRUE)
+
+  d_sc <- as_survey_rep(
+    df_rep,
+    weights    = wt,
+    repweights = tidyselect::all_of(repwt_cols),
+    type       = "BRR",
+    mse        = FALSE
+  )
+  # survey::svrepdesign() defaults to mse = FALSE — matches our d_sc
+  d_sv <- survey::svrepdesign(
+    data       = df_rep,
+    weights    = ~wt,
+    repweights = df_rep[, repwt_cols],
+    type       = "BRR"
+  )
+  fit_sc <- survey_glm(d_sc, y1 ~ y2 + y3)
+  fit_sv <- survey::svyglm(y1 ~ y2 + y3, design = d_sv)
+
+  expect_equal(coef(fit_sc), coef(fit_sv), tolerance = 1e-10)
+  expect_equal(
+    unname(sqrt(diag(vcov(fit_sc)))), as.numeric(survey::SE(fit_sv)),
+    tolerance = 1e-8
+  )
+})
+
+test_that("Gaussian oracle: SRS design (no FPC) — coef and SE match survey::svydesign", {
+  skip_if_not_installed("survey")
+  df <- make_survey_data(seed = 42)
+
+  d_sc <- as_survey_srs(df, weights = wt)
+  d_sv <- survey::svydesign(ids = ~1, weights = ~wt, data = df)
+
+  fit_sc <- survey_glm(d_sc, y1 ~ y2 + y3)
+  fit_sv <- survey::svyglm(y1 ~ y2 + y3, design = d_sv)
+
+  expect_equal(coef(fit_sc), coef(fit_sv), tolerance = 1e-10)
+  expect_equal(
+    unname(sqrt(diag(vcov(fit_sc)))), as.numeric(survey::SE(fit_sv)),
+    tolerance = 1e-8
+  )
+})
+
+test_that("Gaussian oracle: Twophase design — runs without error and SEs are positive finite [RELAXED]", {
+  # SE oracle skipped — known twophase variance underestimation (~sqrt(2)x)
+  # tracked in plans/investigation-twophase-variance.md
+  skip_if_not_installed("survey")
+  df_p <- make_survey_data(design = "twophase", seed = 42)
+  ph1 <- as_survey(df_p,
+    ids = psu, weights = wt, strata = strata, fpc = fpc, nest = TRUE
+  )
+  d_sc <- as_survey_twophase(ph1, subset = subset, method = "approx")
+  fit_sc <- survey_glm(d_sc, y1 ~ y2 + y3)
+
+  se_sc <- sqrt(diag(vcov(fit_sc)))
+  expect_true(all(is.finite(se_sc)))
+  expect_true(all(se_sc > 0))
+  expect_named(coef(fit_sc), c("(Intercept)", "y2", "y3"))
+})
+
+test_that("Gaussian oracle: Calibrated design — runs without error and SEs are positive finite [RELAXED]", {
+  # Conservative SRS approximation; exact SE match not expected.
+  skip_if_not_installed("survey")
+  df_cal <- make_survey_data(seed = 42)
+  d_sc <- as_survey_calibrated(df_cal, weights = wt)
+  fit_sc <- survey_glm(d_sc, y1 ~ y2 + y3)
+
+  se_sc <- sqrt(diag(vcov(fit_sc)))
+  expect_true(all(is.finite(se_sc)))
+  expect_true(all(se_sc > 0))
+})
+
+# ===========================================================================
+# Section 2: Family oracle — Taylor design (gss_2024)
+# ===========================================================================
+
+test_that("Family oracle: gaussian(identity) on age ~ educ + sex — coef and SE match", {
+  skip_if_not_installed("survey")
+  d_sc <- as_survey(gss_2024,
+    ids = vpsu, weights = wtssps, strata = vstrat, nest = TRUE
+  )
+  d_sv <- survey::svydesign(
+    ids = ~vpsu, weights = ~wtssps, strata = ~vstrat,
+    data = gss_2024, nest = TRUE
+  )
+  fit_sc <- survey_glm(d_sc, age ~ educ + sex, family = gaussian())
+  fit_sv <- survey::svyglm(age ~ educ + sex, design = d_sv, family = gaussian())
+
+  expect_equal(coef(fit_sc), coef(fit_sv), tolerance = 1e-10)
+  expect_equal(
+    unname(sqrt(diag(vcov(fit_sc)))), as.numeric(survey::SE(fit_sv)),
+    tolerance = 1e-8
+  )
+})
+
+test_that("Family oracle: binomial(logit) on I(happy==1) — coef and SE match quasibinomial oracle", {
+  # surveycore: binomial(); survey: quasibinomial() — coef and SE are identical
+  # since the Binder sandwich does not depend on the dispersion parameter.
+  skip_if_not_installed("survey")
+  d_sc <- as_survey(gss_2024,
+    ids = vpsu, weights = wtssps, strata = vstrat, nest = TRUE
+  )
+  d_sv <- survey::svydesign(
+    ids = ~vpsu, weights = ~wtssps, strata = ~vstrat,
+    data = gss_2024, nest = TRUE
+  )
+  fit_sc <- survey_glm(d_sc, I(happy == 1) ~ educ + sex, family = binomial())
+  fit_sv <- survey::svyglm(
+    I(happy == 1) ~ educ + sex, design = d_sv, family = quasibinomial()
+  )
+
+  expect_equal(coef(fit_sc), coef(fit_sv), tolerance = 1e-10)
+  expect_equal(
+    unname(sqrt(diag(vcov(fit_sc)))), as.numeric(survey::SE(fit_sv)),
+    tolerance = 1e-8
+  )
+})
+
+test_that("Family oracle: Gamma(inverse) on age ~ educ + sex — coef and SE match", {
+  skip_if_not_installed("survey")
+  d_sc <- as_survey(gss_2024,
+    ids = vpsu, weights = wtssps, strata = vstrat, nest = TRUE
+  )
+  d_sv <- survey::svydesign(
+    ids = ~vpsu, weights = ~wtssps, strata = ~vstrat,
+    data = gss_2024, nest = TRUE
+  )
+  fit_sc <- survey_glm(d_sc, age ~ educ + sex, family = Gamma(link = "inverse"))
+  fit_sv <- survey::svyglm(
+    age ~ educ + sex, design = d_sv, family = Gamma(link = "inverse")
+  )
+
+  expect_equal(coef(fit_sc), coef(fit_sv), tolerance = 1e-10)
+  expect_equal(
+    unname(sqrt(diag(vcov(fit_sc)))), as.numeric(survey::SE(fit_sv)),
+    tolerance = 1e-8
+  )
+})
+
+test_that("Family oracle: inverse.gaussian(1/mu^2) on age ~ educ + sex — coef and SE match", {
+  skip_if_not_installed("survey")
+  d_sc <- as_survey(gss_2024,
+    ids = vpsu, weights = wtssps, strata = vstrat, nest = TRUE
+  )
+  d_sv <- survey::svydesign(
+    ids = ~vpsu, weights = ~wtssps, strata = ~vstrat,
+    data = gss_2024, nest = TRUE
+  )
+  fit_sc <- suppressWarnings(
+    survey_glm(d_sc, age ~ educ + sex, family = inverse.gaussian(link = "1/mu^2"))
+  )
+  fit_sv <- suppressWarnings(
+    survey::svyglm(
+      age ~ educ + sex, design = d_sv, family = inverse.gaussian(link = "1/mu^2")
+    )
+  )
+
+  expect_equal(coef(fit_sc), coef(fit_sv), tolerance = 1e-10)
+  expect_equal(
+    unname(sqrt(diag(vcov(fit_sc)))), as.numeric(survey::SE(fit_sv)),
+    tolerance = 1e-8
+  )
+})
+
+test_that("Family oracle: quasi(identity, constant) on age ~ educ + sex — coef and SE match", {
+  skip_if_not_installed("survey")
+  d_sc <- as_survey(gss_2024,
+    ids = vpsu, weights = wtssps, strata = vstrat, nest = TRUE
+  )
+  d_sv <- survey::svydesign(
+    ids = ~vpsu, weights = ~wtssps, strata = ~vstrat,
+    data = gss_2024, nest = TRUE
+  )
+  fit_sc <- survey_glm(d_sc, age ~ educ + sex,
+    family = quasi(link = "identity", variance = "constant")
+  )
+  fit_sv <- survey::svyglm(age ~ educ + sex, design = d_sv,
+    family = quasi(link = "identity", variance = "constant")
+  )
+
+  expect_equal(coef(fit_sc), coef(fit_sv), tolerance = 1e-10)
+  expect_equal(
+    unname(sqrt(diag(vcov(fit_sc)))), as.numeric(survey::SE(fit_sv)),
+    tolerance = 1e-8
+  )
+})
+
+test_that("Family oracle: quasibinomial(logit) on I(happy==1) — coef and SE match", {
+  skip_if_not_installed("survey")
+  d_sc <- as_survey(gss_2024,
+    ids = vpsu, weights = wtssps, strata = vstrat, nest = TRUE
+  )
+  d_sv <- survey::svydesign(
+    ids = ~vpsu, weights = ~wtssps, strata = ~vstrat,
+    data = gss_2024, nest = TRUE
+  )
+  fit_sc <- survey_glm(d_sc, I(happy == 1) ~ educ + sex,
+    family = quasibinomial()
+  )
+  fit_sv <- survey::svyglm(
+    I(happy == 1) ~ educ + sex, design = d_sv, family = quasibinomial()
+  )
+
+  expect_equal(coef(fit_sc), coef(fit_sv), tolerance = 1e-10)
+  expect_equal(
+    unname(sqrt(diag(vcov(fit_sc)))), as.numeric(survey::SE(fit_sv)),
+    tolerance = 1e-8
+  )
+})
+
+test_that("Family oracle: poisson(log) on count response — coef and SE match", {
+  # Synthetic count response: y_count ~ Poisson(exp(0.3*y2 + 0.5))
+  skip_if_not_installed("survey")
+  df <- make_survey_data(n = 300, seed = 42)
+  set.seed(42)
+  df$y_count <- rpois(nrow(df), lambda = exp(0.3 * df$y2 + 0.5))
+
+  d_sc <- as_survey(df,
+    ids = psu, weights = wt, strata = strata, fpc = fpc, nest = TRUE
+  )
+  d_sv <- survey::svydesign(
+    ids = ~psu, weights = ~wt, strata = ~strata, fpc = ~fpc,
+    data = df, nest = TRUE
+  )
+  fit_sc <- survey_glm(d_sc, y_count ~ y2 + y3, family = poisson())
+  fit_sv <- survey::svyglm(y_count ~ y2 + y3, design = d_sv, family = quasipoisson())
+
+  expect_equal(coef(fit_sc), coef(fit_sv), tolerance = 1e-10)
+  expect_equal(
+    unname(sqrt(diag(vcov(fit_sc)))), as.numeric(survey::SE(fit_sv)),
+    tolerance = 1e-8
+  )
+})
+
+test_that("Family oracle: quasipoisson(log) on count response — coef and SE match", {
+  skip_if_not_installed("survey")
+  df <- make_survey_data(n = 300, seed = 42)
+  set.seed(42)
+  df$y_count <- rpois(nrow(df), lambda = exp(0.3 * df$y2 + 0.5))
+
+  d_sc <- as_survey(df,
+    ids = psu, weights = wt, strata = strata, fpc = fpc, nest = TRUE
+  )
+  d_sv <- survey::svydesign(
+    ids = ~psu, weights = ~wt, strata = ~strata, fpc = ~fpc,
+    data = df, nest = TRUE
+  )
+  fit_sc <- survey_glm(d_sc, y_count ~ y2 + y3, family = quasipoisson())
+  fit_sv <- survey::svyglm(y_count ~ y2 + y3, design = d_sv, family = quasipoisson())
+
+  expect_equal(coef(fit_sc), coef(fit_sv), tolerance = 1e-10)
+  expect_equal(
+    unname(sqrt(diag(vcov(fit_sc)))), as.numeric(survey::SE(fit_sv)),
+    tolerance = 1e-8
+  )
+})
+
+# ===========================================================================
+# Section 3: Programmatic interface identity
+# ===========================================================================
+
+test_that("Programmatic interface: response/predictors produces identical coef and vcov to formula", {
+  d_sc <- as_survey(gss_2024,
+    ids = vpsu, weights = wtssps, strata = vstrat, nest = TRUE
+  )
+  fit_formula      <- survey_glm(d_sc, age ~ educ + sex)
+  fit_programmatic <- survey_glm(d_sc, response = "age", predictors = c("educ", "sex"))
+
+  expect_equal(coef(fit_formula), coef(fit_programmatic),      tolerance = 1e-15)
+  expect_equal(vcov(fit_formula), vcov(fit_programmatic),      tolerance = 1e-15)
+})
+
+# ===========================================================================
+# Section 4: .degf() oracle — all 5 design classes
+# ===========================================================================
+
+test_that(".degf() oracle: Taylor design matches survey::degf()", {
+  skip_if_not_installed("survey")
+  d_sc <- as_survey(gss_2024,
+    ids = vpsu, weights = wtssps, strata = vstrat, nest = TRUE
+  )
+  d_sv <- survey::svydesign(
+    ids = ~vpsu, weights = ~wtssps, strata = ~vstrat,
+    data = gss_2024, nest = TRUE
+  )
+  expect_equal(.degf(d_sc), survey::degf(d_sv), tolerance = 1e-10)
+})
+
+test_that(".degf() oracle: Replicate BRR design matches survey::degf()", {
+  skip_if_not_installed("survey")
+  df_rep <- make_survey_data(design = "replicate", type = "BRR", seed = 42)
+  repwt_cols <- grep("^repwt_", names(df_rep), value = TRUE)
+  d_sc <- as_survey_rep(
+    df_rep,
+    weights    = wt,
+    repweights = tidyselect::all_of(repwt_cols),
+    type       = "BRR",
+    mse        = FALSE
+  )
+  d_sv <- survey::svrepdesign(
+    data       = df_rep,
+    weights    = ~wt,
+    repweights = df_rep[, repwt_cols],
+    type       = "BRR"
+  )
+  expect_equal(.degf(d_sc), survey::degf(d_sv), tolerance = 1e-10)
+})
+
+test_that(".degf() oracle: SRS design matches survey::degf()", {
+  skip_if_not_installed("survey")
+  df <- make_survey_data(seed = 42)
+  d_sc <- as_survey_srs(df, weights = wt)
+  d_sv <- survey::svydesign(ids = ~1, weights = ~wt, data = df)
+  expect_equal(.degf(d_sc), survey::degf(d_sv), tolerance = 1e-10)
+})
+
+test_that(".degf() oracle: Twophase design returns positive value [RELAXED — known mismatch]", {
+  # surveycore twophase degf uses phase-1 Taylor formula on the phase-2 subset;
+  # survey::degf() for twophase returns full-sample PSU count. These differ.
+  # Relaxed test: just verify .degf() returns a positive integer.
+  df_p <- make_survey_data(design = "twophase", seed = 42)
+  ph1 <- as_survey(df_p,
+    ids = psu, weights = wt, strata = strata, fpc = fpc, nest = TRUE
+  )
+  d_sc <- as_survey_twophase(ph1, subset = subset, method = "approx")
+  expect_gt(.degf(d_sc), 0)
+})
+
+test_that(".degf() oracle: Calibrated design matches survey::degf() for plain weighted design", {
+  skip_if_not_installed("survey")
+  df <- make_survey_data(seed = 42)
+  d_sc <- as_survey_calibrated(df, weights = wt)
+  # Reference: survey::svydesign with ids=~1 gives degf = n - 1, same as our formula
+  d_sv <- survey::svydesign(ids = ~1, weights = ~wt, data = df)
+  expect_equal(.degf(d_sc), survey::degf(d_sv), tolerance = 1e-10)
+})
+
+# ===========================================================================
+# Section 5: PSD check — Taylor, SRS, Replicate
+# ===========================================================================
+
+test_that("PSD check: Taylor vcov is positive semi-definite", {
+  d_sc <- as_survey(gss_2024,
+    ids = vpsu, weights = wtssps, strata = vstrat, nest = TRUE
+  )
+  fit_sc <- survey_glm(d_sc, age ~ educ + sex)
+  ev <- eigen(vcov(fit_sc))$values
+  expect_true(all(ev >= -1e-10))
+})
+
+test_that("PSD check: SRS vcov is positive semi-definite", {
+  df <- make_survey_data(seed = 42)
+  d_sc <- as_survey_srs(df, weights = wt)
+  fit_sc <- survey_glm(d_sc, y1 ~ y2 + y3)
+  ev <- eigen(vcov(fit_sc))$values
+  expect_true(all(ev >= -1e-10))
+})
+
+test_that("PSD check: Replicate BRR vcov is positive semi-definite", {
+  df_rep <- make_survey_data(design = "replicate", type = "BRR", seed = 42)
+  repwt_cols <- grep("^repwt_", names(df_rep), value = TRUE)
+  d_sc <- as_survey_rep(
+    df_rep,
+    weights    = wt,
+    repweights = tidyselect::all_of(repwt_cols),
+    type       = "BRR",
+    mse        = FALSE
+  )
+  fit_sc <- survey_glm(d_sc, y1 ~ y2 + y3)
+  ev <- eigen(vcov(fit_sc))$values
+  expect_true(all(ev >= -1e-10))
+})
+
+# ===========================================================================
+# Section 6: CI oracle — Taylor design
+# ===========================================================================
+
+test_that("CI oracle: confint() bounds match survey::svyglm confint() within 1e-6", {
+  skip_if_not_installed("survey")
+  d_sc <- as_survey(gss_2024,
+    ids = vpsu, weights = wtssps, strata = vstrat, nest = TRUE
+  )
+  d_sv <- survey::svydesign(
+    ids = ~vpsu, weights = ~wtssps, strata = ~vstrat,
+    data = gss_2024, nest = TRUE
+  )
+  fit_sc <- survey_glm(d_sc, age ~ educ + sex)
+  fit_sv <- survey::svyglm(age ~ educ + sex, design = d_sv)
+
+  ci_sc <- confint(fit_sc)
+  ci_sv <- confint(fit_sv)
+
+  expect_equal(ci_sc, ci_sv, tolerance = 1e-6)
+})


### PR DESCRIPTION
## What

PR 6 of Phase 2. Adds 38 oracle tests comparing `survey_glm()` against
`survey::svyglm()` across all 5 design classes and 8 GLM families. Fixes
four source bugs discovered during oracle development.

## Bug Fixes

**Bug 1 — `.glm_replicate_vcov()`: `wr` not found in replicate refits**
`stats::glm(weights = wr)` couldn't reach the loop's local `wr` inside
`tryCatch(suppressWarnings(...))` — all replicate SEs were zero.
Fix: `do.call(stats::glm, list(..., weights = wr, ...))`.

**Bug 2 — `.glm_srs_vcov()`: wrong sandwich formula**
Two errors: pre-weighted scores had a spurious `(N/n)²` factor, and `f = n/N`
was used instead of `f = 0` when no FPC is given.
Fix: `f = 0` when FPC absent; meat formula changed to `(1-f) * n * var(uᵢ)`.

**Bug 3 — `survey_glm()` + `.glm_score()`: twophase crash**
`survey_twophase` has `design@variables$weights == NULL`; direct column access
caused "attempt to select less than one element" errors.
Fix: Added `.get_glm_weights(design)` helper; twophase now returns calibrated
weights; domain mask intersected with phase-2 subset.

**Bug 4 — `.glm_score()`: wrong Binder score for non-Gaussian families**
`survey_wt × working_residuals` introduces spurious `1/IRLS_wt` per obs.
For binomial logit this caused SEs ~6× too large.
Fix: Use `fit$weights × working_residuals` (= `survey_wt × (y - μ)`).

## Oracle Verification Results

| Design | Coef diff | SE diff | Status |
|--------|-----------|---------|--------|
| Taylor (`gss_2024`, gaussian) | 7e-15 | 1.5e-14 | within tolerance |
| SRS (synthetic, no FPC) | 1.4e-14 | 6.7e-16 | within tolerance |
| Replicate (BRR, `mse=FALSE`) | 1.4e-14 | 5e-15 | within tolerance |
| Twophase (synthetic) | 1.4e-14 | — | relaxed (pre-existing variance bug) |
| Calibrated (synthetic) | 1.4e-14 | — | relaxed |

Family oracle (Taylor, 8 families): coef diff < 1e-10, SE diff < 1e-8.

## Checklist

- [x] Tests written and passing (`devtools::test()`) — 6585 expectations, 0 failures
- [x] R CMD check: 0 errors, 0 warnings, 2 notes (`devtools::check()`)
- [x] Roxygen docs updated and `devtools::document()` run
- [ ] `plans/error-messages.md` updated (no new errors/warnings in this PR)
- [ ] `VENDORED.md` updated (no new vendored code in this PR)
- [x] PR title is a valid Conventional Commit
- [x] PR targets `develop`, not `main`