### PR TITLE
refactor(variance): use .build_cluster_matrices() in Taylor variance engine

### DIFF
--- a/R/variance-taylor.R
+++ b/R/variance-taylor.R
@@ -138,7 +138,6 @@
     lonely.psu = lonely.psu, stage = stage
   )
 
-  # nocov start — Phase 0 builder always passes single-column cluster/strata matrices
   if (!isTRUE(one.stage) && !is.null(popmat) && NCOL(clusters) > 1L) {
     v.sub <- by(seq_len(n), list(as.numeric(clusters[, 1L])), function(index) {
       .svy_multistage(
@@ -154,7 +153,6 @@
     })
     for (i in seq_along(v.sub)) v <- v + v.sub[[i]]
   }
-  # nocov end
 
   dimnames(v) <- list(colnames(x), colnames(x))
   v
@@ -189,78 +187,30 @@
   vars <- design@variables
 
   y <- data[[y_col]]
-  w <- data[[vars$weights]]   # survey weights = 1 / inclusion_prob
 
-  # --- Cluster IDs ---
-  # If nest = TRUE, make PSU IDs globally unique by interaction with strata.
-  strata_id <- if (!is.null(vars$strata)) {
-    data[[vars$strata]]
-  } else {
-    rep(1L, nrow(data))
-  }
-
-  psu_id <- if (!is.null(vars$ids)) {
-    raw_ids <- data[[vars$ids[[1L]]]]
-    if (isTRUE(vars$nest) && !is.null(vars$strata)) {
-      as.integer(interaction(strata_id, raw_ids, drop = TRUE))
-    } else {
-      raw_ids
-    }
-  } else {
-    seq_len(nrow(data))  # each row is its own PSU
-  }
+  # Build cluster/strata/FPC matrices from full dataset BEFORE na.rm
+  # filtering. sampsize is a design property (number of PSUs per
+  # stratum), not an outcome property — it must reflect the full
+  # dataset. This matches survey package semantics.
+  mats <- .build_cluster_matrices(data, vars)
 
   # --- Handle na.rm ---
-  if (na.rm) {
-    keep    <- !is.na(y)
-    y       <- y[keep]
-    w       <- w[keep]
-    strata_id <- strata_id[keep]
-    psu_id    <- psu_id[keep]
-    if (!is.null(vars$fpc)) {
-      fpc_col_full <- data[[vars$fpc]][keep]
-    } else {
-      fpc_col_full <- NULL
-    }
-  } else {
-    fpc_col_full <- if (!is.null(vars$fpc)) data[[vars$fpc]] else NULL
+  keep <- if (na.rm) !is.na(y) else seq_along(y)
+  y <- y[keep]
+  w <- data[[vars$weights]][keep]
+  mats$clusters_mat <- mats$clusters_mat[keep, , drop = FALSE]
+  mats$strata_mat <- mats$strata_mat[keep, , drop = FALSE]
+  mats$fpcs$sampsize <- mats$fpcs$sampsize[keep, , drop = FALSE]
+  if (!is.null(mats$fpcs$popsize)) {
+    mats$fpcs$popsize <- mats$fpcs$popsize[keep, , drop = FALSE]
   }
-
-  n <- length(y)
-
-  # --- Build cluster and strata matrices ---
-  clusters_mat <- matrix(psu_id, ncol = 1L)
-  strata_mat   <- matrix(strata_id, ncol = 1L)
-
-  # --- Build FPC structure ---
-  # sampsize[i] = number of unique PSUs in stratum of obs i.
-  # Use tapply for O(N log N) instead of the O(N*S) for-loop alternative.
-  psu_per_stratum  <- tapply(psu_id, strata_id, function(ps) length(unique(ps)))
-  sampsize_vec     <- as.integer(psu_per_stratum[as.character(strata_id)])
-  sampsize_mat     <- matrix(sampsize_vec, ncol = 1L)
-
-  # popsize: NULL (no FPC) or per-row population sizes
-  popsize_mat <- if (!is.null(fpc_col_full)) {
-    fpc_vals <- fpc_col_full
-    if (any(fpc_vals > 1, na.rm = TRUE)) {
-      # values > 1 are population sizes
-      matrix(as.numeric(fpc_vals), ncol = 1L)
-    } else {
-      # values in (0,1] are sampling fractions → convert to population sizes
-      matrix(as.numeric(sampsize_vec / fpc_vals), ncol = 1L)
-    }
-  } else {
-    NULL
-  }
-
-  fpcs <- list(sampsize = sampsize_mat, popsize = popsize_mat)
 
   list(
     y        = y,
     w        = w,
-    clusters = clusters_mat,
-    stratas  = strata_mat,
-    fpcs     = fpcs
+    clusters = mats$clusters_mat,
+    stratas  = mats$strata_mat,
+    fpcs     = mats$fpcs
   )
 }
 
@@ -387,50 +337,16 @@
   infl_b   <- w * pair_mask * (cx * cy - b) / W_d
   infl_c   <- w * pair_mask * (cy^2 - c_val) / W_d
 
-  # Build cluster / strata structure (full dataset)
-  strata_id <- if (!is.null(vars$strata)) {
-    data[[vars$strata]]
-  } else {
-    rep(1L, n_full)
-  }
-
-  psu_id <- if (!is.null(vars$ids)) {
-    raw_ids <- data[[vars$ids[[1L]]]]
-    if (isTRUE(vars$nest) && !is.null(vars$strata)) {
-      as.integer(interaction(strata_id, raw_ids, drop = TRUE))
-    } else {
-      raw_ids
-    }
-  } else {
-    seq_len(n_full)
-  }
-
-  clusters_mat <- matrix(psu_id, ncol = 1L)
-  strata_mat   <- matrix(strata_id, ncol = 1L)
-
-  psu_per_stratum <- tapply(psu_id, strata_id, function(ps) length(unique(ps)))
-  sampsize_vec    <- as.integer(psu_per_stratum[as.character(strata_id)])
-  sampsize_mat    <- matrix(sampsize_vec, ncol = 1L)
-
-  fpc_col_full <- if (!is.null(vars$fpc)) data[[vars$fpc]] else NULL
-  popsize_mat  <- if (!is.null(fpc_col_full)) {
-    fpc_vals <- fpc_col_full
-    if (any(fpc_vals > 1, na.rm = TRUE)) {
-      matrix(as.numeric(fpc_vals), ncol = 1L)
-    } else {
-      matrix(as.numeric(sampsize_vec / fpc_vals), ncol = 1L)
-    }
-  } else {
-    NULL
-  }
-
-  fpcs       <- list(sampsize = sampsize_mat, popsize = popsize_mat)
+  # Build cluster / strata / FPC structure from full dataset
+  mats       <- .build_cluster_matrices(data, vars)
   lonely.psu <- getOption("survey.lonely.psu", "remove")
 
   infl_mat <- cbind(infl_a, infl_b, infl_c)
   colnames(infl_mat) <- c("a", "b", "c")
   sigma <- .svy_recvar(
-    infl_mat, clusters_mat, strata_mat, fpcs, lonely.psu = lonely.psu
+    infl_mat,
+    mats$clusters_mat, mats$strata_mat, mats$fpcs,
+    lonely.psu = lonely.psu
   )
 
   list(a = a, b = b, c = c_val, sigma = sigma, n = n_d, n_weighted = W_d)

--- a/changelog/multi-stage/feature-multi-stage-variance-taylor.md
+++ b/changelog/multi-stage/feature-multi-stage-variance-taylor.md
@@ -1,0 +1,33 @@
+# refactor(variance): use .build_cluster_matrices() in Taylor variance engine
+
+**Date**: 2026-03-13
+**Branch**: feature/multi-stage-variance-taylor
+**Phase**: Multi-stage
+
+## Changes
+- Refactor `.taylor_build_inputs()` to use `.build_cluster_matrices()`
+  instead of inline matrix-building code; now returns n x k matrices
+  for k-stage designs (previously always n x 1)
+- Refactor `.vcov_pair_taylor()` to use `.build_cluster_matrices()`
+  instead of duplicated inline cluster/strata/FPC block
+- Remove `# nocov start/end` markers from `.svy_multistage()` multi-stage
+  recursion path (lines 141-157); path is now exercisable via
+  multi-stage designs with FPC
+- Preserve `.svy_onestrat()` `# nocov` markers (different unreachable
+  branches)
+- sampsize is now computed from the full dataset before na.rm filtering,
+  matching survey package semantics
+- Add regression oracle test confirming single-stage NHANES values
+  unchanged after refactor
+- Add shape tests for `.taylor_build_inputs()` output dimensions
+  (1-stage and 2-stage)
+- Add multi-stage oracle tests (2-stage no FPC) comparing get_means()
+  and get_totals() against survey::svymean()/svytotal()
+- Add na.rm semantics test for multi-stage designs
+
+## Files Modified
+- `R/variance-taylor.R` — Refactor `.taylor_build_inputs()` and
+  `.vcov_pair_taylor()` to use `.build_cluster_matrices()`; remove
+  `# nocov` from `.svy_multistage()` multi-stage path
+- `tests/testthat/test-variance-taylor.R` — Add 7 new tests (regression
+  oracle, shape tests, multi-stage oracle, na.rm semantics)

--- a/tests/testthat/test-variance-taylor.R
+++ b/tests/testthat/test-variance-taylor.R
@@ -588,3 +588,216 @@ test_that(".build_cluster_matrices() sampsize matches PSU/SSU counts [unit]", {
     as.integer(expected_ssu_n[as.character(psu_col)])
   )
 })
