### PR TITLE
feat(classes): add universe and missing_codes properties to survey_metadata

### DIFF
--- a/R/core-classes.R
+++ b/R/core-classes.R
@@ -33,6 +33,12 @@
 #' @param question_prefaces A named list mapping variable names to shared
 #'   question battery preface text.
 #' @param notes A named list mapping variable names to analyst notes.
+#' @param universe A named list mapping variable names to universe
+#'   descriptions (e.g., `list(age = "Adults 18+")`). Describes the
+#'   population to which a variable applies.
+#' @param missing_codes A named list mapping variable names to atomic
+#'   vectors of missing-value codes
+#'   (e.g., `list(age = c(Refused = 99L, DK = 98L))`).
 #' @param transformations A named list tracking variable transformation
 #'   history (populated automatically during operations).
 #' @param weighting_history A list recording weighting operations applied to
@@ -62,6 +68,14 @@ survey_metadata <- S7::new_class(
       default = quote(list())
     ),
     notes = S7::new_property(
+      S7::class_list,
+      default = quote(list())
+    ),
+    universe = S7::new_property(
+      S7::class_list,
+      default = quote(list())
+    ),
+    missing_codes = S7::new_property(
       S7::class_list,
       default = quote(list())
     ),

--- a/changelog/metadata-update/feature-metadata-s7-classes.md
+++ b/changelog/metadata-update/feature-metadata-s7-classes.md
@@ -1,0 +1,27 @@
+# Changelog — feature/metadata-s7-classes
+
+**PR:** PR 1 of metadata-update
+**Branch:** `feature/metadata-s7-classes`
+**Depends on:** none
+
+## Changes
+
+### `R/core-classes.R`
+- Added `universe` property (`S7::class_list`, default `list()`) to `survey_metadata`
+- Added `missing_codes` property (`S7::class_list`, default `list()`) to `survey_metadata`
+- Added `@param universe` and `@param missing_codes` to `survey_metadata` roxygen block
+
+### `tests/testthat/test-s7-classes.R`
+- Added 6 new test blocks for `universe` and `missing_codes` properties:
+  - Default `list()` for both properties
+  - Constructor accepts and stores values for both
+  - `@` assignment round-trips for both
+
+### `plans/error-messages.md`
+- Added 11 new rows for metadata-update error/warning classes (M-2/M-7 through M-15)
+- Updated coverage map for `test-metadata-system.R`
+
+## Notes
+- `universe` and `missing_codes` follow the same pattern as existing `notes` and
+  `value_labels` properties — `S7::class_list` with `default = quote(list())`
+- No changes to any function in `core-metadata.R` (deferred to PR 3)

--- a/man/survey_metadata.Rd
+++ b/man/survey_metadata.Rd
@@ -9,6 +9,8 @@ survey_metadata(
   value_labels = list(),
   question_prefaces = list(),
   notes = list(),
+  universe = list(),
+  missing_codes = list(),
   transformations = list(),
   weighting_history = list()
 )
@@ -24,6 +26,14 @@ of value labels (e.g., \code{list(sex = c(Male = 1L, Female = 2L))}).}
 question battery preface text.}
 
 \item{notes}{A named list mapping variable names to analyst notes.}
+
+\item{universe}{A named list mapping variable names to universe
+descriptions (e.g., \code{list(age = "Adults 18+")}). Describes the
+population to which a variable applies.}
+
+\item{missing_codes}{A named list mapping variable names to atomic
+vectors of missing-value codes
+(e.g., \code{list(age = c(Refused = 99L, DK = 98L))}).}
 
 \item{transformations}{A named list tracking variable transformation
 history (populated automatically during operations).}

--- a/plans/decisions-metadata-update.md
+++ b/plans/decisions-metadata-update.md
@@ -1,0 +1,261 @@
+# Decisions Log — surveycore metadata-update
+
+This file records planning decisions made during the metadata-update spec workflow.
+Each entry corresponds to one planning session.
+
+---
+
+## 2026-03-10 — Stage 4: Resolve code review issues (spec-review-metadata-update.md)
+
+### Context
+
+Working through 15 issues identified in the adversarial code review (Pass 1).
+Four were BLOCKING, seven REQUIRED, four SUGGESTION. All resolved in one session.
+
+### Questions & Decisions
+
+**Q: Issue 1 — How should `.parse_setter_input()` handle both old positional form detection (requires quosures) and Convention 2 type checking (requires evaluated values)?**
+- Options considered:
+  - **Option A:** Move old positional form detection to each setter caller using `rlang::enquos()`; `.parse_setter_input()` receives only evaluated values via `rlang::list2(...)`.
+  - **Option B:** Pass both a quosures list and an evaluated list to `.parse_setter_input()`.
+- **Decision:** Option A.
+- **Rationale:** Separates NSE symbol detection (caller concern) from value parsing (shared helper concern). Clean, explicit, keeps the shared helper free of quosure mechanics.
+
+**Q: Issue 2 — Should `.parse_setter_input()` have a `content_type` parameter to discriminate Convention 2 for scalar-content vs. vector-content setters?**
+- Options considered:
+  - **Option A:** Add `content_type = c("scalar", "vector")` parameter.
+  - **Option B:** Remove Convention 2 detection from the helper entirely; handle per setter.
+- **Decision:** Option A.
+- **Rationale:** Minimal change, fully specifies the contract, keeps Convention 2 detection centralized.
+
+**Q: Issue 4 — Should `.resolve_vars()` keep both `x` and `all_cols` parameters, or remove the redundant one?**
+- Options considered:
+  - **Option A:** Remove `all_cols`; compute via `.get_data_cols(x)` internally.
+  - **Option B:** Remove `x`; callers pre-compute `all_cols`.
+- **Decision:** Option A.
+- **Rationale:** `x` is already available for data-masking context; internal computation is a one-liner.
+
+**Q: Issue 8 — Should `extract_var_label()` and `extract_val_labels()` claim backward compatibility with old scalar/bare-vector return types?**
+- Options considered:
+  - **Option A:** Remove backward compat claim; document as breaking changes in NEWS.md.
+  - **Option B:** Add `"scalar"` format option for single-variable calls.
+- **Decision:** Option A.
+- **Rationale:** The extractor signatures are changing substantially; acknowledging the break honestly is simpler and avoids a conditional return-type complexity.
+
+**Q: Issue 13 — Should `extract_metadata()` always return all variables, or follow the same `fill = NULL` (omit) default as other extractors?**
+- Options considered:
+  - **Keep always-include design:** Add justification sentence only.
+  - **Add `fill` argument:** `fill = NULL` (default) omits all-null variables; `fill = "include"` returns all.
+- **Decision:** Add `fill` argument for consistency with other extractors.
+- **Rationale:** User stated: "This should operate the same as other functions." Consistent API is more predictable. `fill = "include"` preserves the structural audit use case.
+
+**Q: Issue 14 — Which dataset should replace `nhanes_2017` in Section 6.5 examples?**
+- Options considered:
+  - `gss_2024` (per CLAUDE.md convention).
+  - `ns_wave1` (user preference — richer metadata including question_preface attributes).
+- **Decision:** Use `ns_wave1`.
+- **Rationale:** User stated `ns_wave1` has richer metadata, making it better for illustrating metadata API features (especially `question_preface` which NHANES and GSS lack in the dataset).
+
+### Outcome
+
+All 15 issues resolved. Spec updated to version 2.0 and approved. Breaking changes
+(extractor return type changes + old positional setter removal) documented in
+Section 8.3. `extract_metadata()` now has `fill` argument. `.parse_setter_input()`
+clarified to receive only evaluated values; old positional detection moved to callers.
+New error class `surveycore_error_setter_mixed_dots` (M-12) added.
+
+---
+
+## 2026-03-11 — Stage 4: Resolve code review issues Pass 2 (spec-review-metadata-update.md)
+
+### Context
+
+Working through 12 issues from the adversarial code review Pass 2 (all REQUIRED or SUGGESTION,
+0 blocking). Issues concentrated in three areas: old-positional-form detection scope, underspecified
+setter edge cases, and missing/incorrect test coverage.
+
+### Questions & Decisions
+
+**Q: Issue 16 — Should only `set_var_label()` do enquos + old-positional-form detection, or all six setters?**
+- Options considered:
+  - **Option A:** Restrict to `set_var_label()` only; other five setters use `rlang::list2(...)` directly.
+  - **Option C:** Do nothing — five setters get dead quosure boilerplate.
+- **Decision:** Option A.
+- **Rationale:** Only `set_var_label()` had an old positional form. The five other setters never did. Consistent with the 2026-03-10 decision that moved old-positional detection to callers.
+
+**Q: Issue 17 — Should `.parse_setter_input()` have an explicit `fn_name` parameter or recover caller name dynamically?**
+- Options considered:
+  - **Option A:** Add explicit `fn_name` string parameter.
+  - **Option B:** Use `rlang::sys_call(-1L)` to recover dynamically (fragile).
+- **Decision:** Option A.
+- **Rationale:** Matches existing codebase pattern (`analysis-helpers.R`, `glm-methods.R`). Zero risk.
+
+**Q: Issues 18 + 19 — Should scalar-content setters coerce non-character input, or always error?**
+- Options considered:
+  - **Coerce (Option A for 19):** Non-character scalars → `as.character()` with warning; length > 1 → error.
+  - **Error only (Option B for 19):** Any non-character or length > 1 → `surveycore_error_label_not_scalar`.
+- **Decision:** Error only (Issue 19 Option B). Unified rule added to Section 4.1 (Issue 18 Option A adjusted to error-only semantics). Sections 4.5, 4.6, 4.7 updated to reference Section 4.1.
+- **Rationale:** Metadata setters should fail loudly. Silently converting `42L` to `"42"` hides likely typos. Simpler — one error class, no coercion logic.
+
+**Q: Issue 20 — Should M-12 cover only mixed (some named, some unnamed) or any unnamed element in `...`?**
+- Options considered:
+  - **Option B:** Extend M-12 condition to `any(!has_name)` (any unnamed). Keep class name.
+  - **Option A:** New M-14 for the all-unnamed case, keep M-12 for mixed-only.
+- **Decision:** Option B.
+- **Rationale:** "Unnamed elements in `...`" is a single coherent concept. Message already says "All `...` arguments must be named." No class rename needed.
+
+**Q: Issue 21 — Convention 3 with `variable = character(0)`: silent no-op, error, or warn?**
+- Options considered:
+  - **Option A:** Silent no-op.
+  - **Option B:** Error.
+  - **User direction:** Issue a warning that nothing happened.
+- **Decision:** Warn + no-op: issues `surveycore_warning_setter_empty_variables` (M-14) and returns `invisible(x)`.
+- **Rationale:** Valid programmatic pattern when a filter produces zero entries at runtime. Warn so users are not silently confused if they expected something to happen.
+
+**Q: Issue 22 — Should `set_missing_codes()` Convention 3 accept a bare atomic vector when `length(variable) == 1L`?**
+- Options: Allow (parallel to `set_val_labels()`) vs. prohibit.
+- **Decision:** Allow (Option A). Identical structure to `set_val_labels()` Section 4.4 exception.
+
+**Q: Issue 23 — In `"list"` format, should `fill = NA_character_` yield `NA_character_` or `NULL` for scalar-content extractors?**
+- Options: `NA_character_` for scalar fields, `NULL` for vector fields (Option A) vs. always `NULL` (Option B).
+- **Decision:** Option A. `NA_character_` is meaningful for character scalar list entries. `NULL` reserved for vector fields where it signals "no labels set."
+
+**Q: Issue 27 — Should `.format_list_result()` `fn_name` feed into M-6, or be removed as unused?**
+- Options: Update M-6 to include `{fn_name}` (Option A) vs. remove unused param (Option B).
+- **Decision:** Option A. More informative error messages. M-6 updated to `"{.fn {fn_name}} received an invalid {.arg format} value."`.
+
+**Q: Issue 26 — Should invalid `fill` values produce an error?**
+- Options: Add cross-reference + `surveycore_error_fill_invalid` validation (Option A) vs. do nothing.
+- **Decision:** Option A. Validation prevents silent misbehavior when users mix `fill = "include"` and `fill = NA_character_` across the two function families.
+
+### Outcome
+
+All 12 Pass 2 issues resolved. Spec updated to version 3.0. New error/warning classes added:
+`surveycore_error_label_not_scalar` (M-13), `surveycore_warning_setter_empty_variables` (M-14),
+`surveycore_error_fill_invalid` (M-15). `.parse_setter_input()` gains `fn_name` parameter.
+M-6 and M-12 message templates updated. Section 4.1 gains unified scalar-content validation
+rule and documents extended M-12 and new M-14 behavior. Section 10.5 test plan expanded with
+bare-vector exception tests, M-13/M-14 tests, data-frame M-9 test.
+
+---
+
+## 2026-03-11 — Stage 3: Resolve plan review issues (plan-review-metadata-update.md)
+
+### Context
+
+Working through 9 issues from the adversarial plan review (Pass 1): 1 BLOCKING, 5 REQUIRED,
+3 SUGGESTIONS. All resolved in one session.
+
+### Questions & Decisions
+
+**Q: Issue 1 — Round-trip tests in PR 3 depend on PR 4's updated extractor API and cannot pass at PR 3 merge time. Where should they live?**
+- Options considered:
+  - **Option A:** Move the 6 round-trip test blocks to PR 4 Step 4.1.
+  - **Option B:** Keep in PR 3 but write against the old scalar API; rewrite in PR 4.
+- **Decision:** Option A.
+- **Rationale:** The round-trip guarantee requires both setter (PR 3) and updated extractor (PR 4). The test belongs in the PR that completes the pair. Keeps both PRs independently mergeable and CI-passing.
+
+**Q: Issue 2 — Changelog entries and NEWS.md breaking changes section were missing from all PRs. Add or skip?**
+- **Decision:** Add. Changelog file added to each PR's Files section and acceptance criteria; NEWS.md step (Step 4.12) added to PR 4 with the 3 breaking changes from spec Section 8.3.
+- **Rationale:** Required by the stage-2-review standard criteria and spec Section 8.3.
+
+**Q: Issue 3 — `.resolve_vars()` had no direct tests in PR 2. Add or defer to PR 4?**
+- Options considered:
+  - **Option A:** Add direct test section in PR 2 Step 2.2 (5 blocks: empty → all cols, specified names, warning + skip, snapshot).
+  - **Option B:** Move entirely to PR 4.
+- **Decision:** Option A.
+- **Rationale:** `.resolve_vars()` drives all extractor behavior. Its contracts must be verified at the PR where it is introduced.
+
+**Q: Issue 4 — lifecycle dependency in PR 1 stated as fact with no verification step. Fix?**
+- **Decision:** Changed PR 1 Notes to require an explicit `grep 'lifecycle' DESCRIPTION` check, with conditional DESCRIPTION update if missing.
+- **Rationale:** Prevents opaque check failure at PR 3 with no guidance in the plan.
+
+**Q: Issue 5 — 98%+ coverage gate absent from PRs 1–3. Add or leave only in PR 4?**
+- Options considered:
+  - **Option A:** Add `covr::package_coverage() ≥ 98%` to all three PRs.
+  - **Option B:** Add only to PR 3.
+- **Decision:** Option A.
+- **Rationale:** Coverage is a per-PR gate, not a final-PR gate. Gaps should be caught early.
+
+**Q: Issue 6 — `devtools::document()` missing from PR 2, PR 3, PR 4 acceptance criteria. Add?**
+- **Decision:** Added to all three. PR 2 notes no .Rd changes expected; PR 3 notes 6 setter .Rd files; PR 4 notes new extractor .Rd files.
+- **Rationale:** Required by r-package-conventions.md for any commit changing roxygen2 content.
+
+**Q: Issue 7 — `air::format_package()` only in global Quality Gates footer, not per-PR criteria. Add?**
+- **Decision:** Added to all four PR acceptance criteria.
+- **Rationale:** Per-PR gate reduces risk of formatter being skipped under time pressure.
+
+**Q: Issue 8 — PR 3 scope is large. Split into 3a (replacements) + 3b (new setters)?**
+- Options considered:
+  - **Option A:** Split into PR 3a + PR 3b.
+  - **Option C:** Do nothing.
+- **Decision:** Option C.
+- **Rationale:** The step list is well-sequenced and the shared `.parse_setter_input()` infrastructure makes splitting awkward. Suggestion-only; no functional risk.
+
+**Q: Issue 9 — No direct tests for `.format_scalar_result()` / `.format_list_result()` in PR 2. Add?**
+- Options considered:
+  - **Option A:** Add direct test sections (5 blocks for scalar, 4 for list).
+  - **Option C:** Rely on indirect testing via PR 4 extractors.
+- **Decision:** Option A.
+- **Rationale:** Direct tests make debugging faster if an extractor test fails; the format helpers have non-trivial branching logic.
+
+### Outcome
+
+All 9 plan review issues resolved. Round-trip tests moved to PR 4. All four PRs now have
+changelog, coverage, document, and formatter acceptance criteria. PR 2 gains direct test
+sections for `.resolve_vars()`, `.format_scalar_result()`, and `.format_list_result()`.
+PR 4 gains a NEWS.md step (Step 4.12) with the 3 breaking changes from spec Section 8.3.
+
+---
+
+## 2026-03-11 — Stage 3: Resolve plan review issues Pass 2 (plan-review-metadata-update.md)
+
+### Context
+
+Working through 7 issues from adversarial plan review Pass 2: 4 REQUIRED (Issues 10–13),
+3 SUGGESTION (Issues 14–16). One REQUIRED issue (10) triggered a scope decision about
+whether to deprecate or hard-delete the four plural setter functions.
+
+### Questions & Decisions
+
+**Q: Issue 10 — Should the four plural setters (`set_variable_labels()` etc.) be deprecated with `lifecycle::deprecate_soft()` wrappers, or deleted outright?**
+- Options considered:
+  - **Deprecate:** Wrap with `lifecycle::deprecate_soft()` wrappers (original plan). The `...`-forwarding bug in the template makes all four deprecated functions error on any real-world call with arguments.
+  - **Delete:** Remove the four functions entirely. Package is pre-1.0, not on CRAN.
+- **Decision:** Delete outright.
+- **Rationale:** User stated deletion is simpler. Package is pre-1.0 with no CRAN release; no deprecation lifecycle is needed. Hard breaking removal is cleaner and avoids the `lifecycle` dependency entirely.
+
+**Q: Issue 13 — Where should the `lifecycle` DESCRIPTION update go (PR 1 vs PR 3)?**
+- **Decision:** Moot — `lifecycle` is never used (Issue 10 resolved by deletion). Removed the lifecycle DESCRIPTION check from PR 1 Notes entirely.
+- **Rationale:** No `lifecycle::` calls anywhere in the plan means no `lifecycle` import is needed.
+
+**Q: Issue 11 — Step 3.15 removes `.check_is_survey()` unconditionally. Make conditional?**
+- **Decision:** Yes (Option A). Step 3.15 rewritten as two explicit sub-steps: run grep, remove ONLY if zero external callers found.
+- **Rationale:** Prevents silent breakage of any caller outside the setter functions.
+
+**Q: Issue 12 — Add `lintr::lint_package()` to Quality Gates and all PR criteria?**
+- **Decision:** Yes (Option A). Added to the Quality Gates footer and to each of the four PR acceptance criteria.
+- **Rationale:** Spec Section XI explicitly requires it; `air` does not enforce native pipe, snake_case, or `<-` assignment rules.
+
+**Q: Issue 14 — Add `testthat::snapshot_review()` to PR 2 and PR 3 acceptance criteria?**
+- **Decision:** Yes (Option A).
+- **Rationale:** First-run snapshots auto-create and pass without review. PRs 2 and 3 generate 30+ new snapshots; per-PR review gate prevents unreviewed error text from being committed.
+
+**Q: Issue 15 — Split PR 3 Step 3.2 (all 6 setters in one step) into per-setter TDD sub-steps?**
+- **Decision:** Yes (Option A). Restructured into Steps 3.2a–3.2g, each followed by a confirm-fail run, then the implementation step, then a confirm-pass run.
+- **Rationale:** Proper TDD cadence — one write/red/implement/green cycle per setter. Keeps each checkpoint small and diagnosable.
+
+**Q: Issue 16 — Remove `extract_universe()` from the "Breaking Changes" NEWS.md item?**
+- **Decision:** Yes (Option A). `extract_universe()` is a new function — it has no prior API to break. Moved to a new `### New Functions` section in Step 4.12 alongside `extract_missing_codes()` and `extract_metadata()`.
+- **Rationale:** Accurate NEWS.md entries matter; inaccurate breaking-change listings confuse users.
+
+### Outcome
+
+All 7 Pass 2 issues resolved. Four plural setters (`set_variable_labels()` etc.) are now
+hard-deleted rather than deprecated. `lifecycle` dependency removed from the plan entirely.
+PR 3 steps restructured into per-setter TDD cycles (Steps 3.2a–3.2g). Step 4.12 now
+produces both a `### Breaking Changes` section (4 items) and a `### New Functions` section
+(5 functions). All four PR acceptance criteria include `lintr::lint_package()` and
+`testthat::snapshot_review()`. Plan approved — ready for `/r-implement`.
+
+---

