### PR TITLE
fix(variance): correct pi2 in two-phase Phase 1 variance formula

### DIFF
--- a/R/variance-twophase.R
+++ b/R/variance-twophase.R
@@ -46,11 +46,8 @@
     }
   }
 
-  # Phase 2 conditional inclusion probabilities (pi2|1)
-  pi2 <- .compute_phase2_probs(design, subset)
-
   # Phase 1 variance contribution
-  v1 <- .twophase_phase1_var(influence, design, pi2, method, lonely.psu)
+  v1 <- .twophase_phase1_var(influence, design, method, lonely.psu)
 
   if (identical(method, "simple")) {
     return(v1)
@@ -74,10 +71,11 @@
 #   V1 = sum_s { nPSUfull_s/(nPSUfull_s-1) *
 #                sum_j { ((x_j * pi2_j - xcenter_s) / sqrt(pi2_j))^2 } }
 # where nPSU_s = phase 2 PSUs in stratum, nPSUfull_s = phase 1 PSUs in stratum,
+# pi2_j = nPSU_s/nPSUfull_s (PSU-level stratum sampling fraction, survey's `usu`),
 # and xcenter_s = mean(x_j * nPSU_s/nPSUfull_s) centering term.
 # Returns a numeric scalar.
 #' @noRd
-.twophase_phase1_var <- function(influence, design, pi2, method, lonely.psu) {
+.twophase_phase1_var <- function(influence, design, method, lonely.psu) {
   ph1_data <- design@data
   ph1_vars <- design@variables$phase1
   subset   <- design@data[[design@variables$subset]]
@@ -133,13 +131,33 @@
   # full or approx: implement onestrat.phase1 formula using phase 2 rows only
   ph2_idx  <- which(subset)
   infl_ph2 <- influence[ph2_idx]
-  pi2_ph2  <- pi2[ph2_idx]
   strata_ph2 <- strata_all[ph2_idx]
   psu_ph2    <- psu_all[ph2_idx]
 
   # nPSUfull per phase 1 stratum (total distinct PSU IDs across all n1 rows)
   nPSUfull_by_strat <- tapply(psu_all, strata_all,
                                function(p) length(unique(p)))
+
+  # Compute per-row Phase 2 PSU sampling fraction (survey's `usu`).
+  # With phase 2 strata: n_ph2_PSU_in_strata2 / n_ph1_PSU_in_strata2 per Phase 2 row.
+  # Without phase 2 strata: n_ph2_PSU_in_ph1_strat / n_ph1_PSU_in_ph1_strat per Phase 2 row.
+  strata2_var <- design@variables$phase2$strata
+  if (!is.null(strata2_var)) {
+    strata2_all <- ph1_data[[strata2_var]]
+    strata2_ph2 <- strata2_all[ph2_idx]
+    n_ph2_by_s2 <- tapply(psu_ph2, strata2_ph2, function(p) length(unique(p)))
+    n_ph1_by_s2 <- tapply(psu_all, strata2_all, function(p) length(unique(p)))
+    usu_ph2 <- as.numeric(
+      n_ph2_by_s2[as.character(strata2_ph2)] /
+        n_ph1_by_s2[as.character(strata2_ph2)]
+    )
+  } else {
+    n_ph2_by_strat <- tapply(psu_ph2, strata_ph2, function(p) length(unique(p)))
+    usu_ph2 <- as.numeric(
+      n_ph2_by_strat[as.character(strata_ph2)] /
+        nPSUfull_by_strat[as.character(strata_ph2)]
+    )
+  }
 
   # Phase 1 FPC column (if provided)
   fpc_all <- if (!is.null(ph1_vars$fpc)) ph1_data[[ph1_vars$fpc]] else NULL
@@ -151,14 +169,15 @@
   for (s in unique_strata) {
     idx_s       <- which(strata_ph2 == s)
     x_s         <- infl_ph2[idx_s]
-    pi2_s       <- pi2_ph2[idx_s]
     psu_s       <- psu_ph2[idx_s]
     nPSUfull_s  <- as.integer(nPSUfull_by_strat[[as.character(s)]])
 
-    # Aggregate influence and pi2 to PSU level
-    x_agg   <- as.numeric(tapply(x_s,   psu_s, sum))
-    pi2_agg <- as.numeric(tapply(pi2_s, psu_s, mean))
-    nPSU_s  <- length(x_agg)
+    # Aggregate influence to PSU level
+    x_agg  <- as.numeric(tapply(x_s, psu_s, sum))
+    nPSU_s <- length(x_agg)
+
+    # Aggregate usu to PSU level (mean handles PSUs spanning multiple phase 2 strata)
+    pi2_agg <- as.numeric(tapply(usu_ph2[idx_s], psu_s, mean))
 
     if (nPSU_s <= 1L) next  # lonely PSU: contributes 0
 

--- a/changelog/phase-0.75/fix-twophase-variance-pi2.md
+++ b/changelog/phase-0.75/fix-twophase-variance-pi2.md
@@ -1,0 +1,30 @@
+# fix(variance): correct pi2 in two-phase Phase 1 variance formula
+
+**Date**: 2026-03-09
+**Branch**: fix/twophase-variance-pi2
+**Phase**: Phase 0.75
+
+## Changes
+
+- Fix `R/variance-twophase.R` `.twophase_phase1_var()`: replace incorrect
+  row-level Phase 2 fraction (`pi2_agg`) with the PSU-level stratum sampling
+  fraction (survey's `usu` = `n_Ph2_PSU_s / n_Ph1_PSU_s`), resolving ~2×
+  variance underestimation for `method = "approx"` and `"full"` designs
+- When `strata2` is specified, compute `pi2_agg` per Phase 2 stratum
+  (`n_Ph2_PSU_in_strata2 / n_Ph1_PSU_in_strata2`) rather than per Phase 1
+  stratum — matches survey's `usu` formula for the stratified Phase 2 case
+- Remove the now-unused `pi2` parameter from `.twophase_phase1_var()`; remove
+  the corresponding `.compute_phase2_probs()` call from `.twophasevar()` (the
+  row-level pi2 is still used correctly in `.twophase_build_inputs()` for
+  calibrated weights / point estimates)
+- Update three unit tests that called `.twophase_phase1_var()` directly with
+  the old 5-argument signature to the new 4-argument signature
+- Mark `plans/investigation-twophase-variance.md` as fixed
+
+## Files Modified
+
+- `R/variance-twophase.R` — bug fix in `.twophase_phase1_var()` and
+  `.twophasevar()` (pi2 parameter removed; usu computation added)
+- `tests/testthat/test-variance-twophase.R` — update three direct
+  `.twophase_phase1_var()` calls to new signature
+- `plans/investigation-twophase-variance.md` — status updated to "Fixed"

--- a/plans/investigation-twophase-variance.md
+++ b/plans/investigation-twophase-variance.md
@@ -2,7 +2,7 @@
 
 **Filed:** 2026-03-09
 **Priority:** High — affects all Phase 1 analysis functions + GLM for twophase designs
-**Status:** Not started
+**Status:** Fixed — `R/variance-twophase.R` (2026-03-09)
 
 ---
 

--- a/tests/testthat/test-variance-twophase.R
+++ b/tests/testthat/test-variance-twophase.R
@@ -26,8 +26,7 @@ test_that(".twophasevar() phase 1 variance component is nonzero for clustered ph
   d   <- as_survey_twophase(ph1, subset = subset, method = "approx")
 
   inp    <- .twophase_build_inputs(d, "y1", na.rm = TRUE)
-  pi2    <- .compute_phase2_probs(d, d@data[[d@variables$subset]])
-  v1     <- .twophase_phase1_var(inp$influence_mean, d, pi2, "approx", "remove")
+  v1     <- .twophase_phase1_var(inp$influence_mean, d, "approx", "remove")
 
   expect_true(is.finite(v1))
   expect_gt(v1, 0)
@@ -41,10 +40,9 @@ test_that(".twophasevar() full variance > phase 1 variance alone (phase 2 adds u
 
   inp    <- .twophase_build_inputs(d, "y1", na.rm = TRUE)
   subset <- d@data[[d@variables$subset]]
-  pi2    <- .compute_phase2_probs(d, subset)
 
   v_total <- .twophasevar(inp$influence_mean, d)
-  v1_only <- .twophase_phase1_var(inp$influence_mean, d, pi2, "approx", "remove")
+  v1_only <- .twophase_phase1_var(inp$influence_mean, d, "approx", "remove")
   v2_only <- .twophase_phase2_var(inp$influence_mean, d, subset, "remove")
 
   expect_equal(v_total, v1_only + v2_only, tolerance = 1e-15)
@@ -63,11 +61,9 @@ test_that('.twophasevar() with method = "simple" equals phase 1 component only',
   )
 
   inp    <- .twophase_build_inputs(d_simple, "y1", na.rm = TRUE)
-  subset <- d_simple@data[[d_simple@variables$subset]]
-  pi2    <- .compute_phase2_probs(d_simple, subset)
 
   v_simple  <- .twophasevar(inp$influence_mean, d_simple)
-  v1_simple <- .twophase_phase1_var(inp$influence_mean, d_simple, pi2,
+  v1_simple <- .twophase_phase1_var(inp$influence_mean, d_simple,
                                      "simple", "remove")
 
   expect_equal(v_simple, v1_simple, tolerance = 1e-15)


### PR DESCRIPTION
## What

Fixes a ~2× variance underestimation in `.twophase_phase1_var()` for
`method = "approx"` and `"full"`: `pi2_agg` was using the row-level overall
Phase 2 fraction (~0.362) instead of the PSU-level stratum sampling fraction
(survey's `usu` = n_Ph2_PSU_s / n_Ph1_PSU_s = ~0.9).

Example: SE(mean y1) was 0.577; correct value (matching `survey::svymean`) is 0.810.

**Root cause:** `pi2_agg` is used in the `onestrat.phase1` formula as `ph2prob`
— the probability that a Phase 1 PSU appears in Phase 2 — which must be the
PSU-level fraction, not the row-level fraction.

**Fix:** Compute `pi2_agg` as `nPSU_s / nPSUfull_s` (no strata2) or per
Phase 2 stratum when `strata2` is specified. The row-level pi2 remains
correct for calibrated weights / point estimates in `.twophase_build_inputs()`.

Closes `plans/investigation-twophase-variance.md`.

## Checklist

- [x] Tests written and passing (`devtools::test()`) — 6585 pass, 0 fail
- [x] R CMD check: 0 errors, 0 warnings (`devtools::check(vignettes=FALSE)`)
- [x] Roxygen docs updated and `devtools::document()` run — no roxygen changes
- [ ] `plans/error-messages.md` updated — no new errors/warnings
- [ ] `VENDORED.md` updated — no new vendored code
- [x] PR title is a valid Conventional Commit
- [x] PR targets `develop`, not `main`