+
+# ---------------------------------------------------------------------------
+# Block 16: Multi-stage Taylor refactor — regression oracle + shape tests
+# ---------------------------------------------------------------------------
+
+test_that(
+  paste(
+    "get_means() on single-stage NHANES matches survey::svymean()",
+    "[regression oracle]"
+  ),
+  {
+    skip_if_not_installed("survey")
+    d <- nhanes_2017[nhanes_2017$ridstatr == 2, ]
+    sc <- as_survey(
+      d,
+      ids = sdmvpsu, weights = wtmec2yr,
+      strata = sdmvstra, nest = TRUE
+    )
+    test_invariants(sc)
+    sv <- survey::svydesign(
+      id = ~sdmvpsu, weights = ~wtmec2yr, strata = ~sdmvstra,
+      data = d, nest = TRUE
+    )
+    sc_result <- get_means(sc, bpxsy1, variance = "se")
+    sv_result <- survey::svymean(~bpxsy1, sv, na.rm = TRUE)
+    expect_equal(
+      sc_result$mean,
+      coef(sv_result)[["bpxsy1"]],
+      tolerance = 1e-10
+    )
+    expect_equal(
+      sc_result$se,
+      as.numeric(survey::SE(sv_result)),
+      tolerance = 1e-8
+    )
+  }
+)
+
+test_that(
+  paste(
+    ".taylor_build_inputs() returns n x 1 matrices for",
+    "current single-stage design [shape]"
+  ),
+  {
+    df <- make_survey_data(n = 100, n_psu = 10, seed = 70)
+    sc <- as_survey(
+      df, ids = psu, weights = wt, strata = strata, fpc = fpc
+    )
+    test_invariants(sc)
+    inp <- surveycore:::.taylor_build_inputs(sc, "y1")
+    expect_identical(ncol(inp$clusters), 1L)
+    expect_identical(ncol(inp$stratas), 1L)
+    expect_identical(ncol(inp$fpcs$sampsize), 1L)
+  }
+)
+
+test_that(
+  paste(
+    ".taylor_build_inputs() returns n x 2 matrices for",
+    "2-stage design without FPC [shape]"
+  ),
+  {
+    df <- make_survey_data(
+      n = 300, n_psu = 30, n_ssu = 5, seed = 1
+    )
+    sc <- as_survey(
+      df,
+      ids = c(psu, ssu), weights = wt, strata = strata
+    )
+    test_invariants(sc)
+    inp <- surveycore:::.taylor_build_inputs(sc, "y1")
+    expect_identical(ncol(inp$clusters), 2L)
+    expect_identical(ncol(inp$stratas), 2L)
+    expect_identical(ncol(inp$fpcs$sampsize), 2L)
+  }
+)
+
+test_that(
+  paste(
+    ".taylor_build_inputs() computes sampsize from full dataset",
+    "before na.rm filtering [semantics]"
+  ),
+  {
+    df <- make_survey_data(n = 100, n_psu = 10, seed = 71)
+    # Add NAs to y1
+    df$y1[1:10] <- NA_real_
+    sc <- as_survey(
+      df, ids = psu, weights = wt, strata = strata, fpc = fpc
+    )
+    inp_narm <- surveycore:::.taylor_build_inputs(
+      sc, "y1", na.rm = TRUE
+    )
+    inp_full <- surveycore:::.taylor_build_inputs(
+      sc, "y1", na.rm = FALSE
+    )
+    # After na.rm, we have fewer rows, but sampsize values should
+    # reflect full-data PSU counts — matching survey package semantics.
+    n_narm <- length(inp_narm$y)
+    n_full <- length(inp_full$y)
+    expect_lt(n_narm, n_full)
+    # sampsize values in na.rm output should come from the full
+    # dataset's PSU counts
+    expect_true(
+      all(
+        unique(inp_narm$fpcs$sampsize[, 1L]) %in%
+          unique(inp_full$fpcs$sampsize[, 1L])
+      )
+    )
+  }
+)
+
+test_that(
+  paste(
+    "get_means() on 2-stage design (no FPC) matches",
+    "survey::svymean() [multi-stage oracle]"
+  ),
+  {
+    skip_if_not_installed("survey")
+    df <- make_survey_data(
+      n = 300, n_psu = 30, n_ssu = 5, seed = 72
+    )
+    sc <- as_survey(
+      df,
+      ids = c(psu, ssu), weights = wt, strata = strata
+    )
+    test_invariants(sc)
+    sv <- survey::svydesign(
+      id = ~ psu + ssu, strata = ~strata,
+      weights = ~wt, data = df
+    )
+    sc_result <- get_means(sc, y1, variance = "se")
+    sv_result <- survey::svymean(~y1, sv, na.rm = TRUE)
+    expect_equal(
+      sc_result$mean,
+      coef(sv_result)[["y1"]],
+      tolerance = 1e-10
+    )
+    expect_equal(
+      sc_result$se,
+      as.numeric(survey::SE(sv_result)),
+      tolerance = 1e-8
+    )
+  }
+)
+
+test_that(
+  paste(
+    "get_totals() on 2-stage design (no FPC) matches",
+    "survey::svytotal() [multi-stage oracle]"
+  ),
+  {
+    skip_if_not_installed("survey")
+    df <- make_survey_data(
+      n = 300, n_psu = 30, n_ssu = 5, seed = 73
+    )
+    sc <- as_survey(
+      df,
+      ids = c(psu, ssu), weights = wt, strata = strata
+    )
+    test_invariants(sc)
+    sv <- survey::svydesign(
+      id = ~ psu + ssu, strata = ~strata,
+      weights = ~wt, data = df
+    )
+    sc_result <- get_totals(sc, y1, variance = "se")
+    sv_result <- survey::svytotal(~y1, sv, na.rm = TRUE)
+    expect_equal(
+      sc_result$total,
+      coef(sv_result)[["y1"]],
+      tolerance = 1e-10
+    )
+    expect_equal(
+      sc_result$se,
+      as.numeric(survey::SE(sv_result)),
+      tolerance = 1e-8
+    )
+  }
+)
+
+test_that(
+  paste(
+    "get_means() on 2-stage design with NAs matches survey",
+    "[multi-stage na.rm oracle]"
+  ),
+  {
+    skip_if_not_installed("survey")
+    df <- make_survey_data(
+      n = 300, n_psu = 30, n_ssu = 5, seed = 74
+    )
+    # Introduce NAs
+    df$y1[c(1, 50, 100, 200)] <- NA_real_
+    sc <- as_survey(
+      df,
+      ids = c(psu, ssu), weights = wt, strata = strata
+    )
+    sv <- survey::svydesign(
+      id = ~ psu + ssu, strata = ~strata,
+      weights = ~wt, data = df
+    )
+    sc_result <- get_means(sc, y1, variance = "se", na.rm = TRUE)
+    sv_result <- survey::svymean(~y1, sv, na.rm = TRUE)
+    expect_equal(
+      sc_result$mean,
+      coef(sv_result)[["y1"]],
+      tolerance = 1e-10
+    )
+    expect_equal(
+      sc_result$se,
+      as.numeric(survey::SE(sv_result)),
+      tolerance = 1e-8
+    )
+  }
+)


### PR DESCRIPTION
## Summary
- Refactor `.taylor_build_inputs()` and `.vcov_pair_taylor()` to use the shared `.build_cluster_matrices()` helper instead of duplicated inline matrix-building code
- `.taylor_build_inputs()` now produces n x k matrices for k-stage designs (previously always n x 1), enabling multi-stage Taylor variance
- Remove `# nocov start/end` markers from `.svy_multistage()` multi-stage recursion path (now exercisable via multi-stage designs with FPC)
- Preserve `.svy_onestrat()` `# nocov` markers (different unreachable branches)

## Test plan
- [x] Regression oracle: single-stage NHANES values match `survey::svymean()` (point 1e-10, SE 1e-8) -- confirms refactor is behavior-preserving
- [x] Shape test: `.taylor_build_inputs()` returns n x 1 for single-stage, n x 2 for 2-stage
- [x] sampsize computed from full dataset before na.rm filtering (matches survey package semantics)
- [x] Multi-stage oracle: 2-stage get_means()/get_totals() match survey::svymean()/svytotal() (no FPC case)
- [x] Multi-stage na.rm oracle: 2-stage with NAs matches survey
- [x] Full test suite: 7158 tests pass, 0 failures
- [x] R CMD check: 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)