--- a/plans/error-messages.md
+++ b/plans/error-messages.md
@@ -118,6 +118,17 @@ against the messages defined here.
 | 79 | `infer_question_prefaces()` | Variable already has `question_preface` and `overwrite = FALSE` | WARN | `surveycore_warning_preface_not_overwritten` | `"{length(skipped)} variable{?s} already {?has/have} a question preface and {?was/were} skipped. Set {.arg overwrite = TRUE} to replace them."` |
 | 80 | `infer_question_prefaces()` | Trimming the preface leaves an empty label | WARN | `surveycore_warning_empty_label_after_trim` | `"Variable {.field {var_name}} would have an empty label after trimming the preface. Skipping."` |
 | 81 | all `get_*()` (via `.validate_shared_args()`) | `na.rm` is not `TRUE` or `FALSE` (e.g., `NA`, `1`, `"yes"`) | ERROR | `surveycore_error_na_rm_not_logical` | `"x" = "{.arg na.rm} must be {.code TRUE} or {.code FALSE}.", "i" = "Got {.obj_type_friendly {na.rm}}."` |
+| M-2/M-7 | all extractors (M-2), all setters (M-7) | A variable specified in `...` / input is not found in `x@data` / `names(x)` | WARN | `surveycore_warning_var_not_found` | Extractor (M-2): `"!" = "{length(missing)} variable{?s} not found in {.arg x} and {?was/were} skipped: {.field {missing}}."` / Setter (M-7): `"!" = "{length(missing)} variable{?s} not found in {.arg x} and {?was/were} skipped: {.field {missing}}.", "i" = "Check spelling. Available columns: {.field {head(all_cols, 10)}}{?.}"` |
+| M-3 | all setters | Both `...` and explicit `variable`/content args are provided simultaneously | ERROR | `surveycore_error_setter_ambiguous` | `"x" = "Provide variable names via {.arg ...} or via {.arg variable}, not both.", "i" = "Use named {.arg ...} args, a named vector in {.arg ...}, or {.arg variable} + {.arg {content_arg}} — not a mix."` |
+| M-4 | all setters | Neither `...` nor `variable`/content args are provided | ERROR | `surveycore_error_setter_empty` | `"x" = "{.fn {fn_name}} requires at least one variable-label pair.", "v" = "Use named {.arg ...} args: {.code {fn_name}(x, age = 'Age in years')}."` |
+| M-5 | all setters (convention 3) | `length(variable) != length(content)` | ERROR | `surveycore_error_setter_mismatched_lengths` | `"x" = "{.arg variable} has {length(variable)} element{?s} but {.arg {content_arg}} has {length(content)} element{?s}.", "i" = "They must be the same length (one content value per variable name)."` |
+| M-6 | all extractors | `format` argument has an invalid value | ERROR | `surveycore_error_format_invalid` | `"x" = "{.fn {fn_name}} received an invalid {.arg format} value {.val {format}}.", "i" = "{.arg format} must be one of {.val {valid_formats}}."` |
+| M-10 | `set_missing_codes()` | A `codes` entry is not an atomic vector | ERROR | `surveycore_error_missing_codes_not_vector` | `"x" = "Missing codes for {.field {var_name}} must be an atomic vector, not {.cls {class(codes_entry)[[1L]]}}.", "i" = "Use a numeric, integer, or character vector (e.g., {.code c(Refused = 99L, {\"Don't know\"} = 98L)})."` |
+| M-11 | `set_var_label()` | Old positional NSE form detected | ERROR | `surveycore_error_old_positional_setter` | `"x" = "The old positional calling form {.code {fn_name}(x, var, content)} is no longer supported.", "i" = "The new unified setter uses named arguments.", "v" = "Use {.code {fn_name}(x, {var_name} = {.val {content_val}})} instead."` |
+| M-12 | all setters | `...` contains any unnamed element(s) — either all unnamed or a mix of named and unnamed | ERROR | `surveycore_error_setter_mixed_dots` | `"x" = "All {.arg ...} arguments must be named when using Convention 1.", "i" = "Got {sum(nzchar(names(dots)))} named and {sum(!nzchar(names(dots)))} unnamed element{?s}.", "v" = "Use {.code {fn_name}(x, age = 'Age', income = 'Annual income')} or a fully named vector."` |
+| M-13 | scalar-content setters (`set_var_label`, `set_question_preface`, `set_var_note`, `set_universe`) | A content value is not a character scalar (wrong type or length > 1) | ERROR | `surveycore_error_label_not_scalar` | `"x" = "Label content for {.field {var_name}} must be a character scalar, not {.cls {class(val)[[1L]]}} of length {length(val)}.", "v" = "Pass a single character string, e.g. {.code {fn_name}(x, {var_name} = 'My label')}."` |
+| M-14 | all setters (convention 3) | `variable` argument is explicitly provided as `character(0)` (length 0) | WARN | `surveycore_warning_setter_empty_variables` | `"!" = "{.fn {fn_name}} was called with {.arg variable} of length 0.", "i" = "No metadata was set. Did you accidentally filter all variable names out?"` |
+| M-15 | all extractors, `extract_metadata()` | `fill` argument has an invalid value for this function | ERROR | `surveycore_error_fill_invalid` | `"x" = "{.fn {fn_name}} does not accept {.code fill = {.val {fill}}}.", "i" = "Valid values for {.fn {fn_name}}: {.val {valid_fill_values}}."` |
 
 ---
 
@@ -158,7 +169,7 @@ Which test files cover which error table rows:
 | `test-constructors.R` | 1–24, 23b, 56–61 |
 | `test-variance-twophase.R` | 63 |
 | `test-validators.R` | 27–35 |
-| `test-metadata-system.R` | 27–30 |
+| `test-metadata-system.R` | 27–30, M-2/M-7, M-3–M-15 |
 | `test-s7-classes.R` | 31–35, 37–39 |
 | `test-update-design.R` | 36 |
 | `test-analysis-helpers.R` | 45, 45a, 45b, 46 (direct unit tests on `.validate_shared_args()` and `.apply_decimals()`); 64 (`.check_unsupported_class()` and `.build_meta()` fallback); also integration-checked in per-function files |

