### PR TITLE
docs(constructors): document PPS variance limitation in as_survey()

### DIFF
--- a/R/core-constructors.R
+++ b/R/core-constructors.R
@@ -296,6 +296,24 @@ as_survey_srs <- function(
 #' is assumed. A warning is issued because population totals cannot be
 #' estimated without weights or population size.
 #'
+#' @section Known limitations:
+#' `as_survey()` does not support probability-proportional-to-size (PPS)
+#' variance estimation. Taylor series linearization treats all designs as
+#' with-replacement, which overestimates (is conservative for) variance in
+#' PPS-without-replacement designs. The Yates-Grundy and Brewer/Overton
+#' estimators available in [survey::svydesign()] via its `pps` and `variance`
+#' arguments are not yet implemented.
+#'
+#' If your design requires PPS-specific variance estimation, create the design
+#' with [survey::svydesign()] and convert it with [from_svydesign()]:
+#' ```r
+#' d_survey <- survey::svydesign(
+#'   ids = ~psu, weights = ~wt, strata = ~stratum,
+#'   pps = "brewer", data = mydata
+#' )
+#' d <- from_svydesign(d_survey)
+#' ```
+#'
 #' @examples
 #' # Full NHANES design: stratified cluster with PSU IDs nested within strata
 #' d <- as_survey(

--- a/man/as_survey.Rd
+++ b/man/as_survey.Rd
@@ -72,6 +72,26 @@ is assumed. A warning is issued because population totals cannot be
 estimated without weights or population size.
 }
 
+\section{Known limitations}{
+
+\code{as_survey()} does not support probability-proportional-to-size (PPS)
+variance estimation. Taylor series linearization treats all designs as
+with-replacement, which overestimates (is conservative for) variance in
+PPS-without-replacement designs. The Yates-Grundy and Brewer/Overton
+estimators available in \code{\link[survey:svydesign]{survey::svydesign()}} via its \code{pps} and \code{variance}
+arguments are not yet implemented.
+
+If your design requires PPS-specific variance estimation, create the design
+with \code{\link[survey:svydesign]{survey::svydesign()}} and convert it with \code{\link[=from_svydesign]{from_svydesign()}}:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{d_survey <- survey::svydesign(
+  ids = ~psu, weights = ~wt, strata = ~stratum,
+  pps = "brewer", data = mydata
+)
+d <- from_svydesign(d_survey)
+}\if{html}{\out{</div>}}
+}
+
 \examples{
 # Full NHANES design: stratified cluster with PSU IDs nested within strata
 d <- as_survey(


### PR DESCRIPTION
## Summary

- Adds a **Known Limitations** section to `as_survey()` noting that Yates-Grundy and Brewer/Overton PPS-without-replacement variance estimators are not yet implemented
- Explains that Taylor linearization overestimates (conservatively) variance for PPS-WOR designs
- Points users needing PPS-specific variance to the `survey::svydesign()` + `from_svydesign()` escape hatch

## Test plan

- [ ] `devtools::document()` regenerated `man/as_survey.Rd` cleanly
- [ ] No source code changes — docs only, no new tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)