### PR TITLE
refactor(glm): replace inline FPC block with .build_cluster_matrices()

### DIFF
--- a/R/glm.R
+++ b/R/glm.R
@@ -226,57 +226,14 @@ survey_glm_fit <- S7::new_class(
 # @return p × p meat matrix.
 #' @noRd
 .taylor_var_score_matrix <- function(score_matrix, design) {
-  vars <- design@variables
-  data <- design@data
-  n <- nrow(data)
-
-  strata_id <- if (!is.null(vars$strata)) {
-    data[[vars$strata]]
-  } else {
-    rep(1L, n)
-  }
-
-  psu_id <- if (!is.null(vars$ids)) {
-    raw_ids <- data[[vars$ids[[1L]]]]
-    if (isTRUE(vars$nest) && !is.null(vars$strata)) {
-      as.integer(interaction(strata_id, raw_ids, drop = TRUE))
-    } else {
-      raw_ids
-    }
-  } else {
-    seq_len(n)
-  }
-
-  clusters_mat <- matrix(psu_id, ncol = 1L)
-  strata_mat <- matrix(strata_id, ncol = 1L)
-
-  psu_per_stratum <- tapply(
-    psu_id,
-    strata_id,
-    function(ps) length(unique(ps))
-  )
-  sampsize_vec <- as.integer(psu_per_stratum[as.character(strata_id)])
-  sampsize_mat <- matrix(sampsize_vec, ncol = 1L)
-
-  popsize_mat <- if (!is.null(vars$fpc)) {
-    fpc_vals <- data[[vars$fpc]]
-    if (any(fpc_vals > 1L, na.rm = TRUE)) {
-      matrix(as.numeric(fpc_vals), ncol = 1L)
-    } else {
-      matrix(as.numeric(sampsize_vec / fpc_vals), ncol = 1L)
-    }
-  } else {
-    NULL
-  }
-
-  fpcs <- list(sampsize = sampsize_mat, popsize = popsize_mat)
+  mats <- .build_cluster_matrices(design@data, design@variables)
   lonely.psu <- getOption("survey.lonely.psu", "remove")
 
   .svy_recvar(
     score_matrix,
-    clusters_mat,
-    strata_mat,
-    fpcs,
+    mats$clusters_mat,
+    mats$strata_mat,
+    mats$fpcs,
     lonely.psu = lonely.psu
   )
 }

--- a/changelog/multi-stage/feature-multi-stage-glm.md
+++ b/changelog/multi-stage/feature-multi-stage-glm.md
@@ -1,0 +1,20 @@
+# refactor(glm): replace inline FPC block with .build_cluster_matrices()
+
+**Date**: 2026-03-13
+**Branch**: feature/multi-stage-glm
+**Phase**: Multi-stage
+
+## Changes
+- Replace inline cluster/strata/FPC matrix-building block in
+  `.taylor_var_score_matrix()` (R/glm.R) with a call to the shared
+  `.build_cluster_matrices()` helper, enabling multi-stage Taylor
+  variance for GLM models
+- Add 2-stage GLM oracle test comparing `survey_glm()` against
+  `survey::svyglm()` for coefficients (1e-10) and SEs (1e-8)
+- Add smoke test verifying `survey_glm()` accepts multi-stage designs
+  without error
+
+## Files Modified
+- `R/glm.R` — Replace inline block in `.taylor_var_score_matrix()` with
+  `.build_cluster_matrices()` call (SRS-specific FPC reference unchanged)
+- `tests/testthat/test-glm.R` — Add multi-stage GLM oracle and smoke tests

--- a/tests/testthat/test-glm.R
+++ b/tests/testthat/test-glm.R
@@ -1088,3 +1088,39 @@ test_that("clean() CIs are numerically identical to confint(fit)", {
     tolerance = 1e-12
   )
 })
+
+
+# ===========================================================================
+# Multi-stage GLM tests
+# ===========================================================================
+
+test_that("survey_glm() matches survey::svyglm() for 2-stage design [oracle]", {
+  skip_if_not_installed("survey")
+  df <- make_survey_data(n = 500, n_psu = 50, n_ssu = 10, seed = 42)
+  sc <- as_survey(df, ids = c(psu, ssu), weights = wt, strata = strata)
+  test_invariants(sc)
+  test_glm_fit_invariants(survey_glm(y1 ~ y2, design = sc))
+  sv <- survey::svydesign(
+    id = ~psu + ssu, weights = ~wt, strata = ~strata,
+    data = df, nest = TRUE
+  )
+  sc_fit <- survey_glm(y1 ~ y2, design = sc)
+  sv_fit <- survey::svyglm(y1 ~ y2, design = sv)
+  expect_equal(sc_fit@coefficients, coef(sv_fit), tolerance = 1e-10)
+  expect_equal(
+    as.numeric(sqrt(diag(sc_fit@vcov))),
+    as.numeric(survey::SE(sv_fit)),
+    tolerance = 1e-8
+  )
+})
+
+test_that("survey_glm() accepts multi-stage design without error [smoke]", {
+  df <- make_survey_data(n = 300, n_psu = 30, n_ssu = 5, seed = 1)
+  sc <- as_survey(
+    df,
+    ids = c(psu, ssu),
+    weights = wt,
+    strata = strata
+  )
+  expect_no_error(survey_glm(y1 ~ y2, design = sc))
+})


### PR DESCRIPTION
## Summary
- Replace the inline cluster/strata/FPC matrix-building block in `.taylor_var_score_matrix()` (`R/glm.R`) with a call to the shared `.build_cluster_matrices()` helper from `R/utils.R`
- This enables multi-stage Taylor variance for GLM models (previously the inline block only handled single-stage designs and would error on multi-column FPC vectors)
- Add 2-stage GLM oracle test comparing `survey_glm()` against `survey::svyglm()` for coefficients (1e-10) and SEs (1e-8)
- Add smoke test verifying `survey_glm()` accepts multi-stage designs without error

## Implementation details
- **Changed**: `.taylor_var_score_matrix()` now delegates all matrix construction to `.build_cluster_matrices(design@data, design@variables)` instead of building clusters, strata, sampsize, and popsize matrices inline
- **Unchanged**: The SRS-specific FPC reference in `.glm_srs_vcov()` (line ~443, `fpc_var <- if (S7::S7_inherits(design, survey_srs)) vars$fpc else NULL`) is intentionally left untouched — it handles single-column FPC for SRS designs only

## Test plan
- [x] Oracle test: `survey_glm()` coefficients and SEs match `survey::svyglm()` for 2-stage design (tolerance 1e-10 / 1e-8)
- [x] Smoke test: `survey_glm()` runs without error on multi-stage design
- [x] All 7089 existing tests pass
- [x] `devtools::check()` — 0 errors, 0 warnings, 1 note (pre-existing worktree `.git` note)

## Dependencies
- Depends on PR #66 (`feature/build-cluster-matrices`) — merged to develop
- Part of the multi-stage implementation plan (PR 6 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)