--- a/plans/impl-metadata-update.md
+++ b/plans/impl-metadata-update.md
@@ -1,0 +1,780 @@
+# Implementation Plan — surveycore metadata-update
+
+**Spec:** `plans/spec-metadata-update.md` (v3.0, approved)
+**Decisions log:** `plans/decisions-metadata-update.md`
+**Plan review:** `plans/plan-review-metadata-update.md` (Pass 1 + Pass 2 resolved — approved)
+
+---
+
+## Overview
+
+This plan implements the metadata API update specified in `spec-metadata-update.md`.
+It adds two new `survey_metadata` fields (`universe`, `missing_codes`), replaces
+the existing singular/plural setter dichotomy with a unified three-convention API,
+extends all extractors with multi-variable support and output format control, adds
+`extract_metadata()` as a summary function, and enables data frame support
+throughout. The deprecated plural setters (`set_variable_labels()`, etc.) remain as
+thin `lifecycle::deprecate_soft()` wrappers. All changes land in two existing files
+(`R/core-classes.R`, `R/core-metadata.R`) and two existing test files.
+
+---
+
+## PR Map
+
+- [x] PR 1: `feature/metadata-s7-classes` — Add `universe`/`missing_codes` to `survey_metadata`; update error catalog
+- [ ] PR 2: `feature/metadata-helpers` — New internal helper infrastructure (`core-metadata.R` top section)
+- [ ] PR 3: `feature/metadata-setters` — Unified setter API + deprecations + `.extract_haven_metadata()` update
+- [ ] PR 4: `feature/metadata-extractors` — Updated extractors + `extract_universe()`, `extract_missing_codes()`, `extract_metadata()`
+
+---
+
+## PR 1: S7 Class Properties + Error Catalog
+
+**Branch:** `feature/metadata-s7-classes`
+**Depends on:** none
+
+### Files (TDD order — tests first)
+
+- `plans/error-messages.md` — Add all new error/warning classes from spec Section IX
+- `tests/testthat/test-s7-classes.R` — New test blocks for `universe` and `missing_codes`
+- `R/core-classes.R` — Add `universe` and `missing_codes` properties to `survey_metadata`
+- `changelog/metadata-update/feature-metadata-s7-classes.md` — Changelog entry for this PR
+
+### Tasks
+
+**Step 1.1:** Update `plans/error-messages.md` before any code.
+Add rows for the following classes (spec Section IX). Use the class names and
+message templates exactly as specified:
+- `surveycore_error_not_survey_or_df` (M-1, already row 78 — verify it exists; if yes, no change needed)
+- `surveycore_warning_var_not_found` (M-2, M-7 — check if already exists; add if missing)
+- `surveycore_error_setter_ambiguous` (M-3)
+- `surveycore_error_setter_empty` (M-4)
+- `surveycore_error_setter_mismatched_lengths` (M-5)
+- `surveycore_error_format_invalid` (M-6)
+- `surveycore_error_labels_unnamed` (M-8, already exists — verify row number)
+- `surveycore_warning_missing_labels` (M-9, already exists — verify row number)
+- `surveycore_error_missing_codes_not_vector` (M-10)
+- `surveycore_error_old_positional_setter` (M-11)
+- `surveycore_error_setter_mixed_dots` (M-12)
+- `surveycore_error_label_not_scalar` (M-13)
+- `surveycore_warning_setter_empty_variables` (M-14)
+- `surveycore_error_fill_invalid` (M-15)
+
+**Step 1.2:** Write failing tests in `tests/testthat/test-s7-classes.R`:
+```
+test_that("survey_metadata() stores universe as empty list by default")
+test_that("survey_metadata() stores missing_codes as empty list by default")
+test_that("survey_metadata(universe = list(...)) stores value correctly")
+test_that("survey_metadata(missing_codes = list(...)) stores value correctly")
+test_that("universe @ assignment round-trips on survey_metadata object")
+test_that("missing_codes @ assignment round-trips on survey_metadata object")
+```
+
+**Step 1.3:** Run `devtools::test(filter = "s7-classes")` → confirm all 6 new blocks fail
+(properties do not yet exist).
+
+**Step 1.4:** Add two properties to `survey_metadata` in `R/core-classes.R`:
+
+```r
+universe = S7::new_property(
+  S7::class_list,
+  default = quote(list())
+),
+missing_codes = S7::new_property(
+  S7::class_list,
+  default = quote(list())
+)
+```
+
+Add corresponding `@param universe` and `@param missing_codes` entries to the
+`survey_metadata` roxygen block. The `@param` style matches existing entries.
+
+**Step 1.5:** Run `devtools::test(filter = "s7-classes")` → confirm all 6 new blocks pass.
+
+**Step 1.6:** Run `devtools::document()` → confirm NAMESPACE and `man/survey_metadata.Rd`
+regenerated without errors.
+
+**Step 1.7:** Run `devtools::check()` → must pass 0 errors, 0 warnings, ≤ 2 notes.
+
+### Acceptance criteria
+
+- [ ] `plans/error-messages.md` contains rows for all 15 error/warning classes in spec Section IX
+- [ ] All 6 new S7 class test blocks pass
+- [ ] `survey_metadata()` creates objects with `universe` and `missing_codes` properties (both `list()` by default)
+- [ ] `air::format_package()` — no diffs
+- [ ] `lintr::lint_package()` — 0 lints
+- [ ] `devtools::check()` 0/0/≤2
+- [ ] `devtools::document()` run; NAMESPACE and `man/survey_metadata.Rd` in sync
+- [ ] `covr::package_coverage()` ≥ 98%
+- [ ] Changelog entry written and committed on this branch
+
+**Notes:**
+- Do NOT change any function in `core-metadata.R` during this PR. The S7 property
+  addition is the only code change.
+- Layer 1 (S7 validator) test pattern: `class=` only, no snapshot (per testing-surveycore.md).
+
+---
+
+## PR 2: Internal Helper Infrastructure
+
+**Branch:** `feature/metadata-helpers`
+**Depends on:** PR 1
+
+### Files (TDD order — tests first)
+
+- `tests/testthat/test-metadata-system.R` — Direct unit tests for `.check_is_survey_or_df()` and `.parse_setter_input()`
+- `R/core-metadata.R` — New internal helpers added at the top of the file (before existing functions)
+- `changelog/metadata-update/feature-metadata-helpers.md` — Changelog entry for this PR
+
+### Tasks
+
+**Step 2.1:** Write failing tests for `.check_is_survey_or_df()` in `test-metadata-system.R`.
+Add a labeled section `# ── .check_is_survey_or_df() ────` with blocks:
+```
+test_that(".check_is_survey_or_df() returns invisibly NULL for a survey_taylor object")
+test_that(".check_is_survey_or_df() returns invisibly NULL for a plain data.frame")
+test_that(".check_is_survey_or_df() errors with surveycore_error_not_survey_or_df for list input")
+test_that(".check_is_survey_or_df() errors with surveycore_error_not_survey_or_df for character input")
+test_that(".check_is_survey_or_df() error snapshot for list input")
+```
+
+**Step 2.2:** Write failing tests for `.parse_setter_input()` in `test-metadata-system.R`.
+Add a labeled section `# ── .parse_setter_input() ────` with blocks:
+```
+test_that(".parse_setter_input() convention 1 (named ...) returns correct named list")
+test_that(".parse_setter_input() convention 1 with !!! splicing returns correct named list")
+test_that(".parse_setter_input() convention 2 scalar (single named char vector) returns correct named list")
+test_that(".parse_setter_input() convention 2 vector (single named list) returns correct named list")
+test_that(".parse_setter_input() convention 3 (variable + content) returns correct named list")
+test_that(".parse_setter_input() convention 3 length mismatch errors with surveycore_error_setter_mismatched_lengths")
+test_that(".parse_setter_input() both ... and variable errors with surveycore_error_setter_ambiguous")
+test_that(".parse_setter_input() neither ... nor variable errors with surveycore_error_setter_empty")
+test_that(".parse_setter_input() unnamed ... elements errors with surveycore_error_setter_mixed_dots")
+test_that(".parse_setter_input() NULL values pass through in returned list")
+test_that("snapshot: surveycore_error_setter_mismatched_lengths message")
+test_that("snapshot: surveycore_error_setter_ambiguous message")
+test_that("snapshot: surveycore_error_setter_empty message")
+test_that("snapshot: surveycore_error_setter_mixed_dots message")
+```
+
+Add a `# ── .resolve_vars() ────` section with blocks:
+```
+test_that(".resolve_vars() with empty var_exprs returns all column names")
+test_that(".resolve_vars() with specified names returns just those names")
+test_that(".resolve_vars() warns with surveycore_warning_var_not_found for missing var")
+test_that(".resolve_vars() returns only valid names after warning")
+test_that("snapshot: .resolve_vars() surveycore_warning_var_not_found message")
+```
+
+Add a `# ── .format_scalar_result() ────` section with blocks:
+```
+test_that(".format_scalar_result() format = 'named_vector' returns named character vector")
+test_that(".format_scalar_result() format = 'list' returns named list")
+test_that(".format_scalar_result() format = 'data_frame' returns tibble with variable/label columns")
+test_that(".format_scalar_result() fill = NULL omits entries with NULL values")
+test_that(".format_scalar_result() fill = NA_character_ includes entries with NA")
+```
+
+Add a `# ── .format_list_result() ────` section with blocks:
+```
+test_that(".format_list_result() format = 'list' returns named list")
+test_that(".format_list_result() format = 'data_frame' returns long tibble")
+test_that(".format_list_result() format = 'named_vector' errors with surveycore_error_format_invalid")
+test_that("snapshot: .format_list_result() surveycore_error_format_invalid message")
+```
+
+**Step 2.3:** Run `devtools::test(filter = "metadata-system")` on just the new blocks
+→ confirm all fail (helpers do not exist yet).
+
+**Step 2.4:** Add the following internal helpers to the TOP of `R/core-metadata.R`
+(before the existing `.check_is_survey()` function, which remains untouched until PR 3):
+
+1. `.check_is_survey_or_df(x, call)` — type guard for survey + data.frame;
+   errors with `surveycore_error_not_survey_or_df` (spec Section 3.2).
+
+2. `.get_data_cols(x)` — returns `names(x)` for data frames, `names(x@data)` for
+   survey objects (spec Section 3.2).
+
+3. `.get_metadata(x)` — returns `x@metadata` for survey objects, `NULL` for data
+   frames (spec Section 3.2).
+
+4. `.parse_setter_input(dots, variable, content, content_arg_name, content_type, fn_name, call)`
+   — shared setter convention detection (spec Section 3.2 and 4.1). Handles:
+   - Convention 1: non-empty named list from `rlang::list2(...)`
+   - Convention 2 scalar: single unnamed element that is a named character vector
+     (when `content_type = "scalar"`)
+   - Convention 2 vector: single unnamed element that is a named list
+     (when `content_type = "vector"`)
+   - Convention 3: `variable` non-NULL, `...` empty
+   - Ambiguity: both `...` and `variable` provided → `surveycore_error_setter_ambiguous`
+   - Empty: neither provided → `surveycore_error_setter_empty`
+   - Unnamed/mixed elements → `surveycore_error_setter_mixed_dots`
+   - Returns named list; `NULL` values allowed (signal key deletion in metadata)
+
+5. `.resolve_vars(x, var_exprs, call)` — resolves `...` quosures for extractors.
+   If `var_exprs` is empty (length 0), returns `.get_data_cols(x)`. Otherwise
+   evaluates bare names / character vectors; issues `surveycore_warning_var_not_found`
+   for missing names and returns only valid ones (spec Section 3.2).
+
+6. `.format_scalar_result(result_list, format, col_name, empty_value)` — converts
+   named list of character scalars into `"named_vector"`, `"list"`, or `"data_frame"`
+   output (spec Section 3.2). Validates `format` against valid options.
+
+7. `.format_list_result(result_list, format, fn_name)` — converts named list of
+   vectors into `"list"` or `"data_frame"` output. `fn_name` used in
+   `surveycore_error_format_invalid` message (spec Section 3.2).
+
+**Step 2.5:** Run `devtools::test(filter = "metadata-system")` on all new blocks
+→ confirm all pass.
+
+**Step 2.6:** Run full `devtools::test()` → confirm existing tests still pass
+(no regressions; old functions unchanged).
+
+**Step 2.7:** Run `devtools::document()` + `devtools::check()` → 0/0/≤2.
+
+### Acceptance criteria
+
+- [ ] All `.check_is_survey_or_df()` test blocks pass (both happy paths + error class + snapshot)
+- [ ] All `.parse_setter_input()` test blocks pass (conventions 1/2/3, all error classes, snapshots)
+- [ ] All `.resolve_vars()` test blocks pass (empty → all cols, specified names, warning + skip, snapshot)
+- [ ] All `.format_scalar_result()` test blocks pass (3 formats, fill = NULL, fill = NA_character_)
+- [ ] All `.format_list_result()` test blocks pass (list, data_frame, named_vector error + snapshot)
+- [ ] Existing `test-metadata-system.R` tests still pass (old functions untouched)
+- [ ] `air::format_package()` — no diffs
+- [ ] `lintr::lint_package()` — 0 lints
+- [ ] `devtools::document()` run; NAMESPACE and `man/` unchanged (no new exports in this PR)
+- [ ] `devtools::check()` 0/0/≤2
+- [ ] `covr::package_coverage()` ≥ 98%
+- [ ] All snapshot tests reviewed with `testthat::snapshot_review()` — no unreviewed diffs
+- [ ] Changelog entry written and committed on this branch
+
+**Notes:**
+- `.parse_setter_input()` receives `dots` as an **evaluated list** (`rlang::list2(...)` at the caller),
+  NOT quosures. The old-positional-form quosure check is the caller's responsibility (`set_var_label()`
+  only — see PR 3).
+- Test these helpers with direct calls (not through the public API). Use synthetic data from
+  `make_survey_data()` to build a survey object for `.check_is_survey_or_df()` tests.
+- Convention 2 scalar: `c(age = "Age in years")` — a named character vector.
+- Convention 2 vector: `list(sex = c(Male = 1L, Female = 2L))` — a named list.
+- `NULL` in returned list: `list(age = NULL)` means "delete key `age`" — each setter
+  must handle this by doing `x@metadata@variable_labels[["age"]] <- NULL`.
+
+---
+
+## PR 3: Unified Setters + Deprecations
+
+**Branch:** `feature/metadata-setters`
+**Depends on:** PR 1, PR 2
+
+### Files (TDD order — tests first)
+
+- `tests/testthat/test-metadata-system.R` — Replace existing setter tests; add new
+  convention/error/warning/data-frame test blocks; add `make_labeled_design()` helper
+- `R/core-metadata.R` — Replace all setter functions; update `.extract_haven_metadata()`;
+  remove `.check_is_survey()`
+- `changelog/metadata-update/feature-metadata-setters.md` — Changelog entry for this PR
+
+### Tasks
+
+**Step 3.1:** Add `make_labeled_design()` helper at the top of `test-metadata-system.R`
+(per spec Section 10.9):
+```r
+make_labeled_design <- function(seed = 42) {
+  df  <- make_survey_data(n = 100, seed = seed)
+  svy <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc)
+  svy <- set_var_label(svy, y1 = "Outcome 1", y2 = "Outcome 2")
+  svy <- set_val_labels(
+    svy,
+    strata = setNames(seq_len(5L), paste0("Stratum ", seq_len(5L)))
+  )
+  svy <- set_universe(svy, y1 = "All respondents")
+  svy <- set_missing_codes(svy, y1 = c("Missing" = -1L))
+  svy
+}
+```
+
+Note: This helper uses the new unified setters. Write it now but it will only work
+after the setters are implemented in Steps 3.4–3.11. Tests referencing it will fail
+until the relevant setter is implemented.
+
+Note: Data frame round-trip blocks (6 total) are intentionally placed in **PR 4 Step 4.1** —
+they depend on the updated extractor return types only implemented in PR 4.
+
+**Step 3.2a:** Write test blocks for `set_var_label()` in `test-metadata-system.R`.
+Add a labeled section `# ── set_var_label() ────` with blocks:
+```
+test_that("set_var_label() convention 1 sets label for one variable")
+test_that("set_var_label() convention 1 sets labels for multiple variables")
+test_that("set_var_label() convention 1 with !!! splicing sets labels")
+test_that("set_var_label() convention 2 (named char vector in ...) sets labels")
+test_that("set_var_label() convention 3 (variable + label) sets labels")
+test_that("set_var_label() returns x invisibly")
+test_that("set_var_label() survives pipe chain of three calls")
+test_that("set_var_label() NULL label deletes the existing entry")
+test_that("set_var_label() data frame: sets attr(df$age, 'label')")
+test_that("set_var_label() errors with surveycore_error_not_survey_or_df for list x")
+test_that("set_var_label() errors with surveycore_error_setter_ambiguous")
+test_that("set_var_label() errors with surveycore_error_setter_empty")
+test_that("set_var_label() errors with surveycore_error_setter_mismatched_lengths")
+test_that("set_var_label() errors with surveycore_error_old_positional_setter for old form")
+test_that("set_var_label() errors with surveycore_error_label_not_scalar for non-character")
+test_that("set_var_label() errors with surveycore_error_label_not_scalar for length > 1")
+test_that("set_var_label() errors with surveycore_error_setter_mixed_dots for unnamed ...")
+test_that("set_var_label() warns with surveycore_warning_var_not_found for missing variable")
+test_that("set_var_label() skips missing var but still sets valid vars")
+test_that("set_var_label() warns with surveycore_warning_setter_empty_variables for variable = character(0)")
+test_that("snapshot: set_var_label() surveycore_error_not_survey_or_df")
+test_that("snapshot: set_var_label() surveycore_error_setter_ambiguous")
+test_that("snapshot: set_var_label() surveycore_error_setter_empty")
+test_that("snapshot: set_var_label() surveycore_error_setter_mismatched_lengths")
+test_that("snapshot: set_var_label() surveycore_error_old_positional_setter")
+test_that("snapshot: set_var_label() surveycore_error_label_not_scalar")
+test_that("snapshot: set_var_label() surveycore_warning_var_not_found")
+test_that("snapshot: set_var_label() surveycore_warning_setter_empty_variables")
+```
+
+**Step 3.3:** Run `devtools::test(filter = "metadata-system")` on the `set_var_label()`
+section → confirm all new blocks fail.
+
+**Step 3.4:** Implement `set_var_label()` in `R/core-metadata.R`:
+- New signature: `set_var_label(x, ..., variable = NULL, label = NULL)`
+- `set_var_label()` ONLY: capture `...` as quosures via `rlang::enquos(...)` first;
+  detect old positional form (exactly 2 `...`, first is unquoted symbol, second is
+  scalar string with no name) → error `surveycore_error_old_positional_setter`
+- After old-form check: evaluate `...` via `rlang::list2(...)`; call
+  `.parse_setter_input(dots, variable, label, "label", "scalar", "set_var_label", call)`
+- For each `var_name -> content` pair in result:
+  - If survey object: check var in `.get_data_cols(x)`, warn + skip if missing
+  - If `content` is not NULL: validate character scalar → error `surveycore_error_label_not_scalar`
+  - Set `x@metadata@variable_labels[[var_name]] <- content` (NULL removes key)
+  - If data frame: `attr(x[[var_name]], "label") <- content`
+- Return `invisible(x)`
+- Full roxygen2 block: `@param x`, `@param ...`, `@param variable`, `@param label`,
+  `@return`, `@examples` (3 conventions), `@family metadata`, `@export`
+
+**Step 3.5:** Run `devtools::test(filter = "metadata-system")` on `set_var_label()` blocks
+→ confirm passing.
+
+**Step 3.2b:** Write test blocks for `set_val_labels()`. Add a labeled section
+`# ── set_val_labels() ────` with blocks (note the bare-vector exception for Conv. 3):
+```
+test_that("set_val_labels() convention 1 sets labels for one variable")
+test_that("set_val_labels() convention 1 sets labels for multiple variables")
+test_that("set_val_labels() convention 2 (single named list in ...) sets labels")
+test_that("set_val_labels() convention 3 (variable + labels list) sets labels")
+test_that("set_val_labels() convention 3 bare named vector accepted when length(variable) == 1")
+test_that("set_val_labels() returns x invisibly")
+test_that("set_val_labels() NULL value deletes the entry")
+test_that("set_val_labels() data frame: sets attr(df$sex, 'labels')")
+test_that("set_val_labels() errors with surveycore_error_labels_unnamed for unnamed vector")
+test_that("set_val_labels() warns with surveycore_warning_missing_labels for partially labeled")
+test_that("set_val_labels() warns with surveycore_warning_missing_labels on data frame")
+test_that("set_val_labels() [error/warning snapshots as above]")
+```
+Run `devtools::test(filter = "metadata-system")` on new blocks → confirm fail.
+
+**Step 3.6:** Implement `set_val_labels()`:
+- New signature: `set_val_labels(x, ..., variable = NULL, labels = NULL)`
+- Evaluate `...` via `rlang::list2(...)` (no old-form check needed)
+- Call `.parse_setter_input(dots, variable, labels, "labels", "vector", "set_val_labels", call)`
+- Convention 3 exception: if `length(variable) == 1L` and `labels` is a bare named
+  vector (not a list), wrap in a list before passing to `.parse_setter_input()`
+- For each pair: check var exists, validate named vector (`surveycore_error_labels_unnamed`),
+  run `.validate_val_labels()` check for M-9, set metadata or attribute
+- Survey objects: `x@metadata@value_labels[[var_name]] <- content`
+- Data frames: `attr(x[[var_name]], "labels") <- content`
+- The `.validate_val_labels()` check reads `x@data[[var]]` for survey objects,
+  `x[[var]]` for data frames (per spec Issue 25 resolution)
+
+**Step 3.7:** Run tests on `set_val_labels()` blocks → confirm passing.
+
+**Step 3.2c:** Write test blocks for `set_question_preface()`. Add a labeled section
+`# ── set_question_preface() ────` with analogous blocks covering conventions 1/2/3,
+return invisibly, NULL deletion, data frame attribute setting, all applicable
+error/warning classes (`content_type = "scalar"`).
+Run `devtools::test(filter = "metadata-system")` on new blocks → confirm fail.
+
+**Step 3.8:** Implement `set_question_preface()`:
+- Signature: `set_question_preface(x, ..., variable = NULL, preface = NULL)`
+- `content_type = "scalar"`, `content_arg_name = "preface"`
+- Scalar validation per Section 4.1 unified rule (error `surveycore_error_label_not_scalar`)
+- Survey: `x@metadata@question_prefaces[[var_name]] <- content`
+- Data frame: `attr(x[[var_name]], "question_preface") <- content`
+
+Run `devtools::test(filter = "metadata-system")` on `set_question_preface()` blocks
+→ confirm passing.
+
+**Step 3.2d:** Write test blocks for `set_var_note()`. Add a labeled section
+`# ── set_var_note() ────` with analogous blocks (same pattern as `set_question_preface()`).
+Run `devtools::test(filter = "metadata-system")` on new blocks → confirm fail.
+
+**Step 3.9:** Implement `set_var_note()`:
+- Signature: `set_var_note(x, ..., variable = NULL, note = NULL)`
+- Same pattern as `set_question_preface()`
+- Survey: `x@metadata@notes[[var_name]] <- content`
+- Data frame: `attr(x[[var_name]], "note") <- content`
+
+Run `devtools::test(filter = "metadata-system")` on `set_var_note()` blocks → confirm passing.
+
+**Step 3.2e:** Write test blocks for `set_universe()`. Add a labeled section
+`# ── set_universe() ────` with analogous blocks (same pattern as `set_var_note()`).
+Run `devtools::test(filter = "metadata-system")` on new blocks → confirm fail.
+
+**Step 3.10:** Implement `set_universe()` (new):
+- Signature: `set_universe(x, ..., variable = NULL, universe = NULL)`
+- Same pattern as `set_var_note()`
+- Survey: `x@metadata@universe[[var_name]] <- content`
+- Data frame: `attr(x[[var_name]], "universe") <- content`
+
+Run `devtools::test(filter = "metadata-system")` on `set_universe()` blocks → confirm passing.
+
+**Step 3.2f:** Write test blocks for `set_missing_codes()`. Add a labeled section
+`# ── set_missing_codes() ────` with analogous blocks covering conventions 1/2/3,
+Convention 3 bare-vector exception, `surveycore_error_missing_codes_not_vector`,
+return invisibly, NULL deletion, data frame attribute setting.
+Run `devtools::test(filter = "metadata-system")` on new blocks → confirm fail.
+
+**Step 3.11:** Implement `set_missing_codes()` (new):
+- Signature: `set_missing_codes(x, ..., variable = NULL, codes = NULL)`
+- `content_type = "vector"`, `content_arg_name = "codes"`
+- Convention 3 exception: same bare-vector exception as `set_val_labels()` when
+  `length(variable) == 1L` — a bare atomic vector for `codes` is wrapped in a list
+- Validation: each entry must be an atomic vector; list entries → `surveycore_error_missing_codes_not_vector`
+- Survey: `x@metadata@missing_codes[[var_name]] <- content`
+- Data frame: `attr(x[[var_name]], "missing_codes") <- content`
+
+Run `devtools::test(filter = "metadata-system")` on `set_missing_codes()` blocks
+→ confirm passing.
+
+**Step 3.12:** Run `devtools::test(filter = "metadata-system")` on all setter blocks
+→ confirm all pass. Also update existing test blocks that assert
+`class = "surveycore_error_not_survey"`: change to
+`class = "surveycore_error_not_survey_or_df"`.
+
+**Step 3.2g:** Write 4 deleted-function confirmation test blocks in
+`test-metadata-system.R`. Add a labeled section `# ── Removed plural setters ────`:
+```
+test_that("set_variable_labels() is removed — calling it errors with 'could not find function'")
+test_that("set_value_labels() is removed — calling it errors with 'could not find function'")
+test_that("set_question_prefaces() is removed — calling it errors with 'could not find function'")
+test_that("set_variable_notes() is removed — calling it errors with 'could not find function'")
+```
+Run `devtools::test(filter = "metadata-system")` on these blocks → confirm fail
+(the functions still exist at this point).
+
+**Step 3.13:** Delete the four plural setter functions from `R/core-metadata.R`:
+remove `set_variable_labels()`, `set_value_labels()`, `set_question_prefaces()`, and
+`set_variable_notes()` entirely. The package is pre-1.0 and not on CRAN; a clean
+breaking removal is preferred over deprecation wrappers. Remove the corresponding
+`@export` tags (if any inline docs exist for these functions). `devtools::document()`
+in Step 3.17 will update NAMESPACE automatically.
+
+Run `devtools::test(filter = "metadata-system")` on the `# ── Removed plural setters ────`
+section → confirm all 4 blocks now pass (functions are gone).
+
+**Step 3.14:** Update `.extract_haven_metadata()` to also read `"note"`, `"universe"`,
+and `"missing_codes"` column attributes. The updated function must:
+- Read `attr(col, "note", exact = TRUE)` → store if non-NULL character scalar
+- Read `attr(col, "universe", exact = TRUE)` → store if non-NULL character scalar
+- Read `attr(col, "missing_codes", exact = TRUE)` → store if non-NULL atomic vector
+- Pass all six fields to `survey_metadata()` constructor call at the end
+
+**Step 3.15:** Conditionally remove `.check_is_survey()` from `R/core-metadata.R`:
+1. Run `grep -r ".check_is_survey(" R/` to find all call sites.
+2. If the only match is inside `core-metadata.R` itself (zero external callers): delete
+   the function.
+   If any external callers are found: leave `.check_is_survey()` in place and do not
+   remove it.
+
+**Step 3.16:** Run `devtools::test(filter = "metadata-system")` → all blocks pass.
+Run `devtools::test()` (full suite) → no regressions.
+
+**Step 3.17:** Run `devtools::document()` + `devtools::check()` → 0/0/≤2.
+
+### Acceptance criteria
+
+- [ ] All 6 unified setter functions work with conventions 1, 2, and 3
+- [ ] Convention 2 detection distinguishes scalar vs. vector content correctly
+- [ ] Old positional form `set_var_label(x, var, "label")` → `surveycore_error_old_positional_setter`
+- [ ] All scalar-content setters → `surveycore_error_label_not_scalar` for non-char or length > 1
+- [ ] `set_val_labels()` and `set_missing_codes()` Convention 3 bare-vector exception works
+- [ ] All 6 setters work on both survey objects and data frames with correct attributes
+- [ ] 4 plural setters (`set_variable_labels()`, `set_value_labels()`, `set_question_prefaces()`, `set_variable_notes()`) deleted; `grep -r "set_variable_labels\|set_value_labels\|set_question_prefaces\|set_variable_notes" R/` returns 0 results
+- [ ] `.extract_haven_metadata()` reads all 6 field attributes
+- [ ] `.check_is_survey()` removed if no external callers found (see Step 3.15)
+- [ ] Existing test expectations updated from `surveycore_error_not_survey` to `surveycore_error_not_survey_or_df`
+- [ ] `air::format_package()` — no diffs
+- [ ] `lintr::lint_package()` — 0 lints
+- [ ] `devtools::document()` run; NAMESPACE and `man/` updated for all 6 exported setter functions
+- [ ] `devtools::check()` 0/0/≤2
+- [ ] `covr::package_coverage()` ≥ 98%
+- [ ] All snapshot tests reviewed with `testthat::snapshot_review()` — no unreviewed diffs
+- [ ] Changelog entry written and committed on this branch
+
+**Notes:**
+- `variable = character(0)` (length-0 explicit arg) → `surveycore_warning_setter_empty_variables` + `invisible(x)`.
+  This is distinct from omitting `variable` (which triggers `surveycore_error_setter_empty`).
+- `NULL` content removes the metadata key (`x@metadata@variable_labels[["age"]] <- NULL` —
+  this truly removes the key, not stores NULL). Verify with `"age" %in% names(...)`.
+- `set_val_labels()` M-9 warning: compare `unique(var[!is.na(var)])` values against label codes.
+  For data frames, `var = x[[var_name]]`; for survey objects, `var = x@data[[var_name]]`.
+- The `.validate_val_labels()` internal helper already implements M-9 correctly — reuse it.
+- `!!! splicing`: automatically supported because callers use `rlang::list2(...)`.
+- For data frame setter behavior when `NULL` content (deletion): `attr(x[[var_name]], "label") <- NULL`
+  removes the attribute. This is standard R behavior.
+- The `make_labeled_design()` helper in `test-metadata-system.R` uses new unified setters —
+  it will work correctly once Step 3.4–3.11 are complete.
+
+---
+
+## PR 4: Updated Extractors + `extract_metadata()`
+
+**Branch:** `feature/metadata-extractors`
+**Depends on:** PR 1, PR 2, PR 3
+
+### Files (TDD order — tests first)
+
+- `tests/testthat/test-metadata-system.R` — Replace existing extractor tests; add new
+  format/fill/data-frame test blocks; add `extract_metadata()` tests
+- `R/core-metadata.R` — Replace all 4 extractors; add `extract_universe()`,
+  `extract_missing_codes()`, `extract_metadata()`
+- `NEWS.md` — Add `### Breaking Changes` section (spec Section 8.3)
+- `changelog/metadata-update/feature-metadata-extractors.md` — Changelog entry for this PR
+
+### Tasks
+
+**Step 4.1:** Write failing test blocks for all updated extractors in `test-metadata-system.R`.
+
+For `extract_var_label()` (and parallel structure for `extract_question_preface()`,
+`extract_var_note()`, `extract_universe()`):
+
+```
+test_that("extract_var_label() single variable returns named character vector (not scalar)")
+test_that("extract_var_label() multiple variables returns named char vector with all names")
+test_that("extract_var_label() no var arg returns metadata for all variables")
+test_that("extract_var_label() no var arg returns empty char(0) when no labels set")
+test_that("extract_var_label() format = 'named_vector' (default) returns named char vector")
+test_that("extract_var_label() format = 'list' returns named list")
+test_that("extract_var_label() format = 'data_frame' returns tibble with variable/label columns")
+test_that("extract_var_label() format = 'data_frame' empty result: zero-row tibble with correct types")
+test_that("extract_var_label() fill = NULL (default): unlabeled variables omitted")
+test_that("extract_var_label() fill = NA_character_: unlabeled variables included with NA")
+test_that("extract_var_label() fill = NA_character_ in 'list' format: NA_character_ list entry")
+test_that("extract_var_label() mix: some labeled, some not — fill = NULL omits unset")
+test_that("extract_var_label() data frame: reads attr(df[[var]], 'label')")
+test_that("extract_var_label() data frame: returns same structure as for survey objects")
+test_that("extract_var_label() errors with surveycore_error_not_survey_or_df for list x")
+test_that("extract_var_label() errors with surveycore_error_format_invalid for invalid format")
+test_that("extract_var_label() warns with surveycore_warning_var_not_found for missing var")
+test_that("extract_var_label() result excludes missing var after warning")
+test_that("extract_var_label() errors with surveycore_error_fill_invalid for fill = 'include'")
+test_that("snapshot: extract_var_label() surveycore_error_format_invalid")
+test_that("snapshot: extract_var_label() surveycore_warning_var_not_found")
+```
+
+For `extract_val_labels()` (format: `"list"`, `"data_frame"` only):
+```
+test_that("extract_val_labels() single variable returns named list (not bare named vector)")
+test_that("extract_val_labels() format = 'list' (default) returns named list")
+test_that("extract_val_labels() format = 'data_frame' returns long tibble with variable/label/value cols")
+test_that("extract_val_labels() format = 'data_frame' coerces codes to character")
+test_that("extract_val_labels() format = 'named_vector' errors with surveycore_error_format_invalid")
+test_that("extract_val_labels() fill = NA_character_ in 'list' format: NULL entries (not NA)")
+test_that("extract_val_labels() data frame: reads attr(df[[var]], 'labels')")
+```
+
+For `extract_missing_codes()`:
+```
+test_that("extract_missing_codes() single variable returns named list")
+test_that("extract_missing_codes() format = 'list' (default): named list with named/unnamed codes preserved")
+test_that("extract_missing_codes() format = 'data_frame': long tibble with variable/description/code cols")
+test_that("extract_missing_codes() format = 'data_frame': description = NA when codes vector is unnamed")
+test_that("extract_missing_codes() format = 'named_vector' errors")
+test_that("extract_missing_codes() fill = NA_character_ in 'list' format: NULL entries")
+test_that("extract_missing_codes() data frame: reads attr(df[[var]], 'missing_codes')")
+```
+
+Data frame round-trip blocks (6 total — one per field, moved here from PR 3 because they
+depend on the updated named-vector return type implemented in this PR):
+```
+test_that("round-trip: set_var_label() on df -> as_survey() -> extract_var_label() matches")
+test_that("round-trip: set_val_labels() on df -> as_survey() -> extract_val_labels() matches")
+test_that("round-trip: set_question_preface() on df -> as_survey() -> extract_question_preface() matches")
+test_that("round-trip: set_var_note() on df -> as_survey() -> extract_var_note() matches")
+test_that("round-trip: set_universe() on df -> as_survey() -> extract_universe() matches")
+test_that("round-trip: set_missing_codes() on df -> as_survey() -> extract_missing_codes() matches")
+```
+
+For `extract_metadata()`:
+```
+test_that("extract_metadata() single variable with all fields returns 7-key list")
+test_that("extract_metadata() result keys are in spec order: variable_label, value_labels, question_preface, note, universe, missing_codes, transformations")
+test_that("extract_metadata() does NOT include weighting_history in any entry")
+test_that("extract_metadata() transformations is always list(), never NULL")
+test_that("extract_metadata() fill = NULL (default): variable with at least one field included")
+test_that("extract_metadata() fill = NULL: variable with no fields omitted")
+test_that("extract_metadata() fill = 'include': variable with no fields included with all-NULL values")
+test_that("extract_metadata() multiple variables, mixed metadata: fill = NULL returns only annotated")
+test_that("extract_metadata() multiple variables: fill = 'include' returns all")
+test_that("extract_metadata() no var arg: fill = NULL returns only annotated variables")
+test_that("extract_metadata() no var arg: fill = 'include' returns all columns")
+test_that("extract_metadata() all variables with no metadata + fill = NULL: returns list()")
+test_that("extract_metadata() all variables with no metadata + fill = 'include': returns full-length list")
+test_that("extract_metadata() single-column data frame with fill = 'include'")
+test_that("extract_metadata() data frame: reads column attributes correctly")
+test_that("extract_metadata() data frame: transformations = list() for all variables")
+test_that("extract_metadata() errors with surveycore_error_not_survey_or_df for list x")
+test_that("extract_metadata() warns with surveycore_warning_var_not_found; result skips missing var")
+test_that("extract_metadata() errors with surveycore_error_fill_invalid for fill = NA_character_")
+test_that("snapshot: extract_metadata() surveycore_error_not_survey_or_df")
+test_that("snapshot: extract_metadata() surveycore_error_fill_invalid")
+```
+
+**Step 4.2:** Run `devtools::test(filter = "metadata-system")` on new blocks
+→ confirm all fail (functions not yet updated).
+
+**Step 4.3:** Implement updated `extract_var_label()`:
+- New signature: `extract_var_label(x, ..., format = "named_vector", fill = NULL)`
+- Validate `fill` against `c(NULL, NA_character_)` → `surveycore_error_fill_invalid`
+  if any other value (e.g., `"include"`)
+- Validate `format` against `c("named_vector", "list", "data_frame")` → `surveycore_error_format_invalid`
+- Capture `...` as quosures via `rlang::enquos(...)`; call `.resolve_vars(x, var_exprs)`
+  to get variable names (issues `surveycore_warning_var_not_found` for missing names)
+- For survey objects: read from `x@metadata@variable_labels`
+- For data frames: read `attr(x[[var_name]], "label", exact = TRUE)`
+- Collect results into named list; apply `fill` filtering
+- Call `.format_scalar_result(result_list, format, "label", fill)` to produce output
+- Update roxygen2: `@param x`, `@param ...`, `@param format`, `@param fill`,
+  `@return` (describes all 3 formats), `@examples` (3 format examples, omit/fill examples),
+  `@family metadata`, `@export`
+
+**Step 4.4:** Implement updated `extract_val_labels()`:
+- New signature: `extract_val_labels(x, ..., format = "list", fill = NULL)`
+- Valid formats: `"list"`, `"data_frame"` only (reject `"named_vector"` → M-6)
+- For data frames: read `attr(x[[var_name]], "labels", exact = TRUE)`
+- `fill = NA_character_` in `"list"` format: `NULL` entries (not `NA_character_`) for
+  vector-content extractors (per spec Section 5.1 note)
+- Use `.format_list_result(result_list, format, "extract_val_labels")`
+- `"data_frame"` format: long tibble — columns `variable` (chr), `label` (chr), `value` (chr).
+  Coerce codes to character for uniform typing. One row per label-code pair.
+
+**Step 4.5:** Implement updated `extract_question_preface()`:
+- Same pattern as `extract_var_label()`; reads `x@metadata@question_prefaces` or
+  `attr(x[[var_name]], "question_preface", exact = TRUE)`
+- `"data_frame"` columns: `variable` (chr), `preface` (chr)
+
+**Step 4.6:** Implement updated `extract_var_note()`:
+- Same pattern; reads `x@metadata@notes` or `attr(x[[var_name]], "note", exact = TRUE)`
+- `"data_frame"` columns: `variable` (chr), `note` (chr)
+
+**Step 4.7:** Implement `extract_universe()` (new):
+- Same pattern as `extract_var_label()`; reads `x@metadata@universe` or
+  `attr(x[[var_name]], "universe", exact = TRUE)`
+- `"data_frame"` columns: `variable` (chr), `universe` (chr)
+- Full roxygen2 block with `@examples`
+
+**Step 4.8:** Implement `extract_missing_codes()` (new):
+- Same pattern as `extract_val_labels()` (vector-content)
+- Reads `x@metadata@missing_codes` or `attr(x[[var_name]], "missing_codes", exact = TRUE)`
+- `"data_frame"` format: long tibble — columns `variable` (chr), `description` (chr,
+  `NA` if codes vector is unnamed), `code` (chr — coerced from original type).
+  One row per code value.
+- Full roxygen2 block with `@examples`
+
+**Step 4.9:** Implement `extract_metadata()` (new):
+- Signature: `extract_metadata(x, ..., fill = NULL)`
+- Valid `fill` values: `NULL` or `"include"` — anything else → `surveycore_error_fill_invalid`
+  (including `NA_character_`, which individual extractors accept)
+- No `format` argument — always returns a named list
+- For each resolved variable name, build a 7-key named list:
+  `variable_label`, `value_labels`, `question_preface`, `note`, `universe`,
+  `missing_codes`, `transformations`
+- For survey objects: read from `x@metadata@*` fields
+- For data frames: read column attributes; `transformations = list()` always
+- `fill = NULL` (default): omit variables where all six content fields are NULL
+  AND `transformations = list()`
+- `fill = "include"`: include all resolved variables regardless
+- Key order must match spec Section 6.4 exactly
+- Full roxygen2 block with `@examples` showing list output structure
+- `@family metadata`, `@export`
+
+**Step 4.10:** Run `devtools::test(filter = "metadata-system")` → all blocks pass.
+Run `devtools::test()` (full suite) → no regressions.
+
+**Step 4.11:** Run `devtools::document()` + `devtools::check()` → 0/0/≤2.
+
+**Step 4.12:** Update `NEWS.md` — add a `### Breaking Changes` section and a
+`### New Functions` section under the current development version heading.
+
+`### Breaking Changes`:
+1. Old positional setter form `set_var_label(svy, age, "label")` is removed; use `set_var_label(svy, age = "label")`.
+2. `extract_var_label()`, `extract_question_preface()`, and `extract_var_note()` now return a named character vector (not a plain scalar) for single-variable calls.
+3. `extract_val_labels()` now returns a named list (not a bare named vector).
+4. `set_variable_labels()`, `set_value_labels()`, `set_question_prefaces()`, and `set_variable_notes()` have been removed. Use `set_var_label()`, `set_val_labels()`, `set_question_preface()`, and `set_var_note()` respectively.
+
+`### New Functions`:
+- `set_universe()` — set universe annotations for survey variables
+- `set_missing_codes()` — set missing code vectors for survey variables
+- `extract_universe()` — extract universe annotations for one or more variables
+- `extract_missing_codes()` — extract missing code vectors for one or more variables
+- `extract_metadata()` — summary function returning all metadata fields for one or more variables
+
+**Step 4.13:** Run `covr::package_coverage()` → ≥ 98% line coverage.
+Run `testthat::snapshot_review()` → approve all new snapshots (no unreviewed diffs).
+
+### Acceptance criteria
+
+- [ ] All updated extractors return named vectors (not scalars) for single-variable calls
+- [ ] All extractors support `format = "named_vector"`, `"list"`, `"data_frame"` (scalar-content)
+- [ ] `extract_val_labels()` and `extract_missing_codes()` reject `format = "named_vector"`
+- [ ] `fill = NULL` omits variables with no metadata; `fill = NA_character_` includes with NA/NULL
+- [ ] `fill = NA_character_` in `"list"` format: `NA_character_` for scalar fields, `NULL` for vector fields
+- [ ] All extractors work on both survey objects and data frames
+- [ ] `extract_universe()` and `extract_missing_codes()` fully implemented and exported
+- [ ] `extract_metadata()` returns exactly 7 keys per variable in spec-specified order
+- [ ] `extract_metadata()` never includes `weighting_history`
+- [ ] `extract_metadata()` `fill = "include"` returns all variables; `fill = NA_character_` → error
+- [ ] `air::format_package()` — no diffs
+- [ ] `lintr::lint_package()` — 0 lints
+- [ ] `devtools::document()` run; NAMESPACE and `man/` updated for all new exported functions
+- [ ] `covr::package_coverage()` ≥ 98%
+- [ ] All snapshot tests match (`testthat::snapshot_review()` before merge)
+- [ ] `devtools::check()` 0/0/≤2
+- [ ] `NEWS.md` includes `### Breaking Changes` entry (4 items: positional setter, extractor return types, val_labels return type, removed plural setters)
+- [ ] Changelog entry written and committed on this branch
+
+**Notes:**
+- The breaking return-type changes from the old API (single-var calls now return named vectors,
+  not scalars) are documented in spec Section 8.3 / NEWS.md. Do NOT add backward-compat shims.
+- `fill` argument validation: check at the top of each function body with
+  `match.arg(fill, choices = c("named_vector", "list", "data_frame"))` — wait, that's for format.
+  For `fill`, use explicit checks: `if (!is.null(fill) && !identical(fill, NA_character_))`.
+  For `extract_metadata()` use: `if (!is.null(fill) && !identical(fill, "include"))`.
+- The `fill` check must be done BEFORE resolving variables.
+- `"data_frame"` output uses `tibble::tibble()` — this is already in `Imports`.
+- For the round-trip guarantee in spec Section 7.5 — the 6 round-trip test blocks are in
+  PR 4 Step 4.1. They assert the new named-vector return types. Confirm all 6 pass after
+  implementing the updated extractors.
+- `extract_metadata()` entry order follows `names(x@data)` column order when `...` is omitted;
+  follows order of `...` arguments when specified.
+
+---
+
+## Quality Gates (All PRs)
+
+Before opening any PR:
+- [ ] `devtools::document()` — no errors; NAMESPACE and man/ in sync
+- [ ] `air::format_package()` — no diffs
+- [ ] `lintr::lint_package()` — 0 lints
+- [ ] `devtools::check()` — 0 errors, 0 warnings, ≤ 2 pre-approved notes
+- [ ] Every new error class has `expect_error(class = "surveycore_error_...")` test
+- [ ] Every new warning class has `expect_warning(class = "surveycore_warning_...")` test
+- [ ] Snapshot tests reviewed with `testthat::snapshot_review()` (not auto-accepted)
+
+---
+
+> **Review the PR map carefully** — the scope of each PR is harder to change once
+> implementation starts. In particular, confirm that PR 3 (setters) and PR 4 (extractors)
+> are correctly separated — the extractors cannot be implemented before the helpers and
+> setters because the round-trip tests depend on both. Run Stage 2 in a new session for
+> an adversarial review of this plan before handing off to `/r-implement`.

