### PR TITLE
feat(utils): extend make_survey_data() with n_ssu and n_unit

### DIFF
--- a/changelog/multi-stage/feature-multi-stage-test-helper.md
+++ b/changelog/multi-stage/feature-multi-stage-test-helper.md
@@ -1,0 +1,18 @@
+# feat(utils): extend make_survey_data() with n_ssu and n_unit parameters
+
+**Date**: 2026-03-13
+**Branch**: feature/multi-stage-test-helper
+**Phase**: Multi-stage
+
+## Changes
+- Add `n_ssu` parameter to `make_survey_data()` for generating SSU IDs and stage-2 FPC
+- Add `n_unit` parameter for generating unit IDs and stage-3 FPC (requires `n_ssu`)
+- SSU IDs use format `"{psu}_s{j}"`, assigned round-robin within each PSU
+- Unit IDs use format `"{ssu}_u{j}"`, assigned round-robin within each SSU
+- `fpc2` = `n_ssu * 2L` (constant within PSU); `fpc3` = `n_unit * 2L` (constant within SSU)
+- Error when `n_unit` is specified without `n_ssu`
+- Default behavior (both NULL) is identical to previous version
+
+## Files Modified
+- `tests/testthat/helper-test-data.R` — add `n_ssu` and `n_unit` parameters to `make_survey_data()`
+- `tests/testthat/test-constructors.R` — add 4 new test cases for multi-stage data generation

--- a/tests/testthat/helper-test-data.R
+++ b/tests/testthat/helper-test-data.R
@@ -30,6 +30,10 @@
 #'   - y3       : integer binary outcome (0/1, ~30% = 1)
 #'   - group    : character categorical variable ("A", "B", "C")
 #'
+#' Additional columns by n_ssu/n_unit:
+#'   - n_ssu non-NULL: ssu (character SSU IDs), fpc2 (integer, n_ssu * 2L)
+#'   - n_unit non-NULL: unit (character unit IDs), fpc3 (integer, n_unit * 2L)
+#'
 #' Additional columns by design:
 #'   - design = "replicate": repwt_1 ... repwt_R replicate weight columns
 #'   - design = "twophase":  subset (logical, ~40% TRUE), phase1_prob (numeric),
@@ -37,6 +41,12 @@
 #'
 #' @param n         Total number of rows. Default 500L.
 #' @param n_psu     Number of PSUs. Default 50L. For BRR/Fay must be even.
+#' @param n_ssu     Number of SSUs per PSU. Default NULL (no SSU column).
+#'   When non-NULL, adds `ssu` (character, format `"{psu}_s{j}"`) and `fpc2`
+#'   (integer, `n_ssu * 2L`) columns.
+#' @param n_unit    Number of units per SSU. Default NULL (no unit column).
+#'   Requires `n_ssu` to also be non-NULL. When non-NULL, adds `unit`
+#'   (character, format `"{ssu}_u{j}"`) and `fpc3` (integer, `n_unit * 2L`).
 #' @param n_strata  Number of strata. Default 5L.
 #' @param design    Survey design type: "taylor", "replicate", or "twophase".
 #' @param type      Replicate weight method (used when design = "replicate").
@@ -52,6 +62,8 @@
 make_survey_data <- function(
   n = 500L,
   n_psu = 50L,
+  n_ssu = NULL,
+  n_unit = NULL,
   n_strata = 5L,
   design = c("taylor", "replicate", "twophase"),
   type = "brr",
@@ -69,6 +81,10 @@ make_survey_data <- function(
       n_psu,
       "."
     )
+  }
+
+  if (!is.null(n_unit) && is.null(n_ssu)) {
+    stop("n_unit requires n_ssu to be specified.")
   }
 
   set.seed(seed)
@@ -130,6 +146,37 @@ make_survey_data <- function(
     group = group,
     stringsAsFactors = FALSE
   )
+
+  # --- SSU column (multi-stage) ---
+  if (!is.null(n_ssu)) {
+    # Assign SSU IDs round-robin within each PSU
+    ssu_index <- integer(n)
+    for (p in seq_len(n_psu)) {
+      rows_in_psu <- which(psu_index == p)
+      ssu_index[rows_in_psu] <- rep_len(
+        seq_len(n_ssu),
+        length(rows_in_psu)
+      )
+    }
+    df$ssu <- paste0(df$psu, "_s", ssu_index)
+    df$fpc2 <- as.integer(n_ssu) * 2L
+  }
+
+  # --- Unit column (three-stage) ---
+  if (!is.null(n_unit)) {
+    # Assign unit IDs round-robin within each SSU
+    unit_index <- integer(n)
+    unique_ssus <- unique(df$ssu)
+    for (s in unique_ssus) {
+      rows_in_ssu <- which(df$ssu == s)
+      unit_index[rows_in_ssu] <- rep_len(
+        seq_len(n_unit),
+        length(rows_in_ssu)
+      )
+    }
+    df$unit <- paste0(df$ssu, "_u", unit_index)
+    df$fpc3 <- as.integer(n_unit) * 2L
+  }
 
   # --- Replicate weights ---
   if (design == "replicate") {

--- a/tests/testthat/test-constructors.R
+++ b/tests/testthat/test-constructors.R
@@ -2322,3 +2322,81 @@ test_that("as_survey() leaves weighting_history as list() for plain data.frame",
   test_invariants(d)
   expect_identical(d@metadata@weighting_history, list())
 })