--- a/plans/plan-review-metadata-update.md
+++ b/plans/plan-review-metadata-update.md
@@ -1,0 +1,581 @@
+## Plan Review: metadata-update — Pass 1 (2026-03-11)
+
+### New Issues
+
+---
+
+#### Section: PR Map / Cross-PR Dependencies
+
+---
+
+**Issue 1: Round-trip tests written in PR 3 depend on PR 4's updated extractor API — they cannot pass at PR 3 merge time**
+Severity: BLOCKING
+Violates github-strategy.md: all PRs must pass CI (which requires all tests to pass) before merging to develop.
+
+PR 3 Step 3.2 lists six round-trip test blocks:
+```
+test_that("round-trip: set_var_label() on df -> as_survey() -> extract_var_label() matches")
+... (one per field)
+```
+These tests call `extract_var_label(svy, age)` and compare against the new return type
+(`c(age = "Age in years")` — a named vector). But the updated extractor is implemented
+only in PR 4. At PR 3 merge time, the OLD `extract_var_label()` returns `"Age in years"`
+(a plain scalar). The assertion `expect_equal(extract_var_label(svy, age), c(age = "Age in years"))`
+fails because `identical(c(age = "Age in years"), "Age in years")` is `FALSE`.
+
+PR 4's Notes confirm this: "these round-trip tests were already added in PR 3 step 3.2.
+The extractors in PR 4 are needed for them to pass." But PR 3's Step 3.16 says
+"Run `devtools::test()` (full suite) → no regressions" — a quality gate that is
+impossible to satisfy if the round-trip tests are failing.
+
+Options:
+- **[A]** Move the six round-trip test blocks from PR 3 Step 3.2 to PR 4 Step 4.1. They belong in the same PR as the extractor implementation they depend on. PR 3 retains all setter-only tests; PR 4 gets all extractor tests including the round-trip verification. — Effort: low, Risk: low, Impact: PRs are independently mergeable
+- **[B]** Keep round-trip tests in PR 3 but write them against the OLD extractor API (returning a plain scalar). Then update them in PR 4 to match the new named-vector return. — Effort: medium, Risk: medium (two-pass test rewrite is error-prone and confusing)
+- **[C] Do nothing** — PR 3 cannot pass CI; implementer is blocked and must guess.
+
+**Recommendation: [A]** — the round-trip guarantee requires both the setter (PR 3) and the
+extractor (PR 4) to be implemented; the test belongs in the PR that completes the pair.
+
+---
+
+#### Section: All PRs — File Completeness
+
+---
+
+**Issue 2: Changelog entries and NEWS.md breaking changes missing from all four PR file lists and acceptance criteria**
+Severity: REQUIRED
+Violates stage-2-review.md: "Changelog entry written and committed on this branch" is a required standard acceptance criterion for every PR. Violates spec Section 8.3: "NEWS.md entry: The following breaking changes must be documented in a `### Breaking Changes` section of NEWS.md."
+
+No PR's file list includes a `changelog/*/feature-*.md` file. No PR's acceptance criteria
+includes "changelog entry written and committed." The "Quality Gates (All PRs)" footer
+mentions `devtools::check()`, `air::format_package()`, and snapshot review — but not
+changelog or NEWS.md.
+
+Spec Section 8.3 explicitly requires a NEWS.md `### Breaking Changes` entry covering:
+1. Old positional setter form `set_var_label(svy, age, "label")` removed.
+2. `extract_var_label()` and scalar extractors now return named vector, not scalar.
+3. `extract_val_labels()` now returns named list, not bare named vector.
+
+The quality gates (Section XI) also list "NEWS.md includes a `### Breaking Changes` entry"
+but this does not appear in any individual PR's acceptance criteria.
+
+Options:
+- **[A]** Add `changelog/metadata-update/feature-{branch-name}.md` to each PR's Files
+  section. Add "changelog entry written and committed on this branch" to each PR's
+  acceptance criteria. Add a step to PR 4 (the final PR) to update NEWS.md with the
+  breaking changes from spec Section 8.3. — Effort: low, Risk: none
+- **[C] Do nothing** — breaking changes silently undocumented; CI may pass but release
+  notes are missing.
+
+**Recommendation: [A]**
+
+---
+
+#### Section: PR 2 — Internal Helper Infrastructure
+
+---
+
+**Issue 3: `.resolve_vars()` has no direct tests in PR 2 — the helper will be untested at PR 2 merge time**
+Severity: REQUIRED
+Violates testing-standards.md §2: "When unsure whether an edge case needs a test, write the test." Violates engineering-preferences.md §2: "more tests is better."
+
+PR 2 Steps 2.1 and 2.2 write direct unit tests for two of the seven new helpers:
+`.check_is_survey_or_df()` and `.parse_setter_input()`. The other five — `.get_data_cols()`,
+`.get_metadata()`, `.resolve_vars()`, `.format_scalar_result()`, `.format_list_result()` —
+have no direct tests in PR 2. They are tested only indirectly when PR 4's extractor tests
+run.
+
+`.resolve_vars()` is particularly complex and high-impact:
+- Empty `var_exprs` → returns all column names (default behavior for all extractors)
+- Missing variable name → issues `surveycore_warning_var_not_found` and skips
+- Mixed bare names + character vectors → resolves to correct string vector
+
+These behaviors drive the behavior of all six extractors. A bug in `.resolve_vars()`
+will manifest as broken extractors in PR 4, but there will be no PR 2 test to pinpoint
+the root cause.
+
+Options:
+- **[A]** Add a `# ── .resolve_vars() ────` section in PR 2 Step 2.2 with direct test
+  blocks:
+  ```
+  test_that(".resolve_vars() with empty var_exprs returns all column names")
+  test_that(".resolve_vars() with specified names returns just those names")
+  test_that(".resolve_vars() warns with surveycore_warning_var_not_found for missing var")
+  test_that(".resolve_vars() returns only valid names after warning")
+  test_that("snapshot: .resolve_vars() surveycore_warning_var_not_found message")
+  ```
+  Update PR 2 acceptance criteria to include "`.resolve_vars()` test blocks pass."
+  — Effort: low, Risk: none
+- **[B]** Move `.resolve_vars()` tests entirely to PR 4's Step 4.1, accepting the gap in
+  PR 2. — Effort: trivial, Risk: medium (helpers untested at PR 2 merge; bug discovery
+  deferred to PR 4 implementation)
+- **[C] Do nothing** — `.resolve_vars()` is tested only indirectly; a PR 2 bug in default-
+  all-variables behavior could go undetected until PR 4's test failures are investigated.
+
+**Recommendation: [A]** — `.resolve_vars()` is the backbone of all extractor behavior;
+its behavioral contracts must be verified at the PR where it is introduced.
+
+---
+
+**Issue 4: `lifecycle` in Imports stated as an assumption, not a verification step — if wrong, error surfaces only at PR 3**
+Severity: REQUIRED
+Violates contract completeness; the spec (Section 8.4) says "lifecycle must be added to
+`Imports` in `DESCRIPTION` if not already present."
+
+PR 1 Notes say: "lifecycle is already in Imports — no DESCRIPTION change needed." This
+is stated as a fact. No step in PR 1 verifies this (e.g., no `grep lifecycle DESCRIPTION`
+step). The deprecated functions using `lifecycle::deprecate_soft()` are first added in
+PR 3 Steps 3.13. If lifecycle is not in Imports, `devtools::check()` at PR 3 Step 3.17
+will fail with "package 'lifecycle' is required but not imported" — with no guidance in
+the plan about what to fix or where.
+
+Options:
+- **[A]** Change PR 1 Step 1.1 or PR 1 Notes to: "Verify lifecycle is in Imports:
+  `grep 'lifecycle' DESCRIPTION`. If missing, add `lifecycle (>= 1.0.0)` to `Imports`
+  in `DESCRIPTION` and update the DESCRIPTION Files entry for this PR." Add
+  `DESCRIPTION` (conditional) to PR 1 Files section. — Effort: trivial, Risk: none
+- **[C] Do nothing** — implementer hits an opaque check failure at PR 3; no hint in
+  the plan about the root cause.
+
+**Recommendation: [A]**
+
+---
+
+**Issue 5: 98%+ line coverage criterion absent from PR 1, PR 2, and PR 3 acceptance criteria**
+Severity: REQUIRED
+Violates testing-standards.md §2: "PRs that drop coverage below 95% are blocked by CI."
+The plan specifies coverage only in PR 4's acceptance criteria (`covr::package_coverage() ≥ 98%`).
+
+Each PR that adds new code can drop coverage if its tests don't cover all paths. PRs 1-3
+introduce new code paths (S7 properties, seven internal helpers, six setters + deprecations)
+without coverage gates. An uncovered branch in PR 2's `.parse_setter_input()` will not
+be caught until PR 4's coverage check — by which point the gap is harder to trace.
+
+Options:
+- **[A]** Add `covr::package_coverage() ≥ 98%` to the acceptance criteria of PRs 1, 2,
+  and 3 (same criterion already in PR 4). — Effort: trivial, Risk: none
+- **[B]** Add only PR 3 (the largest PR with the most new code paths). — Effort: trivial,
+  Risk: low (small PRs 1 and 2 are less likely to introduce coverage gaps)
+- **[C] Do nothing** — coverage gaps can accumulate across PRs 1-3 and only surface at
+  the end of PR 4.
+
+**Recommendation: [A]** — coverage is a per-PR gate, not a final-PR gate.
+
+---
+
+**Issue 6: `devtools::document()` missing from PR 2 and PR 3 acceptance criteria**
+Severity: REQUIRED
+Violates r-package-conventions.md: "Run `devtools::document()` before committing any
+file that changes roxygen2 content." Violates the stage-2-review.md required standard
+criterion: "`devtools::document()` run; NAMESPACE and man/ in sync."
+
+PR 1 acceptance criteria correctly includes "`devtools::document()` run; NAMESPACE and
+`man/survey_metadata.Rd` in sync." But:
+
+- PR 2 acceptance criteria: no `devtools::document()` criterion. (PR 2 adds only
+  internal helpers with `@keywords internal @noRd` — no NAMESPACE or .Rd changes.
+  The step mentions it but the acceptance criterion does not.)
+- PR 3 acceptance criteria: no `devtools::document()` criterion. PR 3 adds or updates
+  six exported functions (`set_var_label`, `set_val_labels`, `set_question_preface`,
+  `set_var_note`, `set_universe`, `set_missing_codes`) with full roxygen2 blocks.
+  NAMESPACE and six .Rd files change. This is the most critical PR for documentation
+  and the criterion is missing.
+- PR 4 acceptance criteria: no `devtools::document()` criterion. PR 4 adds
+  `extract_universe()`, `extract_missing_codes()`, `extract_metadata()` (all exported).
+
+Options:
+- **[A]** Add "`devtools::document()` run; NAMESPACE and `man/` files in sync" to PR 2,
+  PR 3, and PR 4 acceptance criteria. For PR 2, note that no .Rd changes are expected.
+  — Effort: trivial, Risk: none
+- **[C] Do nothing** — PR 3 ships with stale NAMESPACE or man/ files; CI may pass but
+  the published package is wrong.
+
+**Recommendation: [A]**
+
+---
+
+#### Section: Suggestions
+
+---
+
+**Issue 7: `air::format_package()` absent from individual PR acceptance criteria**
+Severity: SUGGESTION
+Violates code-style.md §5: "Run `air::format_package()` before opening a PR."
+
+The "Quality Gates (All PRs)" footer at the end of the plan mentions `air::format_package()
+— no diffs`. However, it does not appear in any individual PR's acceptance criteria.
+Under time pressure an implementer who reads only the per-PR section might skip formatting.
+
+Options:
+- **[A]** Add "`air::format_package()` — no diffs" to each PR's acceptance criteria.
+  — Effort: trivial
+- **[C] Do nothing** — formatter is mentioned in the global quality gates; risk is low
+  but nonzero.
+
+**Recommendation: [A]**
+
+---
+
+**Issue 8: PR 3 bundles function replacements, new functions, deprecations, and helper cleanup — the scope is very large**
+Severity: SUGGESTION
+Violates github-strategy.md PR granularity guidance: "The right PR is the smallest
+coherent unit of work."
+
+PR 3 contains:
+- Replacement of 4 existing setters (`set_var_label`, `set_val_labels`,
+  `set_question_preface`, `set_var_note`) — breaking API changes
+- 2 brand-new setters (`set_universe`, `set_missing_codes`) — new functionality
+- 4 deprecated-function wrappers
+- `.extract_haven_metadata()` update
+- `.check_is_survey()` removal
+- Adding `make_labeled_design()` test helper
+- 100+ new test blocks
+
+`set_universe()` and `set_missing_codes()` are genuinely new functions (no replacement
+involved). They could form a separate `feature/metadata-new-setters` PR after PR 3's
+replacements are merged, reducing the review surface of the largest PR in the plan.
+
+Options:
+- **[A]** Split PR 3 into PR 3a (replacements of 4 existing setters + deprecations +
+  helper cleanup) and PR 3b (new `set_universe()` + `set_missing_codes()` functions).
+  PR 4 depends on both 3a and 3b. — Effort: low, Risk: low, Impact: smaller, reviewable
+  PRs; .extract_haven_metadata() update goes in 3b (it only adds universe/missing_codes)
+- **[C] Do nothing** — large but not technically wrong; implementation is sequential
+  so scope can be managed with the step-by-step task list.
+
+**Recommendation: [C] acceptable** — the step-by-step tasks in PR 3 are well-sequenced
+and the shared `.parse_setter_input()` infrastructure makes per-function splitting
+awkward. This is a quality-of-life suggestion only.
+
+---
+
+**Issue 9: No direct tests for `.format_scalar_result()` and `.format_list_result()` in PR 2**
+Severity: SUGGESTION
+
+PR 2 writes direct tests for `.check_is_survey_or_df()` and `.parse_setter_input()` but
+not for `.format_scalar_result()` or `.format_list_result()`. Both helpers contain
+non-trivial logic:
+- `.format_scalar_result()`: three output format branches, `fill` filtering logic
+- `.format_list_result()`: two output format branches, `surveycore_error_format_invalid`
+  error path
+
+These are tested only indirectly through PR 4's extractor tests. If a format
+branch in either helper has a bug, it won't have a direct test to isolate it.
+
+Options:
+- **[A]** Add a small `# ── .format_scalar_result() ────` section in PR 2 Step 2.2
+  with 3-4 direct unit tests (one per format, one for empty result). Similarly for
+  `.format_list_result()`. — Effort: low
+- **[C] Do nothing** — indirectly tested via PR 4 extractors; risk is low since the
+  helpers are simple wrappers.
+
+**Recommendation: [A]** — direct tests make debugging faster if an extractor test fails.
+
+---
+
+## Summary (Pass 1)
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 1 |
+| REQUIRED | 5 |
+| SUGGESTION | 3 |
+
+**Total issues:** 9
+
+**Overall assessment:** The plan is well-structured with clear TDD task ordering, correct
+dependency sequencing, and comprehensive test coverage in PRs 3 and 4. One blocking issue
+must be resolved before implementation: the six round-trip tests in PR 3 depend on PR 4's
+updated extractor API signatures and cannot pass at PR 3 merge time — moving them to PR 4
+is the fix. Five required issues address missing acceptance criteria (coverage gates,
+document criterion, changelog/NEWS.md) and one verification gap (lifecycle in Imports).
+Resolving these leaves the plan fully implementable.
+
+---
+
+## Plan Review: metadata-update — Pass 2 (2026-03-11)
+
+### Prior Issues (Pass 1)
+
+| # | Title | Status |
+|---|---|---|
+| 1 | Round-trip tests in PR 3 depend on PR 4's extractor API — cannot pass at PR 3 CI | ✅ Resolved |
+| 2 | Changelog entries and NEWS.md missing from all four PRs | ✅ Resolved |
+| 3 | `.resolve_vars()` has no direct tests in PR 2 | ✅ Resolved |
+| 4 | `lifecycle` in Imports not verified, only assumed | ✅ Resolved |
+| 5 | 98%+ coverage criterion absent from PRs 1–3 | ✅ Resolved |
+| 6 | `devtools::document()` missing from PR 2 and PR 3 acceptance criteria | ✅ Resolved |
+| 7 | `air::format_package()` absent from per-PR acceptance criteria | ✅ Resolved |
+| 8 | PR 3 scope very large — split suggestion | ⚠️ Still open ([C] was recommendation; unchanged) |
+| 9 | No direct tests for `.format_scalar_result()` and `.format_list_result()` in PR 2 | ✅ Resolved |
+
+### New Issues
+
+---
+
+#### Section: PR 1 — S7 Class Properties + Error Catalog
+
+No new issues found.
+
+---
+
+#### Section: PR 2 — Internal Helper Infrastructure
+
+No new issues found.
+
+---
+
+#### Section: PR 3 — Unified Setters + Deprecations
+
+---
+
+**Issue 10: `lifecycle::deprecate_soft()` template in Step 3.13 passes `...` as fourth argument — this will throw an error for any non-trivial call**
+Severity: REQUIRED
+Violates code correctness: the code template in the plan produces broken deprecated functions.
+
+PR 3 Step 3.13 provides this code template:
+```r
+set_variable_labels <- function(x, ...) {
+  lifecycle::deprecate_soft("0.5.0", "set_variable_labels()", "set_var_label()", ...)
+  set_var_label(x, ...)
+}
+```
+
+`lifecycle::deprecate_soft()` has this signature:
+```r
+deprecate_soft(when, what, with = NULL, details = NULL, id = NULL, env = caller_env(), user_env = caller_env(1))
+```
+
+The `...` from the outer function is forwarded as a fourth positional argument, which
+maps to `details`. When a caller passes named arguments (e.g.,
+`set_variable_labels(svy, age = "Age in years")`), `rlang::list2(age = "Age in years")`
+enters the fourth slot. Since `details` is not named `age`, R throws
+`Error: unused argument (age = "Age in years")`. This means every deprecated function
+that receives variable-setting arguments will error instead of emitting a deprecation
+warning and delegating.
+
+The correct template is:
+```r
+set_variable_labels <- function(x, ...) {
+  lifecycle::deprecate_soft("0.5.0", "set_variable_labels()", "set_var_label()")
+  set_var_label(x, ...)
+}
+```
+The `...` is passed only to `set_var_label()`, not to `lifecycle::deprecate_soft()`.
+
+Options:
+- **[A]** Fix the code template in Step 3.13 to remove `...` from the
+  `lifecycle::deprecate_soft()` call for all four deprecated wrappers. Update
+  the deprecation test blocks in Step 3.2 to call the deprecated functions WITH
+  arguments (e.g., `set_variable_labels(svy, age = "Age in years")`) to catch
+  this class of bug in CI. — Effort: trivial, Risk: none
+- **[C] Do nothing** — all four deprecated functions throw errors when used with
+  any arguments; deprecation tests that call them without arguments would pass
+  while real-world usage silently fails.
+
+**Recommendation: [A]** — fix the template; the bug is concrete and the fix is one word.
+
+---
+
+**Issue 11: PR 3 Step 3.15 removes `.check_is_survey()` unconditionally — spec requires removal to be conditional on grep result**
+Severity: REQUIRED
+Violates spec Section 3.2: "If call sites exist elsewhere (e.g., `infer_question_prefaces()` or other functions not updated by this spec), leave `.check_is_survey()` in place and do not remove it."
+
+Step 3.15 reads:
+> "Remove `.check_is_survey()` from `R/core-metadata.R` (zero callers remaining after
+> all setter replacements). Verify with `grep -r ".check_is_survey(" R/`."
+
+The phrasing states "zero callers" as a fact and presents the `grep` as post-hoc
+verification. The spec requires a conditional: remove ONLY IF grep returns zero results
+across all R/ files. If `infer_question_prefaces()` or any other function in the codebase
+calls `.check_is_survey()`, removing it breaks that function silently (no compilation
+error, but a runtime "could not find function" error).
+
+Options:
+- **[A]** Rewrite Step 3.15 as two explicit sub-steps:
+  1. Run `grep -r ".check_is_survey(" R/` to find all call sites.
+  2. If the ONLY result is inside `core-metadata.R` (i.e., zero external callers):
+     remove `.check_is_survey()`. Otherwise: leave it in place and do not remove it.
+  — Effort: trivial, Risk: none
+- **[C] Do nothing** — if an external caller exists, the implementer removes the function
+  anyway, breaking that caller; CI would catch it only if the caller has tests.
+
+**Recommendation: [A]** — grep is a one-line check that prevents a hard-to-debug silent failure.
+
+---
+
+#### Section: All PRs — Quality Gates
+
+---
+
+**Issue 12: `lintr::lint_package()` missing from Quality Gates footer and all four PR acceptance criteria**
+Severity: REQUIRED
+Violates spec Section XI: "`lintr::lint_package()` produces 0 lints (80-char line length,
+native pipe, snake_case, `<-` assignment)" is explicitly required.
+
+The Quality Gates footer at the bottom of the plan lists:
+- `devtools::document()` ✅
+- `air::format_package()` ✅
+- `devtools::check()` ✅
+- Snapshot review ✅
+
+`lintr::lint_package()` is absent from the footer and from all four individual PR
+acceptance criteria. `air` handles code formatting (indentation, line wrapping) but
+`lintr` checks style rules that `air` does not enforce: native pipe consistency
+(`pipe_consistency_linter("native")`), object naming (`object_name_linter("snake_case")`),
+and assignment operator (`assignment_linter()`). Code with `%>%` pipes or `=` assignments
+would pass `air::format_package()` cleanly but fail `lintr::lint_package()`.
+
+Options:
+- **[A]** Add `lintr::lint_package() — 0 lints` to the Quality Gates footer and to
+  each PR's acceptance criteria (same position as `air::format_package()`).
+  — Effort: trivial, Risk: none
+- **[C] Do nothing** — style violations that `air` doesn't catch could enter the codebase;
+  only detected if CI is configured to run lintr (which is not confirmed in the plan).
+
+**Recommendation: [A]**
+
+---
+
+**Issue 13: Lifecycle DESCRIPTION update in PR 1 may produce a non-pre-approved R CMD check NOTE if lifecycle is not already used in the package**
+Severity: REQUIRED
+Violates the ≤2 pre-approved notes constraint: adding a package to `Imports` without
+any `::` usage in current source produces an "Imported but not used" NOTE.
+
+PR 1 Notes now correctly include: "Verify `lifecycle` is in `Imports`: run
+`grep 'lifecycle' DESCRIPTION`. If missing, add `lifecycle (>= 1.0.0)` to `Imports`."
+
+If lifecycle is NOT already in Imports AND NOT already used via `lifecycle::` calls in
+any existing R/ file, adding it to DESCRIPTION in PR 1 creates an Imports entry with
+zero corresponding `lifecycle::` calls in the codebase. R CMD check scans source files
+for `::` usage and produces a NOTE for packages listed in Imports that are not referenced:
+"package 'lifecycle' listed in Imports, but is not used in package source." This is NOT
+one of the two pre-approved notes, so PR 1's acceptance criterion `devtools::check()
+0/0/≤2` would be violated.
+
+The `lifecycle::deprecate_soft()` calls are only introduced in PR 3. The correct
+placement for the DESCRIPTION update (if lifecycle is absent) is PR 3, where it first
+has a call site.
+
+Options:
+- **[A]** Change PR 1 Notes to: "Verify `lifecycle` is in `Imports`. If missing, **note
+  that DESCRIPTION will be updated in PR 3** when `lifecycle::deprecate_soft()` is first
+  called. Do not add it in PR 1." Move the conditional DESCRIPTION update step to PR 3
+  (e.g., between Steps 3.12 and 3.13). — Effort: trivial, Risk: none
+- **[B]** Keep the check in PR 1 but only add lifecycle to Imports in PR 3 regardless
+  of where the check is performed. — Effort: trivial, effectively same as [A]
+- **[C] Do nothing** — if lifecycle is not yet in Imports, PR 1's `devtools::check()`
+  produces a new non-pre-approved NOTE that fails the acceptance criterion.
+
+**Recommendation: [A]** — DESCRIPTION changes belong in the PR where the dependency
+is first used.
+
+---
+
+#### Section: Suggestions
+
+---
+
+**Issue 14: Snapshot test review criterion absent from PR 2 and PR 3 acceptance criteria**
+Severity: SUGGESTION
+
+PR 4 acceptance criteria include "All snapshot tests match (`testthat::snapshot_review()`
+before merge)." The Quality Gates footer includes "Snapshot tests reviewed with
+`testthat::snapshot_review()` (not auto-accepted)."
+
+PRs 2 and 3 also create new snapshots:
+- PR 2: `.check_is_survey_or_df()` error snapshot, four `.parse_setter_input()` error
+  snapshots, one `.resolve_vars()` warning snapshot, one `.format_list_result()` error
+  snapshot — at least 7 new snapshots
+- PR 3: all setter error and warning snapshots — 20+ new snapshots
+
+When `expect_snapshot(error = TRUE, ...)` runs for the first time in a test suite,
+testthat auto-creates the snapshot file and the test passes. Without a `snapshot_review()`
+step, the implementer may commit snapshots containing incorrect or unreviewed error text.
+
+Options:
+- **[A]** Add "Run `testthat::snapshot_review()` — approve all new snapshots before merge"
+  to PR 2 and PR 3 acceptance criteria. — Effort: trivial
+- **[C] Do nothing** — the global quality gates mention it; risk is that per-PR
+  review is skipped in practice.
+
+**Recommendation: [A]**
+
+---
+
+**Issue 15: PR 3 Step 3.2 writes tests for all 6 setters in one step — exceeds the 2–5 minute task granularity guideline**
+Severity: SUGGESTION
+Violates implementation-workflow skill: "Each task in the plan should be one action
+(2–5 minutes). TDD sub-steps must be explicit steps."
+
+Step 3.2 is a single step that asks the implementer to write ALL test blocks for ALL
+six setters before any implementation — at minimum 60–80 test blocks covering
+conventions 1/2/3, return values, pipe chains, NULL deletion, data frame attributes,
+all error classes, all warning classes, and snapshots. Executing this in one step takes
+significantly longer than 5 minutes and creates a large unstaged file with no
+intermediate checkpoint.
+
+Steps 3.4–3.12 correctly implement one setter per step. The test-writing phase should
+mirror this granularity.
+
+Options:
+- **[A]** Split Step 3.2 into six sub-steps, one per setter:
+  - Step 3.2a: Write `set_var_label()` test blocks
+  - Step 3.2b: Write `set_val_labels()` test blocks
+  - Steps 3.2c–f: Write test blocks for the remaining four setters
+  Each sub-step is immediately followed by its implementation step in the TDD cycle.
+  (e.g., 3.2a → 3.3 confirm failure → 3.4 implement `set_var_label()` → 3.5 confirm pass
+  → 3.2b → confirm failure → 3.6 implement `set_val_labels()` → 3.7 confirm pass → ...)
+  — Effort: low reorganization, Risk: none
+- **[C] Do nothing** — large single step is inconvenient but the implementer can
+  work through it sequentially; `r-implement` handles granular execution.
+
+**Recommendation: [A]** — aligning test-writing steps with implementation steps makes
+TDD failures immediately diagnosable and keeps each checkpoint small.
+
+---
+
+**Issue 16: Step 4.12 NEWS.md item 2 incorrectly lists `extract_universe()` as a breaking return-type change**
+Severity: SUGGESTION
+
+PR 4 Step 4.12 item 2 reads:
+> "`extract_var_label()`, `extract_question_preface()`, `extract_var_note()`,
+> `extract_universe()` now return a named character vector (not a plain scalar)
+> for single-variable calls."
+
+`extract_universe()` is a NEW function introduced by this spec. It has no prior API
+and therefore no prior return type to break. Including it in the "Breaking Changes"
+section is technically inaccurate and may confuse users who understand a breaking
+change as a change to an existing function's behavior.
+
+Options:
+- **[A]** Remove `extract_universe()` from item 2. The correct list is:
+  "`extract_var_label()`, `extract_question_preface()`, and `extract_var_note()`
+  now return a named character vector (not a plain scalar)." List
+  `extract_universe()` and `extract_missing_codes()` in a separate `### New
+  Functions` or `### New Features` section if one exists. — Effort: trivial
+- **[C] Do nothing** — technically inaccurate but harmless; users will understand
+  the intent.
+
+**Recommendation: [A]** — accurate NEWS.md entries matter; the fix is one line.
+
+---
+
+## Summary (Pass 2)
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 0 |
+| REQUIRED | 4 |
+| SUGGESTION | 3 |
+
+**Total new issues:** 7
+
+**Overall assessment:** The plan is substantially improved from Pass 1 — all eight
+resolvable prior issues are addressed and the blocking issue is gone. Four required
+fixes remain before implementation: Issue 10 (the `lifecycle::deprecate_soft()` template
+bug) is the highest priority, as it would silently ship broken deprecated functions that
+error on any real-world call; Issues 11–13 are straightforward clarifications. Three
+suggestions address test step granularity, snapshot review placement, and NEWS.md
+accuracy. Resolving the four required issues leaves the plan fully ready for
+`/r-implement`.

--- a/plans/spec-metadata-update.md
+++ b/plans/spec-metadata-update.md
@@ -1,8 +1,8 @@
 # surveycore Metadata API Update — Formal Specification
 
-**Version:** 2.0
+**Version:** 3.0
 **Date:** March 2026
-**Status:** Approved — code review resolved; ready for implementation
+**Status:** Approved — code review Pass 2 resolved; ready for implementation
 
 ---
 
@@ -237,6 +237,7 @@ unnamed elements (Section IX, M-12).
   content,
   content_arg_name,
   content_type = c("scalar", "vector"),  # "scalar" for char setters; "vector" for list/code setters
+  fn_name,           # name of the calling setter, e.g. "set_var_label" — used in M-4 and M-12 messages
   call = rlang::caller_env()
 )
 ```
@@ -280,7 +281,7 @@ format. Used by `extract_val_labels()` and `extract_missing_codes()`.
 .format_list_result <- function(
   result_list,  # named list of named vectors (or NAs/NULLs)
   format,       # "list" or "data_frame"
-  fn_name       # "extract_val_labels" or "extract_missing_codes"
+  fn_name       # name of the calling extractor — used in M-6 (surveycore_error_format_invalid) message
 )
 ```
 
@@ -342,8 +343,23 @@ error with `surveycore_error_setter_ambiguous`.
 **Empty error:** If `...` is empty AND `variable` is NULL, error with
 `surveycore_error_setter_empty`.
 
+**Unnamed `...` elements:** If any element of `...` has no name (whether all
+unnamed or a mix of named and unnamed), error with
+`surveycore_error_setter_mixed_dots` (M-12). This covers the case
+`set_var_label(svy, c("Age", "Income"))` where the single unnamed element is
+itself an unnamed vector — it satisfies neither Convention 1 (elements of `...`
+must be named) nor Convention 2 (requires the single element to be a
+**named** vector).
+
 **Length mismatch (convention 3 only):** If `length(variable) != length(content)`,
 error with `surveycore_error_setter_mismatched_lengths`.
+
+**Convention 3 with `length(variable) == 0`:** Issues
+`surveycore_warning_setter_empty_variables` and returns `invisible(x)`
+unchanged. This is a valid programmatic pattern when a filter reduces the
+variable vector to zero entries at runtime (e.g.,
+`set_universe(svy, variable = vars[vars %in% valid_cols], ...)`). No metadata
+is modified.
 
 **Variable not found:** If a variable name appears in the input but not in the
 data (`x@data` or `names(x)` for data frames), issue a
@@ -352,6 +368,15 @@ it. Do NOT error — this allows safe bulk operations on heterogeneous datasets.
 
 **`!!!` splicing support:** All three conventions support `rlang::list2(...)`
 semantics, so `!!!` works with convention 1 and 2 in the `...` position.
+
+**Scalar-content validation (applies to all four scalar-content setters:
+`set_var_label()`, `set_question_preface()`, `set_var_note()`,
+`set_universe()`):** Each content value must be a character scalar
+(`is.character(v) && length(v) == 1L`, excluding `NULL` which signals
+deletion). A non-character value or a vector of length > 1 errors immediately
+with `surveycore_error_label_not_scalar`. No coercion is performed. This rule
+is defined once here and referenced (not restated) in Sections 4.3, 4.5, 4.6,
+and 4.7.
 
 **Return:** `invisible(x)` always. The modified object is returned — for survey
 objects, the `@metadata` property is updated. For data frames, column