+
+# =============================================================================
+# make_survey_data() extension — multi-stage (n_ssu, n_unit)
+# =============================================================================
+
+test_that("make_survey_data() with n_ssu produces ssu and fpc2 columns", {
+  df <- make_survey_data(n = 100, n_psu = 10, n_ssu = 5, seed = 1)
+
+  # ssu column exists and is character
+
+  expect_true("ssu" %in% names(df))
+  expect_type(df$ssu, "character")
+
+  # fpc2 column exists and is integer
+
+  expect_true("fpc2" %in% names(df))
+  expect_type(df$fpc2, "integer")
+
+  # ssu IDs follow format "{psu}_s{j}"
+  expect_true(all(grepl("^psu_\\d+_s\\d+$", df$ssu)))
+
+  # ssu IDs are unique within each PSU
+  ssu_per_psu <- split(df$ssu, df$psu)
+  for (psu_ssus in ssu_per_psu) {
+    n_unique_ssu <- length(unique(psu_ssus))
+    expect_lte(n_unique_ssu, 5L)
+  }
+
+  # fpc2 is constant within each PSU and equals n_ssu * 2L
+  fpc2_per_psu <- split(df$fpc2, df$psu)
+  for (psu_fpc2 in fpc2_per_psu) {
+    expect_identical(unique(psu_fpc2), 10L) # n_ssu * 2L = 5 * 2 = 10
+  }
+})
+
+test_that("make_survey_data() with n_ssu and n_unit produces unit and fpc3", {
+  df <- make_survey_data(
+    n = 100, n_psu = 10, n_ssu = 5, n_unit = 3, seed = 1
+  )
+
+  # unit column exists and is character
+  expect_true("unit" %in% names(df))
+  expect_type(df$unit, "character")
+
+  # fpc3 column exists and is integer
+  expect_true("fpc3" %in% names(df))
+  expect_type(df$fpc3, "integer")
+
+  # unit IDs follow format "{ssu}_u{j}"
+  expect_true(all(grepl("_s\\d+_u\\d+$", df$unit)))
+
+  # fpc3 is constant within each SSU and equals n_unit * 2L
+  fpc3_per_ssu <- split(df$fpc3, df$ssu)
+  for (ssu_fpc3 in fpc3_per_ssu) {
+    expect_identical(unique(ssu_fpc3), 6L) # n_unit * 2L = 3 * 2 = 6
+  }
+})
+
+test_that("make_survey_data() errors when n_unit given without n_ssu", {
+  expect_error(
+    make_survey_data(n_unit = 3),
+    regexp = "n_ssu"
+  )
+})
+
+test_that("make_survey_data() with no n_ssu/n_unit is identical to original", {
+  df_old <- make_survey_data(n = 100, n_psu = 10, seed = 42)
+  df_new <- make_survey_data(n = 100, n_psu = 10, n_ssu = NULL, seed = 42)
+
+  # Same columns — no ssu, fpc2, unit, fpc3
+  expect_false("ssu" %in% names(df_new))
+  expect_false("fpc2" %in% names(df_new))
+  expect_false("unit" %in% names(df_new))
+  expect_false("fpc3" %in% names(df_new))
+
+  # Identical output
+  expect_identical(df_old, df_new)
+})


### PR DESCRIPTION
## What this does
Extends `make_survey_data()` in `helper-test-data.R` with two new parameters (`n_ssu`, `n_unit`) for generating multi-stage survey test data. SSU IDs are assigned round-robin within PSUs, unit IDs round-robin within SSUs, with corresponding FPC columns. Default behavior is unchanged when both parameters are NULL.

## Technical changes
- **New functions:** None (extends existing `make_survey_data()`)
- **New tests:** 4 new test cases in `test-constructors.R`
- **Modified files:** `tests/testthat/helper-test-data.R`, `tests/testthat/test-constructors.R`
- **Plan section:** `feature/multi-stage-test-helper` — PR 1 from `plans/impl-multi-stage.md`

## Spec coverage
**From `plans/spec-multi-stage.md §XI`:**
- [x] `n_ssu` parameter adds `ssu` column (character, format `"{psu}_s{j}"`)
- [x] `n_ssu` parameter adds `fpc2` column (integer, constant per PSU = `n_ssu * 2L`)
- [x] `n_unit` parameter adds `unit` column (character, format `"{ssu}_u{j}"`)
- [x] `n_unit` parameter adds `fpc3` column (integer, constant per SSU = `n_unit * 2L`)
- [x] Error when `n_unit` specified without `n_ssu`
- [x] Default behavior identical when both NULL

## Test results
`devtools::test()`: 7031 tests, 0 failures
`devtools::check()`: 0 errors, 0 warnings, 1 note (hidden .git directory — worktree artifact)

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)