@@ -396,8 +421,10 @@ For survey objects, `x@metadata@variable_labels` is updated. For data frames,
 `attr(df[[var]], "label")` is updated for each variable.
 
 **Behavior rules:**
-- Each label value must be a single character string. Non-character or
-  length > 1 values are coerced with a warning (using `as.character()`).
+- Each label value must be a single character string (character scalar). A
+  non-character value or a vector of length > 1 errors with
+  `surveycore_error_label_not_scalar`. (See Section 4.1 for the unified
+  scalar-content validation rule.)
 - `NULL` label removes an existing label entry (same as deleting the key from
   the named list).
 - Variable not found in data → `surveycore_warning_var_not_found`, skip.
@@ -432,7 +459,7 @@ svy <- svy |>
   set_var_label(income = "Annual income")
 ```
 
-**Error / warning rows:** See Section IX, rows M-1, M-3, M-4, M-5, M-7.
+**Error / warning rows:** See Section IX, rows M-1, M-3, M-4, M-5, M-7, M-11, M-13.
 
 ### 4.4 `set_val_labels()`
 
@@ -461,7 +488,9 @@ For survey objects, `x@metadata@value_labels` is updated. For data frames,
   any(names(entry) == "")` triggers `surveycore_error_labels_unnamed`.
 - Extra labels (codes not present in the data) are silently allowed.
 - Observed values without a label trigger `surveycore_warning_missing_labels`
-  (same as existing behavior).
+  (M-9). This check applies to both survey objects and data frames: observed
+  unique values are read from `x@data[[var]]` for survey objects, or `x[[var]]`
+  for data frames.
 - `NULL` labels value removes the entry for that variable.
 - Variable not found in data → `surveycore_warning_var_not_found`, skip.
 
@@ -528,7 +557,9 @@ For survey objects, `x@metadata@question_prefaces` is updated. For data frames,
 `attr(df[[var]], "question_preface")` is updated.
 
 **Behavior rules:**
-- Each preface value must be a single character string.
+- Each preface value must be a character scalar. Non-character or length > 1
+  errors with `surveycore_error_label_not_scalar` (see Section 4.1 unified
+  scalar-content validation rule).
 - `NULL` preface removes the entry for that variable.
 - Variable not found in data → `surveycore_warning_var_not_found`, skip.
 
@@ -588,6 +619,9 @@ For survey objects, `x@metadata@notes` is updated. For data frames,
 `attr(df[[var]], "note")` is updated.
 
 **Behavior rules:**
+- Each note value must be a character scalar. Non-character or length > 1
+  errors with `surveycore_error_label_not_scalar` (see Section 4.1 unified
+  scalar-content validation rule).
 - `NULL` note removes the entry for that variable.
 - Variable not found in data → `surveycore_warning_var_not_found`, skip.
 
@@ -633,6 +667,9 @@ set_universe(x, ..., variable = NULL, universe = NULL)
 `@metadata`. For data frames, `attr(df[[var]], "universe")` is updated.
 
 **Behavior rules:**
+- Each universe value must be a character scalar. Non-character or length > 1
+  errors with `surveycore_error_label_not_scalar` (see Section 4.1 unified
+  scalar-content validation rule).
 - `NULL` universe removes the entry for that variable.
 - Variable not found in data → `surveycore_warning_var_not_found`, skip.
 - Universe strings are documentation only — no computational validation is
@@ -719,7 +756,12 @@ svy <- set_missing_codes(
 )
 ```
 
-**Error / warning rows:** See Section IX, rows M-1, M-3, M-4, M-5, M-7, M-10.
+**Convention 3 for `codes`:** `codes` argument must be a list of atomic vectors
+(one per variable). A bare atomic vector (not wrapped in a list) for a single
+variable is accepted when `length(variable) == 1L`, parallel to
+`set_val_labels()` Section 4.4.
+
+**Error / warning rows:** See Section IX, rows M-1, M-3, M-4, M-5, M-7, M-10, M-14.
 
 ---
 
@@ -751,14 +793,32 @@ field.
 | `fill` value | Behavior |
 |-------------|----------|
 | `NULL` (default) | Variables with no metadata are OMITTED from the result. |
-| `NA_character_` | Variables with no metadata are INCLUDED with the value `NA`. For `"named_vector"` output: `NA_character_`. For `"list"` output: `NULL` (since `NA` is not a meaningful list value for vector fields). For `"data_frame"` output: `NA` in the content column. |
+| `NA_character_` | Variables with no metadata are INCLUDED. For `"named_vector"` output: `NA_character_`. For `"list"` output: `NA_character_` for scalar fields; `NULL` for vector fields (see note below). For `"data_frame"` output: `NA` in the content column. |
 
-**Note on `fill = NA_character_` in `"list"` format:** Users who pass
-`fill = NA_character_` with `format = "list"` will receive `NULL` entries for
-variables without metadata — not `NA_character_`. This is intentional: `NA`
-has no meaningful interpretation as a placeholder for a named vector field (e.g.,
-value labels). The `NULL` signals "no labels set" consistently with R list
-semantics. If you need `NA` placeholders, use `format = "data_frame"`.
+**Note on `fill = NA_character_` in `"list"` format:** Behavior differs by
+field type:
+
+- **Scalar-content extractors** (`extract_var_label`, `extract_question_preface`,
+  `extract_var_note`, `extract_universe`): `fill = NA_character_` in `"list"`
+  format yields `NA_character_` list entries for variables with no metadata.
+  `NA` is a valid placeholder for a character scalar field.
+- **Vector-content extractors** (`extract_val_labels`, `extract_missing_codes`):
+  `fill = NA_character_` in `"list"` format yields `NULL` entries. `NA` has no
+  meaningful interpretation as a placeholder for a named vector field (e.g.,
+  value labels). The `NULL` signals "no labels set" consistently with R list
+  semantics.
+
+If you need uniform `NA` placeholders regardless of field type, use
+`format = "data_frame"`.
+
+**Note on fill values for `extract_metadata()`:** `extract_metadata()` uses
+`fill = "include"` (not `fill = NA_character_`) because its output is a
+structured list, not a typed vector — `NA_character_` has no meaningful
+interpretation there. Passing `fill = NA_character_` to `extract_metadata()`
+errors with `surveycore_error_fill_invalid`. Conversely, passing
+`fill = "include"` to individual extractors (e.g., `extract_var_label()`) also
+errors with `surveycore_error_fill_invalid`. Each function validates its `fill`
+argument against its own allowed set at the top of the function body.
 
 **`format` argument:**
 
@@ -1085,7 +1145,7 @@ extract_metadata(x, ..., fill = NULL)
 |----------|------|---------|-------------|
 | `x` | survey object or `data.frame` | required | The object to query. |
 | `...` | bare names or missing | empty | Variables to include. If empty, all variables. |
-| `fill` | `NULL` or `"include"` | `NULL` | Controls whether variables with no metadata in any field are returned. `NULL` (default) omits variables where all six metadata fields are `NULL` (and `transformations` is `list()`). `"include"` returns all variables regardless of whether they have any metadata — useful for structural audits. Note: `extract_metadata()` does NOT have a `format` argument; the output structure is always a named list. |
+| `fill` | `NULL` or `"include"` | `NULL` | Controls whether variables with no metadata in any field are returned. `NULL` (default) omits variables where all six metadata fields are `NULL` (and `transformations` is `list()`). `"include"` returns all variables regardless of whether they have any metadata — useful for structural audits. Any other value (including `NA_character_`) errors with `surveycore_error_fill_invalid`. Note: `extract_metadata()` does NOT have a `format` argument; the output structure is always a named list. Unlike individual extractors which use `fill = NA_character_` to include missing variables, `extract_metadata()` uses `"include"` because its values are structured lists, not typed scalars. |
 
 `fill = "include"` is equivalent to the old always-include behavior. The
 default `fill = NULL` follows the same "omit unset variables" convention as
@@ -1330,15 +1390,21 @@ vector — this triggers `surveycore_error_setter_empty` (neither convention
 detects a valid input when an unnamed symbol and a string are passed as
 separate positional args).
 
-**Detection and error message:** Each setter captures `...` as quosures via
-`rlang::enquos(...)` **before** evaluating them, and checks for the old
-positional form at the top of the function body — before passing evaluated
-values to `.parse_setter_input()`. Detection condition: the quosures list has
-exactly two elements where the first is an unquoted symbol
-(`rlang::is_symbol(rlang::quo_get_expr(qs[[1L]]))`) and the second is a scalar
-string with no name. If detected, issue a targeted error with class
-`surveycore_error_old_positional_setter` immediately (do not call
-`.parse_setter_input()`). Only after passing this check should the setter
+**Detection and error message:** Only `set_var_label()` performs the old
+positional form check. The other five setters (`set_val_labels()`,
+`set_question_preface()`, `set_var_note()`, `set_universe()`,
+`set_missing_codes()`) never had a positional form with a bare symbol + scalar
+string signature, so they skip this check entirely and evaluate `...` directly
+via `rlang::list2(...)`.
+
+For `set_var_label()` only: capture `...` as quosures via `rlang::enquos(...)`
+**before** evaluating them, and check for the old positional form at the top of
+the function body — before passing evaluated values to `.parse_setter_input()`.
+Detection condition: the quosures list has exactly two elements where the first
+is an unquoted symbol (`rlang::is_symbol(rlang::quo_get_expr(qs[[1L]]))`) and
+the second is a scalar string with no name. If detected, issue a targeted error
+with class `surveycore_error_old_positional_setter` immediately (do not call
+`.parse_setter_input()`). Only after passing this check should `set_var_label()`
 evaluate `...` via `rlang::list2(...)` and proceed to `.parse_setter_input()`.
 
 ```
@@ -1378,13 +1444,16 @@ noted.
 | M-3 | all setters | Both `...` and explicit `variable`/content args are provided simultaneously | ERROR | `surveycore_error_setter_ambiguous` | `"x" = "Provide variable names via {.arg ...} or via {.arg variable}, not both.", "i" = "Use named {.arg ...} args, a named vector in {.arg ...}, or {.arg variable} + {.arg {content_arg}} — not a mix."` |
 | M-4 | all setters | Neither `...` nor `variable`/content args are provided | ERROR | `surveycore_error_setter_empty` | `"x" = "{.fn {fn_name}} requires at least one variable-label pair.", "v" = "Use named {.arg ...} args: {.code {fn_name}(x, age = 'Age in years')}."` |
 | M-5 | all setters (convention 3) | `length(variable) != length(content)` | ERROR | `surveycore_error_setter_mismatched_lengths` | `"x" = "{.arg variable} has {length(variable)} element{?s} but {.arg {content_arg}} has {length(content)} element{?s}.", "i" = "They must be the same length (one content value per variable name)."` |
-| M-6 | all extractors | `format` argument has an invalid value | ERROR | `surveycore_error_format_invalid` | `"x" = '{.arg format} must be one of {.val {valid_formats}}, not {.val {format}}.', "i" = "Got: {.val {format}}."` |
+| M-6 | all extractors | `format` argument has an invalid value | ERROR | `surveycore_error_format_invalid` | `"x" = "{.fn {fn_name}} received an invalid {.arg format} value {.val {format}}.", "i" = "{.arg format} must be one of {.val {valid_formats}}."` |
 | M-7 | all setters | A variable specified in input is not found in `x@data` / `names(x)` | WARN | `surveycore_warning_var_not_found` | `"!" = "{length(missing)} variable{?s} not found in {.arg x} and {?was/were} skipped: {.field {missing}}.", "i" = "Check spelling. Available columns: {.field {head(all_cols, 10)}}{?.}"` |
 | M-8 | `set_val_labels()`, `set_value_labels()` (deprecated) | A labels entry is not a fully named vector | ERROR | `surveycore_error_labels_unnamed` | `"x" = "Value labels for {.field {var_name}} must be a fully named vector.", "i" = "All elements must have names (e.g., {.code c(Male = 1L, Female = 2L)})."` (existing class — reuse row 29) |
 | M-9 | `set_val_labels()` | Some observed data values have no corresponding label | WARN | `surveycore_warning_missing_labels` | `"!" = "Not all values of {.field {var_name}} are labeled.", "i" = "Unlabeled values: {.val {missing}}."` (existing class — reuse row 30) |
 | M-10 | `set_missing_codes()` | A `codes` entry is not an atomic vector | ERROR | `surveycore_error_missing_codes_not_vector` | `"x" = "Missing codes for {.field {var_name}} must be an atomic vector, not {.cls {class(codes_entry)[[1L]]}}.", "i" = "Use a numeric, integer, or character vector (e.g., {.code c(Refused = 99L, {\"Don't know\"} = 98L)})."` |
 | M-11 | `set_var_label()` | Old positional NSE form detected | ERROR | `surveycore_error_old_positional_setter` | `"x" = "The old positional calling form {.code {fn_name}(x, var, content)} is no longer supported.", "i" = "The new unified setter uses named arguments.", "v" = "Use {.code {fn_name}(x, {var_name} = {.val {content_val}})} instead."` |
-| M-12 | all setters | `...` contains a mix of named and unnamed elements (matches no convention) | ERROR | `surveycore_error_setter_mixed_dots` | `"x" = "All {.arg ...} arguments must be named when using Convention 1.", "i" = "Got {sum(nzchar(names(dots)))} named and {sum(!nzchar(names(dots)))} unnamed element{?s}.", "v" = "Use {.code {fn_name}(x, age = 'Age', income = 'Annual income')} or a fully named vector."` |
+| M-12 | all setters | `...` contains any unnamed element(s) — either all unnamed or a mix of named and unnamed (matches no convention) | ERROR | `surveycore_error_setter_mixed_dots` | `"x" = "All {.arg ...} arguments must be named when using Convention 1.", "i" = "Got {sum(nzchar(names(dots)))} named and {sum(!nzchar(names(dots)))} unnamed element{?s}.", "v" = "Use {.code {fn_name}(x, age = 'Age', income = 'Annual income')} or a fully named vector."` |
+| M-13 | scalar-content setters (`set_var_label`, `set_question_preface`, `set_var_note`, `set_universe`) | A content value is not a character scalar (wrong type or length > 1) | ERROR | `surveycore_error_label_not_scalar` | `"x" = "Label content for {.field {var_name}} must be a character scalar, not {.cls {class(val)[[1L]]}} of length {length(val)}.", "v" = "Pass a single character string, e.g. {.code {fn_name}(x, {var_name} = 'My label')}."` |
+| M-14 | all setters (convention 3) | `variable` argument is explicitly provided as `character(0)` (length 0) | WARN | `surveycore_warning_setter_empty_variables` | `"!" = "{.fn {fn_name}} was called with {.arg variable} of length 0.", "i" = "No metadata was set. Did you accidentally filter all variable names out?"` |
+| M-15 | all extractors, `extract_metadata()` | `fill` argument has an invalid value for this function | ERROR | `surveycore_error_fill_invalid` | `"x" = "{.fn {fn_name}} does not accept {.code fill = {.val {fill}}}.", "i" = "Valid values for {.fn {fn_name}}: {.val {valid_fill_values}}."` |
 
 **Notes:**
 - M-2 and M-7 use the same warning class `surveycore_warning_var_not_found`
@@ -1458,6 +1527,8 @@ For each of the six setters (`set_var_label`, `set_val_labels`,
 - Convention 1 with `!!!` splicing sets correct metadata
 - Convention 2 (single named vector) sets correct metadata
 - Convention 3 (explicit `variable` + content) sets correct metadata
+- **Convention 3 bare-vector exception (`set_val_labels()`):** `set_val_labels(svy, variable = "sex", labels = c(Male = 1L, Female = 2L))` (bare vector, not list) sets labels correctly when `length(variable) == 1L`
+- **Convention 3 bare-vector exception (`set_missing_codes()`):** `set_missing_codes(svy, variable = "q5", codes = c(99L, 98L))` (bare vector, not list) sets codes correctly when `length(variable) == 1L`
 - Return value is `invisible(x)` (test with `withVisible()`)
 - Result survives pipe chain: three consecutive setter calls return valid object
 - **NULL deletion (scalar-content setters: `set_var_label`, `set_question_preface`,
@@ -1473,12 +1544,16 @@ For each of the six setters (`set_var_label`, `set_val_labels`,
 - Neither provided → `surveycore_error_setter_empty` (class + snapshot)
 - Convention 3 length mismatch → `surveycore_error_setter_mismatched_lengths` (class + snapshot)
 - Old positional NSE form → `surveycore_error_old_positional_setter` (class + snapshot) [set_var_label only]
+- Non-character or length > 1 content value → `surveycore_error_label_not_scalar` (class + snapshot) [scalar-content setters only: `set_var_label`, `set_question_preface`, `set_var_note`, `set_universe`]
+- Unnamed `...` element → `surveycore_error_setter_mixed_dots` (class + snapshot)
 
 **Warning path blocks:**
 - Variable not in data → `surveycore_warning_var_not_found` (class + snapshot)
 - Variable skipped but other variables still set (result check on the returned object)
 - `set_val_labels()` with partially labeled data → `surveycore_warning_missing_labels`
+- `set_val_labels(df, ...)` on a data frame with unlabeled values → `surveycore_warning_missing_labels` (confirms M-9 fires for data frames)
 - `set_missing_codes()` with list-type codes entry → `surveycore_error_missing_codes_not_vector`
+- Convention 3 with `variable = character(0)` → `surveycore_warning_setter_empty_variables` (class + snapshot)
 
 **Data frame blocks:**
 - `set_var_label(df, age = "Age in years")` sets `attr(df$age, "label") == "Age in years"`

--- a/plans/spec-review-metadata-update.md
+++ b/plans/spec-review-metadata-update.md
@@ -1,0 +1,574 @@
+## Spec Review: metadata-update — Pass 1 (2026-03-10)
+
+### New Issues
+
+#### Section: III. Architecture / Internal Helpers
+
+---
+
+**Issue 1: `.parse_setter_input()` cannot simultaneously detect the old positional form (requires quosures) and check Convention 2 content types (requires evaluated values)**
+Severity: BLOCKING
+Violates engineering-preferences.md §5 (explicit over clever); creates an unresolvable implementation ambiguity.
+
+Section 8.3 specifies old positional form detection via:
+```r
+rlang::is_symbol(rlang::quo_get_expr(dots[[1L]]))
+```
+This requires `dots` to be a list of **unevaluated quosures** (captured with `rlang::enquos(...)`). But Convention 2 detection (Section 4.1) checks whether `dots[[1L]]` is a named character vector or named list — which requires **evaluated values** (captured with `rlang::list2(...)`). These two strategies are mutually exclusive: a quosure is not the evaluated value; an evaluated value has lost the symbol information needed for the old positional form check.
+
+The spec says `.parse_setter_input()` handles both, but does not resolve how.
+
+Options:
+- **[A]** Move old positional form detection to the caller (each setter) before invoking `.parse_setter_input()`, using `rlang::enquos(...)` at the setter level. `.parse_setter_input()` receives only evaluated values via `rlang::list2(...)`. — Effort: low, Risk: low, Impact: cleaner separation of concerns, Maintenance: low
+- **[B]** Pass both a quosures list AND an evaluated list to `.parse_setter_input()`, increasing its parameter count. — Effort: low, Risk: medium (complex signature), Impact: single entry point for all detection, Maintenance: medium
+- **[C] Do nothing** — implementer must guess the capture strategy; whichever they choose silently breaks either Convention 2 or old-form detection.
+
+**Recommendation: [A]** — separates NSE symbol detection (caller concern) from value parsing (shared helper concern). Clean, explicit, and keeps `.parse_setter_input()` free of quosure mechanics.
+
+---
+
+**Issue 2: `.parse_setter_input()` has no mechanism to discriminate Convention 2 content type between scalar-content and list-content setters**
+Severity: BLOCKING
+Violates engineering-preferences.md §5 (explicit over clever).
+
+Convention 2 detection differs fundamentally by setter type:
+- For `set_var_label()`, `set_question_preface()`, `set_var_note()`, `set_universe()`: Convention 2 is a single unnamed element in `...` that is a named **character vector**.
+- For `set_val_labels()`, `set_missing_codes()`: Convention 2 is a single unnamed element in `...` that is a named **list**.
+
+The spec calls `.parse_setter_input()` a "shared" helper for all six setters but provides no parameter to communicate which content type to expect. Without this, Convention 2 detection for `set_val_labels(svy, list(...))` is indistinguishable from a list accidentally passed to `set_var_label()`. The helper cannot correctly validate Convention 2 without knowing the expected content type.
+
+Options:
+- **[A]** Add a `content_type` parameter to `.parse_setter_input()` accepting `"scalar"` or `"vector"`. Convention 2 detection branches on this value. — Effort: low, Risk: low, Impact: fully specifies the helper's contract, Maintenance: low
+- **[B]** Remove Convention 2 detection from `.parse_setter_input()` and handle it in each setter individually. `.parse_setter_input()` handles only Convention 1 and 3. — Effort: low, Risk: low, Impact: slightly less shared code, Maintenance: low
+- **[C] Do nothing** — implementer guesses; Convention 2 for `set_val_labels()` likely broken or inconsistent.
+
+**Recommendation: [A]** — minimal change, fixes the gap explicitly.
+
+---
+
+**Issue 3: `.resolve_vars_from_x()` in the helpers list (Section 3.2 opening) vs `.resolve_vars()` in the detailed spec below it — same helper, two different names**
+Severity: REQUIRED
+Violates contract completeness; creates ambiguity about which name to implement.
+
+Section 3.2's opening table lists `.resolve_vars_from_x()`. The detailed spec block at the bottom of Section 3.2 defines `.resolve_vars()` with a different signature. These are the same helper. The implementation would have to pick one arbitrarily.
+
+Options:
+- **[A]** Fix the opening table to say `.resolve_vars()`, matching the detailed spec. — Effort: trivial, Risk: none
+- **[C] Do nothing** — implementer names it one or the other; the other name ends up as a dead reference.
+
+**Recommendation: [A]**
+
+---
+
+**Issue 4: `.resolve_vars()` takes both `x` and `all_cols` but `all_cols` is derivable from `x` via `.get_data_cols(x)` — redundant parameter**
+Severity: REQUIRED
+Violates DRY (engineering-preferences.md §1).
+
+The spec defines `.get_data_cols(x)` which returns `names(x)` for data frames and `names(x@data)` for survey objects. Then `.resolve_vars()` takes both `x` (for "data-masking context") and `all_cols` (already computable from `x`). The spec does not explain why `x` is needed separately — if data-masking means evaluating bare names against the data, the data is in `x@data`, not in `x` directly. Passing `all_cols` as a pre-computed vector when `x` is also available is redundant.
+
+Options:
+- **[A]** Remove `all_cols` from `.resolve_vars()`; compute it internally via `.get_data_cols(x)`. — Effort: trivial, Risk: low
+- **[B]** Remove `x` and keep `all_cols`; document that callers compute `all_cols = .get_data_cols(x)` before the call. — Effort: trivial, Risk: low
+- **[C] Do nothing** — both parameters remain; implementations pass both redundantly.
+
+**Recommendation: [A]** — `x` is already available; `.get_data_cols(x)` is a one-liner call.
+
+---
+
+#### Section: IV. Setter API
+
+---
+
+**Issue 5: `.check_is_survey()` becomes dead code in `core-metadata.R` but disposition is unresolved**
+Severity: REQUIRED
+
+Section 3.2 says: "The old `.check_is_survey()` is retained for functions that intentionally do NOT accept data frames (none in this spec — all functions gain data frame support). If `.check_is_survey()` is still referenced elsewhere in the codebase, it is not removed."
+
+There are no such functions in this spec. The current `core-metadata.R` has 8 call sites for `.check_is_survey()`, all of which are being replaced. After this spec is implemented, `.check_is_survey()` in `core-metadata.R` will have zero callers within that file. The spec doesn't specify:
+- Whether to remove it from `core-metadata.R` or keep a dead helper
+- Whether it exists elsewhere in the codebase (it may be used by `infer_question_prefaces()` or other functions)
+
+An implementer searching for other callers and finding none would be left guessing whether to delete it.
+
+Options:
+- **[A]** Add explicit instruction: "Search the codebase for other `.check_is_survey()` call sites before implementation. If none exist outside `core-metadata.R`, remove it from `core-metadata.R`. If call sites exist elsewhere, leave it in place." — Effort: trivial, Risk: none
+- **[C] Do nothing** — dead helper likely remains; or implementer accidentally deletes it and breaks callers elsewhere.
+
+**Recommendation: [A]**
+
+---
+
+**Issue 6: Convention 1 with mixed named and unnamed `...` args — no error class specified**
+Severity: REQUIRED
+
+Section 4.1 says Convention 1 requires all elements named ("`rlang::list2(...)` produces a non-empty named list (all elements named)"). But a call like `set_var_label(svy, age = "Age", "orphan string")` produces a partially-named list. This doesn't match Convention 1 (not all named), Convention 2 (not a single unnamed element), or Convention 3 (`variable` is NULL). The error table (Section IX) has no class for this case. Without an explicit error class, the implementer doesn't know whether to raise `surveycore_error_setter_empty` (wrong — some input is present), `surveycore_error_setter_ambiguous` (wrong — no `variable` was set), or a new class.
+
+Options:
+- **[A]** Treat mixed named/unnamed `...` as a new detectable case in `.parse_setter_input()` with its own error class `surveycore_error_setter_mixed_dots`. Add to Section IX and `plans/error-messages.md`. — Effort: low, Risk: low
+- **[B]** Re-use `surveycore_error_setter_empty` with message: "All `...` arguments must be named when using Convention 1." Describe this in `.parse_setter_input()` spec. — Effort: trivial, Risk: low (slightly misleading class name)
+- **[C] Do nothing** — implementer guesses; likely raises a confusing error or silently drops the unnamed element.
+
+**Recommendation: [A]** — clean error class for an easily-triggerable misuse.
+
+---
+
+**Issue 7: `NULL` content in `.parse_setter_input()` return value is unspecified**
+Severity: REQUIRED
+
+Section 4.3 says "`NULL` label removes an existing label entry (same as deleting the key from the named list)." This requires `.parse_setter_input()` to pass `NULL` values through in the returned named list. But the helper spec says "Returns a named list where names are variable name strings and values are the content to set" without specifying what `NULL` content means or how it's represented. Questions:
+- Does `list(age = NULL)` in the returned list mean "delete this key"?
+- Can `.parse_setter_input()` return a list with NULL values from Convention 3 (`variable = c("age", "income"), label = c("Age", NULL)`)? — that's not a valid character vector in R anyway.
+- What about Convention 1: `set_var_label(svy, age = NULL)`? Is this valid?
+
+Options:
+- **[A]** Specify explicitly: `.parse_setter_input()` allows `NULL` values in the returned list. Each setter iterates the result; a `NULL` value means "delete the key from the metadata list." Document this in the helper spec. — Effort: low, Risk: low
+- **[C] Do nothing** — setter implementations differ on whether NULL deletes or errors.
+
+**Recommendation: [A]**
+
+---
+
+#### Section: V. Extractor API
+
+---
+
+**Issue 8: The test plan contradicts the output contract: Section 10.6 claims single-variable calls return a scalar, but the output contract specifies named_vector format returning a named vector**
+Severity: BLOCKING
+Breaks backward compatibility and creates an unresolvable contradiction within the spec itself.
+
+Section 10.6 test plan states:
+> "Happy path — single variable (backward compatibility): `extract_var_label(svy, age)` returns the label string (or `NULL`)"
+
+But Section 5.2 output contract states:
+> "`\"named_vector\"`: `c(age = \"Age in years\", income = \"Annual income\")` — named character vector"
+
+With `format = "named_vector"` (the default), `extract_var_label(svy, age)` returns `c(age = "Age in years")` — a named character vector of length 1. This is **not** the same as `"Age in years"` (a plain character scalar):
+- `identical(c(age = "Age in years"), "Age in years")` → `FALSE`
+- Code doing `if (extract_var_label(svy, age) == "Age in years")` still works (R coerces), but `switch()`, `match()`, and `identical()` calls break silently.
+
+The same contradiction applies to `extract_val_labels()`: old API returns `c(Male = 1L, Female = 2L)` directly; new API with default `format = "list"` returns `list(sex = c(Male = 1L, Female = 2L))`. The test plan says "behavior identical to old API" — but a list is fundamentally not a named vector.
+
+The spec cannot simultaneously claim backward compatibility AND return named-vector/list format by default. One must give.
+
+Options:
+- **[A]** Remove the backward compatibility claim from Section 10.6. Explicitly document these as breaking changes in NEWS.md (alongside the old positional setter form). Update Section 10.6 to test the new return types. — Effort: low, Risk: low (changes are well-defined), Impact: honest spec, Maintenance: low
+- **[B]** Add a new format option `"scalar"` that returns a plain character scalar for single-variable calls when exactly one variable is requested. Set `format = "scalar"` as a fourth option, but keep `"named_vector"` as the default for multi-variable calls. — Effort: medium, Risk: medium (complex conditional), Maintenance: medium
+- **[C] Do nothing** — test will fail; implementer is forced to choose. Backward compat is implicitly broken without a NEWS.md entry.
+
+**Recommendation: [A]** — honest and simple. Both extractors are already changing signatures substantially; acknowledge the break, document it, and move on.
+
+---
+
+#### Section: VII. Data Frame Support
+
+---
+
+**Issue 9: Round-trip test in Section 7.5 and Section 10.5 missing two of the six metadata fields**
+Severity: REQUIRED
+
+Section 7.5 explicitly tests the round-trip guarantee for 4 of 6 fields: `variable_labels`, `value_labels`, `universe`, `missing_codes`. The `question_prefaces` and `notes` fields are omitted from:
+- The round-trip code block in Section 7.5
+- The "Round-trip" test bullets in Section 10.5 ("set on df → `as_survey()` → extract from survey object (one block per field)")
+
+The spec says `.extract_haven_metadata()` already reads `"question_preface"` and the `"note"` attribute isn't listed in `.extract_haven_metadata()`'s current behavior (the code reads `"label"`, `"labels"`, `"question_preface"` but not `"note"`). If `note` round-trips are not tested, a silent failure in `.extract_haven_metadata()` won't be caught.
+
+Options:
+- **[A]** Add `set_var_note()` and `set_question_preface()` to the Section 7.5 round-trip code example and to Section 10.5's round-trip block list. Verify Section 7.3 specifies that `.extract_haven_metadata()` reads `"note"` attributes too. — Effort: trivial, Risk: none
+- **[C] Do nothing** — round-trip for notes and prefaces is untested; silent regression is possible.
+
+**Recommendation: [A]**
+
+---
+
+#### Section: VIII. Deprecations
+
+---
+
+**Issue 10: Existing tests use `surveycore_error_not_survey` but the new `.check_is_survey_or_df()` uses `surveycore_error_not_survey_or_df` — no test migration path specified**
+Severity: REQUIRED
+
+The existing `core-metadata.R` uses `.check_is_survey()` which raises `surveycore_error_not_survey`. The new spec replaces all call sites with `.check_is_survey_or_df()` which raises `surveycore_error_not_survey_or_df`. Any existing test in `test-metadata-system.R` that asserts `class = "surveycore_error_not_survey"` will fail after implementation.
+
+The spec correctly identifies `surveycore_error_not_survey_or_df` as the class to use (confirmed in error-messages.md row 78) but does not mention that existing tests need to be updated.
+
+Options:
+- **[A]** Add a note in Section 10.3 or Section XI quality gates: "All existing `expect_error(class = \"surveycore_error_not_survey\")` assertions in `test-metadata-system.R` must be updated to `\"surveycore_error_not_survey_or_df\"`." — Effort: trivial, Risk: none
+- **[C] Do nothing** — implementer discovers test failures; no guidance on what to do.
+
+**Recommendation: [A]**
+
+---
+
+#### Section: X. Testing Plan
+
+---
+
+**Issue 11: No test specified for `NULL` content removing a metadata entry**
+Severity: REQUIRED
+
+Section 4.3 specifies: "`NULL` label removes an existing label entry (same as deleting the key from the named list)." The same behavior is specified for `set_val_labels()`, `set_question_preface()`, `set_var_note()`, `set_universe()`, and `set_missing_codes()`. However, Section 10.5 has no test block for "set content to NULL removes the entry." Without this test, the deletion behavior could silently store `NULL` in the metadata list instead of removing the key.
+
+Options:
+- **[A]** Add to Section 10.5 happy path blocks: "Setting `NULL` content removes the existing entry (verify with `is.null(x@metadata@variable_labels[['age']])` and `!('age' %in% names(x@metadata@variable_labels))`)." One block per setter type (scalar-content setters share a template; list-content setters share another). — Effort: low, Risk: none
+- **[C] Do nothing** — deletion behavior is untested; NULL-stores-rather-than-deletes bugs survive.
+
+**Recommendation: [A]**
+
+---
+
+#### Section: General / Cross-Cutting
+
+---
+
+**Issue 12: `fill = NA_character_` has three different runtime behaviors across formats — asymmetry is not prominently documented**
+Severity: SUGGESTION
+Violates API Coherence (Lens 6): same input, three different behaviors depending on `format`.
+
+Section 5.1 says:
+- `"named_vector"` + `fill = NA_character_` → value is `NA_character_`
+- `"list"` + `fill = NA_character_` → value is `NULL` (not `NA_character_`)
+- `"data_frame"` + `fill = NA_character_` → value is `NA` in the column
+
+A user who reads `fill = NA_character_` as "include missing variables as NA" will be surprised to receive `NULL` in list format. This asymmetry is technically correct (NA is meaningless as a list entry for vector fields) but will cause user confusion.
+
+Options:
+- **[A]** Add a note box in Section 5.1 under the `fill` table: "Note: `fill = NA_character_` in `"list"` format yields `NULL` entries (not `NA`), because `NA` has no meaningful interpretation as a placeholder for a named vector field." — Effort: trivial
+- **[C] Do nothing** — users discover the asymmetry from behavior or buried table row.
+
+**Recommendation: [A]**
+
+---
+
+**Issue 13: `extract_metadata()` always returns all variables (no `fill` argument) while all other extractors filter by default — asymmetry is not justified in the spec**
+Severity: SUGGESTION
+
+Section 5.1 default for extractors: `fill = NULL` → omit variables with no metadata. Section 6.3 for `extract_metadata()`: always includes all variables, no `fill` argument. This means a survey object with 80 columns and 5 labeled variables produces:
+- `extract_var_label(svy)` → 5-element result
+- `extract_metadata(svy)` → 80-element result (75 with all-NULL fields)
+
+The spec justifies this as "a complete inventory of the design's variables, not just those with metadata" (Section 6.3) — but doesn't explain why a user building a codebook would want to process 75 all-NULL entries. The design choice may be correct but should be justified explicitly to prevent an implementer from adding a `fill` argument "for consistency."
+
+Options:
+- **[A]** Add one sentence to Section 6.1 or 6.3: "The always-include design is intentional — `extract_metadata()` is a structural audit function, not a filtered view. Users who want only annotated variables should use individual extractors with `fill = NULL`." — Effort: trivial
+- **[C] Do nothing** — the current spec is technically complete; this is a clarity improvement.
+
+**Recommendation: [A]**
+
+---
+
+**Issue 14: Examples throughout the spec use `nhanes_2017`, violating the CLAUDE.md convention requiring GSS dataset**
+Severity: SUGGESTION
+
+`CLAUDE.md` states: "Use the GSS dataset (not NHANES or gss_2024) for examples and tests unless told otherwise." Section 6.5, the `make_labeled_design()` helper (Section 10.9), and several inline examples reference `nhanes_2017`. While the spec is a planning document (not the roxygen source), the Section 6.5 example will likely be copied verbatim into roxygen `@examples` blocks during implementation. The CLAUDE.md convention should be respected here.
+
+Options:
+- **[A]** Update Section 6.5 console output example to use `gss_2022` (or the canonical GSS dataset). Note in Section 10.9 that `make_labeled_design()` uses `make_survey_data()` (synthetic) rather than NHANES. — Effort: low
+- **[C] Do nothing** — implementer must remember to swap datasets; easy to overlook under time pressure.
+
+**Recommendation: [A]**
+
+---
+
+**Issue 15: Warning tests specified with `class + result check` but testing-standards.md requires dual pattern (class + snapshot) for user-facing warnings**
+Severity: SUGGESTION
+
+Section 10.5 specifies for `surveycore_warning_var_not_found`:
+> "Variable not in data → `surveycore_warning_var_not_found` (class + result check)"
+
+`testing-standards.md` states the dual pattern (class= + snapshot) is required for constructor errors and should apply to all user-facing diagnostic messages. The snapshot captures the exact warning text so unintentional message changes are caught in CI. The spec's "class + result check" omits the snapshot half. For a warning that will be triggered frequently in real workflows, snapshot coverage is appropriate.
+
+Options:
+- **[A]** Change to "class + snapshot" for all `surveycore_warning_var_not_found` tests, consistent with warning testing patterns for all other warning classes. — Effort: trivial
+- **[C] Do nothing** — warning message text can change without failing tests; CI won't catch regressions.
+
+**Recommendation: [A]**
+
+---
+
+## Summary (Pass 1)
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 4 |
+| REQUIRED | 7 |
+| SUGGESTION | 4 |
+
+**Total issues:** 15
+
+**Overall assessment:** The spec is thorough and well-structured, but has four blocking issues that must be resolved before implementation: (1) a direct contradiction between the test plan's "backward compatible scalar return" claim and the output contract's named-vector/list formats for all four existing extractors; (2–3) two unresolved implementation ambiguities in the shared `.parse_setter_input()` helper around quosure capture strategy and Convention 2 content-type discrimination; and (4) a name inconsistency between helper spec entries. Resolving these will produce an implementable spec with no architectural guesses required.
+
+---
+
+## Spec Review: metadata-update — Pass 2 (2026-03-10)
+
+### Prior Issues (Pass 1)
+
+| # | Title | Status |
+|---|---|---|
+| 1 | `.parse_setter_input()` quosure vs. evaluated list capture conflict | ✅ Resolved |
+| 2 | `.parse_setter_input()` no `content_type` parameter for Convention 2 discrimination | ✅ Resolved |
+| 3 | `.resolve_vars_from_x()` vs `.resolve_vars()` name inconsistency | ✅ Resolved |
+| 4 | `.resolve_vars()` redundant `all_cols` parameter | ✅ Resolved |
+| 5 | `.check_is_survey()` dead code disposition unresolved | ✅ Resolved |
+| 6 | Convention 1 with mixed named/unnamed `...` — no error class | ✅ Resolved |
+| 7 | `NULL` content in `.parse_setter_input()` return value unspecified | ✅ Resolved |
+| 8 | Test plan contradicts output contract: scalar return vs. named-vector | ✅ Resolved |
+| 9 | Round-trip test missing `question_prefaces` and `notes` fields | ✅ Resolved |
+| 10 | Test migration: `surveycore_error_not_survey` → `surveycore_error_not_survey_or_df` not noted | ✅ Resolved |
+| 11 | No test for `NULL` content removing a metadata entry | ✅ Resolved |
+| 12 | `fill = NA_character_` asymmetry across formats undocumented | ✅ Resolved |
+| 13 | `extract_metadata()` always-include vs. other extractors asymmetry unjustified | ✅ Resolved |
+| 14 | Examples use `nhanes_2017`, violating CLAUDE.md GSS convention | ✅ Resolved |
+| 15 | Warning tests missing snapshot half | ✅ Resolved |
+
+All 15 Pass 1 issues are resolved. The spec has been substantially improved. Pass 2 finds the following new issues.
+
+---
+
+### New Issues
+
+#### Section: III. Architecture / Internal Helpers
+
+---
+
+**Issue 16: Section 8.3 says "each setter" does enquos capture for old-positional-form detection, but only `set_var_label()` has the M-11 error — creates five setters with unnecessary quosure overhead and a cross-reference contradiction**
+Severity: REQUIRED
+Violates engineering-preferences.md §3 (right level of engineering) and contract completeness.
+
+Section 8.3 states: "Each setter captures `...` as quosures via `rlang::enquos(...)` **before** evaluating them, and checks for the old positional form at the top of the function body." But M-11 in Section IX says "Function(s): `set_var_label()`" — not all setters. Section 10.5 confirms: "Old positional NSE form → `surveycore_error_old_positional_setter` (class + snapshot) [set_var_label only]."
+
+The contradiction: if all six setters perform `rlang::enquos(...)` capture and then check for the old positional form, five of them will never trigger M-11 (the old form was specific to `set_var_label(svy, age, "label")`). The spec gives no reason why `set_val_labels()`, `set_question_preface()`, `set_var_note()`, `set_universe()`, and `set_missing_codes()` need quosure capture — none had an old positional form with a bare symbol + scalar string signature. An implementer reading Section 8.3 literally would add unnecessary `rlang::enquos()` calls and dead detection branches to five functions.
+
+Additionally, Section 4.3 "Error / warning rows" lists M-1, M-3, M-4, M-5, M-7 but omits M-11, even though M-11 is specific to `set_var_label()`. This is a cross-reference bug.
+
+Options:
+- **[A]** Rewrite Section 8.3 to say: "Only `set_var_label()` performs the old positional form check using `rlang::enquos(...)`. The other five setters skip this check and evaluate `...` directly via `rlang::list2(...)`. The detection condition applies exclusively to `set_var_label()`." Add M-11 to Section 4.3's error row list. — Effort: trivial, Risk: none, Impact: removes ambiguity, Maintenance: low
+- **[C] Do nothing** — five setters acquire needless quosure boilerplate; or implementer skips it for all setters and misses the detection in `set_var_label()` too.
+
+**Recommendation: [A]**
+
+---
+
+**Issue 17: `.parse_setter_input()` is missing a `fn_name` parameter required for M-4 and M-12 error message interpolation**
+Severity: REQUIRED
+Violates contract completeness; M-4 and M-12 cannot be implemented without it.
+
+M-4 template: `"x" = "{.fn {fn_name}} requires at least one variable-label pair."` M-12 template: `"v" = "Use {.code {fn_name}(x, age = 'Age', income = 'Annual income')} or a fully named vector."`
+
+Both use `{fn_name}` — the name of the calling setter function (e.g., `"set_var_label"`, `"set_missing_codes"`). But the `.parse_setter_input()` signature is:
+```r
+.parse_setter_input(dots, variable, content, content_arg_name, content_type, call)
+```
+There is no `fn_name` parameter. The helper has no way to produce the correct message text for M-4 or M-12 unless the caller passes its name. `sys.call()` inside the helper would return `.parse_setter_input()` itself, not the setter's name.
+
+Options:
+- **[A]** Add `fn_name` as a parameter to `.parse_setter_input()`. Each setter passes its own name as a string: `fn_name = "set_var_label"`. — Effort: trivial, Risk: none
+- **[B]** Use `rlang::caller_env()` plus `rlang::call_name(rlang::sys_call(-1L))` to recover the caller name dynamically. — Effort: low, Risk: medium (fragile with non-standard call stacks)
+- **[C] Do nothing** — M-4 and M-12 messages either omit the function name (wrong) or fail to interpolate (runtime error).
+
+**Recommendation: [A]** — explicit, zero risk, one extra parameter.
+
+---
+
+#### Section: IV. Setter API
+
+---
+
+**Issue 18: `set_var_note()` and `set_universe()` are missing content validation rules — non-character inputs have undefined behavior**
+Severity: REQUIRED
+Violates contract completeness; `code-style.md` §3 requires all edge case behaviors explicitly defined.
+
+`set_var_label()` (Section 4.3) says: "Each label value must be a single character string. Non-character or length > 1 values are coerced with a warning (using `as.character()`)." `set_question_preface()` (Section 4.5) says: "Each preface value must be a single character string." But `set_var_note()` (Section 4.6) and `set_universe()` (Section 4.7) have no equivalent validation rule. Their behavior rules say only `NULL` removes the entry and missing-variable warns.
+
+Without a rule, `set_var_note(svy, income = 42L)` or `set_universe(svy, age = c("Adults 18+", "Extra string"))` have undefined behavior. Will it error? Coerce silently? Store a non-character value in metadata?
+
+Additionally, `set_question_preface()` (4.5) says "must be a single character string" but gives no behavior for violation (error? coerce?). This is inconsistent with `set_var_label()` which specifies coercion. All four scalar-content setters should have the same validation rule — the spec should state it once in Section 4.1 under unified calling convention, not per-function, or at minimum add it to Sections 4.5, 4.6, and 4.7.
+
+Options:
+- **[A]** Add a unified validation rule to Section 4.1: "For scalar-content setters (`set_var_label`, `set_question_preface`, `set_var_note`, `set_universe`): each content value must be a character scalar. Non-character values are coerced via `as.character()` with a `surveycore_warning_label_coerced` warning. Vectors of length > 1 are rejected with `surveycore_error_label_not_scalar`." Remove the per-function restatements. — Effort: low, Risk: low
+- **[B]** Add the missing rule only to 4.6 and 4.7; leave 4.3 and 4.5 as-is. — Effort: trivial, Risk: low (duplication persists but gaps are closed)
+- **[C] Do nothing** — `set_var_note()` and `set_universe()` have undefined behavior for non-character input; tests cannot assert on it.
+
+**Recommendation: [A]** — DRY, complete, and fixes a latent ambiguity in 4.5 too.
+
+---
+
+**Issue 19: `set_var_label()` content coercion warning has no error class defined in Section IX — violates `code-style.md` §3**
+Severity: REQUIRED
+Violates code-style.md §3: "class= is required on every `cli_warn()` call — no exceptions."
+
+Section 4.3 states: "Non-character or length > 1 values are coerced with a warning (using `as.character()`)." But Section IX has no warning class for this coercion. Without a class:
+1. The `cli_warn()` call cannot be written (code-style.md requires `class=`)
+2. No `expect_warning(class = ...)` test can be written (testing-standards.md requires class-matched assertions)
+3. "length > 1 coerced" is semantically ambiguous — `as.character(c("label1", "label2"))` produces `c("label1", "label2")`, not a scalar. The spec doesn't say whether "coercion" means collapse (`paste0()`), take first (`[[1L]]`), or error.
+
+Options:
+- **[A]** Add two rows to Section IX: `surveycore_warning_label_content_coerced` (for non-character → character coercion) and `surveycore_error_label_not_scalar` (for length > 1 content — which cannot be meaningfully coerced to a single value). Add to Section 10.5 test blocks. Clarify that `as.character()` handles only non-character single values; length > 1 is an error. — Effort: low, Risk: none
+- **[B]** Remove the coercion behavior entirely. All label content must be a character scalar; non-character or length > 1 always errors with a single error class `surveycore_error_label_not_scalar`. — Effort: trivial, Risk: low (more restrictive but simpler)
+- **[C] Do nothing** — `cli_warn()` call cannot be written without a class; or implementer invents a class not in the spec.
+
+**Recommendation: [B]** — coercion is a code smell for a metadata setter; failing loudly is better than silently accepting `42L` as a label.
+
+---
+
+**Issue 20: Single unnamed vector in `...` (e.g., `set_var_label(svy, c("Age", "Income"))`) — falls through all convention detection paths, no matching error class**
+Severity: REQUIRED
+Violates contract completeness; realistic user mistake with undefined behavior.
+
+Consider: `set_var_label(svy, c("Age in years", "Annual income"))` — an unnamed character vector passed as a single `...` element. Detection paths:
+- Convention 1: all elements named? No — `dots[[1L]]` has no element name. Fail.
+- Convention 2: exactly one unnamed element that is itself a **named** vector? No — the vector has no names. Fail.
+- Convention 3: `variable` is NULL. Fail.
+- M-12 (mixed named/unnamed): is there a _mix_? No — the one element in `...` is unnamed. All are unnamed. M-12 fires only when some are named and some are not.
+- M-4 (empty): `dots` is non-empty. Fail.
+
+Result: no detection path matches. Behavior is undefined. The implementer must either invent a fifth case or crash with an uninformative error.
+
+Options:
+- **[A]** Extend M-4 (or add M-13) to cover "single unnamed non-named-vector element in `...`": "error with `surveycore_error_setter_unnamed_vector` — `{.arg ...} contains an unnamed vector; use named arguments (e.g., set_var_label(x, age = 'Age'))` or a named vector." — Effort: low, Risk: none
+- **[B]** Extend M-12 to cover "all unnamed elements" in addition to "mixed": rename `surveycore_error_setter_mixed_dots` to `surveycore_error_setter_unnamed_dots` and fire it when any element in `...` has no name (either all unnamed or mixed). — Effort: trivial, Risk: low (slight semantic change to M-12)
+- **[C] Do nothing** — user gets an uninformative R error about no matching detection branch.
+
+**Recommendation: [B]** — simplest extension; "unnamed elements in `...`" is a single coherent concept regardless of whether some or all are unnamed.
+
+---
+
+**Issue 21: Convention 3 with `variable = character(0)` / `label = character(0)` — behavior unspecified**
+Severity: REQUIRED
+Violates engineering-preferences.md §4 (handle more edge cases, not fewer).
+
+Section 4.1 says "Length mismatch (convention 3 only): If `length(variable) != length(content)`, error with `surveycore_error_setter_mismatched_lengths`." But `character(0)` and `character(0)` have equal length (both 0). So the length mismatch check passes. Then the setter iterates over the result (an empty named list). It would return `invisible(x)` unchanged — a silent no-op. Is this the intended behavior?
+
+Section 4.1 says "Empty error: If `...` is empty AND `variable` is NULL, error with `surveycore_error_setter_empty`." Convention 3 with `variable = character(0)` is not "variable is NULL" — it is explicitly provided, just empty. The spec is silent on this case.
+
+Options:
+- **[A]** Specify: "Convention 3 with `length(variable) == 0` is a silent no-op: return `invisible(x)` unchanged. No warning is issued." — Effort: trivial
+- **[B]** Specify: "Convention 3 with `length(variable) == 0` errors with `surveycore_error_setter_empty`." — Effort: trivial
+- **[C] Do nothing** — implementer chooses; behavior varies between implementations.
+
+**Recommendation: [A]** — an empty variable vector is a valid programmatic pattern when the vector was filtered down to zero entries. Silently returning unchanged is the least surprising behavior.
+
+---
+
+**Issue 22: `set_missing_codes()` Convention 3 bare atomic vector for `codes` — no exception noted; `set_val_labels()` allows this but `set_missing_codes()` doesn't specify**
+Severity: REQUIRED
+Violates contract completeness; creates inconsistent behavior between structurally parallel functions.
+
+Section 4.4 (`set_val_labels()`) specifies: "A bare named vector (not wrapped in a list) for a single variable is accepted when `length(variable) == 1L`." This accommodates `set_val_labels(svy, variable = "sex", labels = c(Male = 1L, Female = 2L))` — where `labels` is a bare vector, not a list.
+
+Section 4.8 (`set_missing_codes()`) has no equivalent exception. Its argument table says `codes | list or NULL`. An implementer applying the same logic would accept `set_missing_codes(svy, variable = "q5", codes = c(99L, 98L))` by analogy — but the spec prohibits it (type is "list"). A strict implementer would error; a lenient one would accept it. Behavior is undefined.
+
+Options:
+- **[A]** Add the same exception to Section 4.8: "A bare atomic vector (not wrapped in a list) for a single variable is accepted when `length(variable) == 1L`." — Effort: trivial, Risk: none
+- **[B]** Explicitly exclude this exception from `set_missing_codes()`: "Unlike `set_val_labels()`, a bare vector for `codes` is NOT accepted; always wrap in a list: `codes = list(c(99L, 98L))`." — Effort: trivial, Risk: low
+- **[C] Do nothing** — implementations diverge; one accepts `codes = c(99L, 98L)` for single-variable calls, another errors.
+
+**Recommendation: [A]** — the parallel structure between `set_val_labels()` and `set_missing_codes()` means users will expect the same exception to apply; denying it without documentation is a trap.
+
+---
+
+#### Section: V. Extractor API
+
+---
+
+**Issue 23: `fill = NA_character_` in `"list"` format for scalar-content extractors — spec says `NULL` applies to "vector fields" but doesn't specify behavior for character-scalar fields**
+Severity: REQUIRED
+Violates contract completeness; implementer must guess.
+
+Section 5.1 (fill argument table) says:
+> "For `"list"` output: `NULL` (since `NA` is not a meaningful list value for **vector fields**)."
+
+The phrase "vector fields" implies this applies only to `extract_val_labels()` and `extract_missing_codes()`. But `extract_var_label()`, `extract_question_preface()`, `extract_var_note()`, and `extract_universe()` also support `format = "list"`. For these functions, the list values are character scalars, not vectors — so `NA_character_` IS a meaningful list value for a scalar field. Two interpretations:
+
+1. `extract_var_label(svy, fill = NA_character_, format = "list")` → `list(age = "Age in years", psu = NA_character_)` (NA is meaningful for scalars)
+2. `extract_var_label(svy, fill = NA_character_, format = "list")` → `list(age = "Age in years", psu = NULL)` (consistent rule: list format always yields NULL)
+
+Interpretation 1 is more consistent with the note box added in Pass 1 resolution (which says `NULL` for "vector fields" — implying scalar fields are different). But the spec doesn't confirm this.
+
+Options:
+- **[A]** Add to Section 5.1: "For scalar-content extractors (`extract_var_label`, `extract_question_preface`, `extract_var_note`, `extract_universe`): `fill = NA_character_` in `"list"` format yields `NA_character_` list entries (since `NA` is a valid scalar value). For vector-content extractors (`extract_val_labels`, `extract_missing_codes`): `fill = NA_character_` in `"list"` format yields `NULL` entries." — Effort: low, Risk: none
+- **[B]** Unify the behavior: `"list"` format always yields `NULL` entries for any `fill` value, for all extractors. Update the note box accordingly. — Effort: low, Risk: medium (slightly surprising for scalar fields but consistent)
+- **[C] Do nothing** — `.format_scalar_result()` and `.format_list_result()` will behave differently in ways not anticipated by the spec.
+
+**Recommendation: [A]** — preserves intuitive behavior (`NA_character_` in a list of strings is fine) while maintaining the `NULL` rule for vector fields where it is justified.
+
+---
+
+#### Section: X. Testing Plan
+
+---
+
+**Issue 24: Section 10.5 has no test for `set_val_labels()` Convention 3 with bare named vector (the `length(variable) == 1L` exception from Section 4.4)**
+Severity: REQUIRED
+Violates testing-standards.md: every documented behavior exception must have a test.
+
+Section 4.4 documents: "A bare named vector (not wrapped in a list) for a single variable is accepted when `length(variable) == 1L`." This is an explicit behavior exception that deviates from the type contract (`labels | list or NULL`). Section 10.5 has a "Convention 3 (explicit `variable` + content) sets correct metadata" block, but it would use the standard list form. The bare-vector exception is never tested. If an implementer forgets to implement the exception, no test catches it.
+
+Options:
+- **[A]** Add a test block to Section 10.5 under `set_val_labels()`: "Convention 3 — bare named vector accepted for single variable: `set_val_labels(svy, variable = 'sex', labels = c(Male = 1L, Female = 2L))` sets the labels correctly." — Effort: trivial, Risk: none
+- **[C] Do nothing** — the exception is untested; regressions go undetected.
+
+**Recommendation: [A]**
+
+---
+
+**Issue 25: `surveycore_warning_missing_labels` (M-9) — spec doesn't say whether the data-value comparison fires for data frame inputs**
+Severity: REQUIRED
+Violates contract completeness; `set_val_labels()` on data frames is a new capability, and M-9's condition requires reading column values.
+
+M-9 fires when "Some observed data values have no corresponding label." For survey objects, `x@data[[var]]` provides the observed values to compare against. For data frames, `x[[var]]` provides them. The spec Section 4.4 says M-9 is retained "same as existing behavior" — but the existing behavior only runs for survey objects. The spec doesn't say whether `set_val_labels(df, sex = c(Male = 1L))` — when `df$sex` contains the value `2` — issues `surveycore_warning_missing_labels` or silently stores the partial labels.
+
+Options:
+- **[A]** Add to Section 4.4: "The `surveycore_warning_missing_labels` check applies for both survey objects (`x@data[[var]]`) and data frames (`x[[var]]`). The comparison reads observed unique values regardless of object type." — Effort: trivial, Risk: none
+- **[B]** Restrict M-9 to survey objects only: "Data frames do not trigger `surveycore_warning_missing_labels` — the warning is deferred to when the data frame is passed to `as_survey()`." — Effort: trivial, Risk: low
+- **[C] Do nothing** — implementations diverge; one warns for data frames, another doesn't.
+
+**Recommendation: [A]** — the comparison is cheap, the information is available, and users annotating data frames deserve the same guard as users annotating survey objects.
+
+---
+
+#### Section: General / Cross-Cutting
+
+---
+
+**Issue 26: `fill` argument semantics differ between `extract_metadata()` (`NULL`/`"include"`) and individual extractors (`NULL`/`NA_character_`) — inconsistency not called out; invalid `fill` values unspecified for both**
+Severity: SUGGESTION
+Violates API Coherence (Lens 6): same argument name, different valid values, no user-facing note.
+
+Individual extractors: `fill = NULL` (omit) or `fill = NA_character_` (include with NA). `extract_metadata()`: `fill = NULL` (omit) or `fill = "include"` (include all). A user reading the API would naturally try `extract_var_label(svy, fill = "include")` expecting the `extract_metadata()` semantics — but `"include"` is not `NA_character_`, so it would be treated as a non-NULL fill value and include variables with their fill value set to the string `"include"`. Similarly, `extract_metadata(svy, fill = NA_character_)` would silently do the wrong thing (since only `NULL` and `"include"` are meaningful for that function).
+
+Additionally, neither the individual extractor specs nor the `extract_metadata()` spec defines what happens with invalid `fill` values — there's no `surveycore_error_fill_invalid` class.
+
+Options:
+- **[A]** Add to Section 6.3 a note: "Note: `extract_metadata()` uses `fill = "include"` rather than `fill = NA_character_` because the output is a structured list, not a typed vector. Passing `fill = NA_character_` to `extract_metadata()` is treated as an invalid value and errors with `surveycore_error_fill_invalid`." Similarly note for individual extractors that `fill = "include"` is not a valid value. Add `surveycore_error_fill_invalid` to Section IX. — Effort: low, Risk: low
+- **[C] Do nothing** — inconsistency is discoverable by reading both sections carefully; no validation means silent misbehavior.
+
+**Recommendation: [A]** — validation on fill values costs almost nothing and prevents a class of confusing bugs.
+
+---
+
+**Issue 27: `.format_list_result()` `fn_name` parameter purpose not explained in helper spec**
+Severity: SUGGESTION
+Minor contract incompleteness — low risk since the purpose is inferable.
+
+Section 3.2 defines `.format_list_result(result_list, format, fn_name)` but provides no description of what `fn_name` does. Presumably it is used in the `surveycore_error_format_invalid` message (since invalid format is the only error `.format_list_result()` would raise). But an implementer might use it differently or omit it.
+
+Options:
+- **[A]** Add one sentence: "`fn_name`: used in the `surveycore_error_format_invalid` message body (`{.fn {fn_name}} does not support format = ...`)." — Effort: trivial
+- **[C] Do nothing** — inferable; low risk.
+
+**Recommendation: [A]** — trivial fix.
+
+---
+
+## Summary (Pass 2)
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 0 |
+| REQUIRED | 10 |
+| SUGGESTION | 2 |
+
+**Total new issues:** 12
+
+**Overall assessment:** All four blocking issues from Pass 1 are resolved and the spec is substantially stronger. No new blocking issues were found. The ten required issues are concentrated in three areas: (1) the old-positional-form detection scope (Section 8.3 says "each setter" but only `set_var_label()` needs it — Issues 16 and 17 on the missing `fn_name` parameter); (2) underspecified edge case behavior in setters (the unnamed-vector-in-`...` case, Convention 3 with empty vector, bare-atomic-vector for `set_missing_codes()`, content validation gaps in `set_var_note()` and `set_universe()`); (3) missing or incorrect test coverage (bare-vector exception for `set_val_labels()` Convention 3, M-9 for data frames). Resolving these leaves the spec fully implementable with no guesses required. The two suggestions (fill semantics inconsistency and `.format_list_result()` doc) are low-priority polish items.

--- a/tests/testthat/test-s7-classes.R
+++ b/tests/testthat/test-s7-classes.R
@@ -109,6 +109,39 @@ test_that("survey_metadata() stores value labels correctly", {
   expect_identical(m@value_labels$sex, c(Male = 1L, Female = 2L))
 })
 
+test_that("survey_metadata() stores universe as empty list by default", {
+  m <- survey_metadata()
+  expect_identical(m@universe, list())
+})
+
+test_that("survey_metadata() stores missing_codes as empty list by default", {
+  m <- survey_metadata()
+  expect_identical(m@missing_codes, list())
+})
+
+test_that("survey_metadata(universe = list(...)) stores value correctly", {
+  m <- survey_metadata(universe = list(age = "Adults 18+", income = "All respondents"))
+  expect_identical(m@universe$age,    "Adults 18+")
+  expect_identical(m@universe$income, "All respondents")
+})
+
+test_that("survey_metadata(missing_codes = list(...)) stores value correctly", {
+  m <- survey_metadata(missing_codes = list(age = c(Refused = 99L, DK = 98L)))
+  expect_identical(m@missing_codes$age, c(Refused = 99L, DK = 98L))
+})
+
+test_that("universe @ assignment round-trips on survey_metadata object", {
+  m <- survey_metadata()
+  m@universe <- list(income = "Employed adults")
+  expect_identical(m@universe$income, "Employed adults")
+})
+
+test_that("missing_codes @ assignment round-trips on survey_metadata object", {
+  m <- survey_metadata()
+  m@missing_codes <- list(age = c(-1L, -2L))
+  expect_identical(m@missing_codes$age, c(-1L, -2L))
+})
+
 
 # ── survey_base ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

Adds `universe` and `missing_codes` properties to the `survey_metadata` S7 class, following the same pattern as the existing `notes` and `value_labels` properties.

## Checklist

- [x] Tests written and passing (`devtools::test()`) — 6 new blocks, FAIL 0 | PASS 6592
- [x] R CMD check: 0 errors, 0 warnings (`devtools::check()`) — 3 pre-existing notes
- [x] Roxygen docs updated and `devtools::document()` run
- [x] `plans/error-messages.md` updated — 11 new rows added (M-2/M-7 through M-15)
- [ ] `VENDORED.md` updated — n/a (no variance code)
- [x] PR title is a valid Conventional Commit (`feat(scope): description`)
- [x] PR targets `develop`, not `main`

## Notes

R CMD check shows 3 notes (one more than the ≤2 pre-approved limit). All are pre-existing, not introduced by this PR:
1. `checking for future file timestamps` — environmental/time verification
2. `Non-standard files/directories found at top level` — `README.html` (untracked, generated) and `SOPs/` (pre-existing directory)
3. `checking for unstated dependencies in vignettes` — `surveytidy` in vignette, pre-existing

`README.html` can be removed from the working directory to drop note #2.