### PR TITLE
feat(constructors): support multi-column FPC for multi-stage designs

### DIFF
--- a/R/core-constructors.R
+++ b/R/core-constructors.R
@@ -270,8 +270,12 @@ as_survey_srs <- function(
 #' @param strata <[`tidy-select`][tidyselect::language]> Stratification
 #'   variable column (a single column).
 #' @param fpc <[`tidy-select`][tidyselect::language]> Finite population
-#'   correction column (a single column). Accepts either total population size
-#'   (integer) or sampling fraction (numeric, 0–1). Cannot contain `NA`.
+#'   correction column(s). For single-stage designs, supply one column.
+#'   For multi-stage designs, supply one column per stage:
+#'   `fpc = c(fpc_stage1, fpc_stage2)`. Each column accepts either total
+#'   population size (integer, all > 1) or sampling fraction (numeric,
+#'   all in (0, 1]). Cannot contain `NA`. Cannot have more columns than
+#'   `ids` stages; fewer is allowed (later stages assume infinite population).
 #' @param nest Logical. If `TRUE`, PSU IDs are treated as nested within
 #'   strata — i.e., the same ID value in two different strata refers to two
 #'   distinct PSUs. Set `nest = TRUE` when PSU IDs are not globally unique
@@ -415,13 +419,19 @@ as_survey <- function(
     class_none = "surveycore_error_strata_not_found",
     class_multi = "surveycore_error_strata_multiple"
   )
-  fpc_var <- .resolve_single_col(
-    fpc_quo,
-    data,
-    "fpc",
-    class_none = "surveycore_error_fpc_not_found",
-    class_multi = "surveycore_error_fpc_multiple"
-  )
+  # fpc (may select multiple columns for multi-stage designs)
+  if (rlang::quo_is_null(fpc_quo)) {
+    fpc_vars <- NULL
+  } else {
+    fpc_cols <- tidyselect::eval_select(fpc_quo, data)
+    if (length(fpc_cols) == 0L) {
+      cli::cli_abort(
+        c("x" = "{.arg fpc} matched no columns in {.arg data}"),
+        class = "surveycore_error_fpc_not_found"
+      )
+    }
+    fpc_vars <- names(fpc_cols)
+  }
 
   # ── Probs / weights reconciliation ─────────────────────────────────────────
 
@@ -513,8 +523,191 @@ as_survey <- function(
   # Validate design variable columns exist and are atomic
   .validate_design_vars(c(ids_vars, strata_var), data)
 
-  # Validate fpc column (no NAs) via Layer 2
-  .validate_fpc(fpc_var, data)
+  # ── Multi-stage FPC validation ──────────────────────────────────────────────
+
+  if (!is.null(fpc_vars)) {
+    n_fpc <- length(fpc_vars)
+    n_ids <- if (is.null(ids_vars)) 1L else length(ids_vars)
+
+    # Error 88: fpc has more columns than ID stages
+    if (n_fpc > n_ids) {
+      cli::cli_abort(
+        c(
+          "x" = paste0(
+            "{.arg fpc} selected {n_fpc} column(s) but ",
+            "{.arg ids} has only {n_ids} stage(s)."
+          ),
+          "i" = paste0(
+            "FPC columns must correspond 1-to-1 with ID stages. ",
+            "Supply at most {n_ids} FPC column(s)."
+          )
+        ),
+        class = "surveycore_error_fpc_too_many_stages"
+      )
+    }
+
+    # Warning 89: fpc has fewer columns than ID stages
+    if (n_fpc < n_ids) {
+      cli::cli_warn(
+        c(
+          "!" = paste0(
+            "{.arg fpc} has {n_fpc} column(s) but ",
+            "{.arg ids} has {n_ids} stage(s)."
+          ),
+          "i" = paste0(
+            "Later stages assume sampling from an infinite ",
+            "population (no FPC)."
+          )
+        ),
+        class = "surveycore_warning_fpc_partial_stages"
+      )
+    }
+
+    # Per-column FPC validation loop
+    for (j in seq_along(fpc_vars)) {
+      fpc_var_j <- fpc_vars[[j]]
+      fpc_col_j <- data[[fpc_var_j]]
+
+      # FPC check: NA values (reuse Layer 2 helper for each column)
+      .validate_fpc(fpc_var_j, data)
+
+      # FPC check: non-positive values (row 57)
+      n_bad <- sum(fpc_col_j <= 0, na.rm = TRUE)
+      if (n_bad > 0L) {
+        cli::cli_abort(
+          c(
+            "x" = paste0(
+              "{.arg fpc} column {.field {fpc_var_j}} has {n_bad} ",
+              "non-positive value(s). FPC values must be > 0."
+            ),
+            "i" = paste0(
+              "FPC must be either population sizes (> 1) or ",
+              "sampling fractions (0 < f \u2264 1)."
+            )
+          ),
+          class = "surveycore_error_fpc_nonpositive"
+        )
+      }
+
+      # Determine if this column is population size or fraction
+      has_above_one <- any(fpc_col_j > 1, na.rm = TRUE)
+      has_le_one <- any(fpc_col_j <= 1, na.rm = TRUE)
+
+      # FPC check: ambiguous (mixes > 1 and <= 1) — row 58
+      if (has_above_one && has_le_one) {
+        cli::cli_abort(
+          c(
+            "x" = paste0(
+              "{.arg fpc} column {.field {fpc_var_j}} mixes ",
+              "values > 1 (population sizes) and values ",
+              "\u2264 1 (sampling fractions). All FPC values ",
+              "must be consistently one type."
+            ),
+            "i" = paste0(
+              "Use all values > 1 for population sizes, or ",
+              "all values in (0, 1] for sampling fractions."
+            )
+          ),
+          class = "surveycore_error_fpc_ambiguous"
+        )
+      }
+
+      # Stage-j-aware checks: parent cluster grouping
+      if (has_above_one) {
+        # Population size type: check within parent clusters
+        # For stage 1: group by strata (if present) or treat as one group
+        # For stage j>1: group by the (j-1)th ID column
+        if (j == 1L) {
+          parent_col <- if (!is.null(strata_var)) {
+            data[[strata_var]]
+          } else {
+            rep(1L, nrow(data))
+          }
+        } else {
+          parent_col <- data[[ids_vars[[j - 1L]]]]
+        }
+
+        # Error 90: FPC pop size < cluster count within parent
+        parent_groups <- split(
+          seq_len(nrow(data)),
+          parent_col
+        )
+        n_bad_parents <- 0L
+        for (grp_rows in parent_groups) {
+          fpc_val <- fpc_col_j[grp_rows[[1L]]]
+          # Count clusters at this stage within this parent
+          if (j <= length(ids_vars)) {
+            n_clusters <- length(
+              unique(data[[ids_vars[[j]]]][grp_rows])
+            )
+          } else {
+            n_clusters <- length(grp_rows)
+          }
+          if (fpc_val < n_clusters) {
+            n_bad_parents <- n_bad_parents + 1L
+          }
+        }
+
+        if (n_bad_parents > 0L) {
+          cli::cli_abort(
+            c(
+              "x" = paste0(
+                "Stage-{j} FPC column {.field {fpc_var_j}} has ",
+                "population sizes smaller than the observed ",
+                "cluster count in {n_bad_parents} parent ",
+                "group(s)."
+              ),
+              "i" = paste0(
+                "Population size must be >= the number of ",
+                "sampled units within each parent cluster."
+              )
+            ),
+            class = "surveycore_error_fpc_smaller_than_n"
+          )
+        }
+      } else {
+        # Fraction type: check constancy within parent clusters
+        if (j == 1L) {
+          parent_col <- if (!is.null(strata_var)) {
+            data[[strata_var]]
+          } else {
+            rep(1L, nrow(data))
+          }
+        } else {
+          parent_col <- data[[ids_vars[[j - 1L]]]]
+        }
+
+        parent_groups <- split(
+          seq_len(nrow(data)),
+          parent_col
+        )
+        any_not_constant <- FALSE
+        for (grp_rows in parent_groups) {
+          vals <- fpc_col_j[grp_rows]
+          if (length(unique(vals)) > 1L) {
+            any_not_constant <- TRUE
+            break
+          }
+        }
+
+        if (any_not_constant) {
+          cli::cli_abort(
+            c(
+              "x" = paste0(
+                "Stage-{j} FPC column {.field {fpc_var_j}} is ",
+                "not constant within parent clusters."
+              ),
+              "i" = paste0(
+                "FPC fractions must be the same for all units ",
+                "within each parent cluster."
+              )
+            ),
+            class = "surveycore_error_fpc_not_constant"
+          )
+        }
+      }
+    }
+  }
 
   # Warning 12: strata has only one unique value
   if (!is.null(strata_var)) {
@@ -538,7 +731,7 @@ as_survey <- function(
     ids = ids_vars,
     weights = weights_var,
     strata = strata_var,
-    fpc = fpc_var,
+    fpc = fpc_vars,
     nest = isTRUE(nest),
     probs_provided = probs_provided,
     visible_vars = NULL

--- a/changelog/multi-stage/feature-multi-stage-constructor.md
+++ b/changelog/multi-stage/feature-multi-stage-constructor.md
@@ -1,0 +1,47 @@
+# PR 3: Update `as_survey()` Multi-Column FPC
+
+**Branch:** `feature/multi-stage-constructor`
+**Merged:** 2026-03-13
+
+## Summary
+
+Updated `as_survey()` to accept multi-column FPC for multi-stage designs
+(e.g., `fpc = c(fpc_stage1, fpc_stage2)`). Each column corresponds 1-to-1
+with the ID stages specified in `ids`.
+
+## Changes
+
+### `R/core-constructors.R`
+- Replaced `.resolve_single_col()` for FPC with `tidyselect::eval_select()`
+  to allow multiple columns
+- Added per-column validation loop: NA, nonpositive, ambiguous type,
+  stage-aware cluster count vs. population size, fraction constancy checks
+- Added error `surveycore_error_fpc_too_many_stages` when FPC has more
+  columns than ID stages
+- Added warning `surveycore_warning_fpc_partial_stages` when FPC has fewer
+  columns than ID stages
+- Added error `surveycore_error_fpc_smaller_than_n` when stage-j FPC pop
+  size is smaller than observed cluster count within parent
+- Added error `surveycore_error_fpc_not_constant` when stage-j FPC fraction
+  varies within parent cluster
+- `@variables$fpc` now stores a character vector (length >= 1) instead of
+  character(1) for multi-stage designs; remains character(1) for single-stage
+- Updated `@param fpc` roxygen documentation
+- `as_survey_replicate()` and `as_survey_srs()` unchanged (still reject
+  multi-column FPC)
+
+### `tests/testthat/test-constructors.R`
+- Added 9 new test blocks in "as_survey() multi-stage FPC" section
+- Happy path: multi-column and single-column FPC storage
+- Error paths: too many stages, NA, nonpositive, smaller-than-n,
+  not-constant (all dual-pattern)
+- Warning path: partial FPC stages
+- `as_survey_replicate()` still rejects multi-column FPC
+
+### `plans/error-messages.md`
+- Added rows 88-91 for new error/warning classes
+- Updated row 13b scope note (now only enforced for replicate/SRS)
+- Updated coverage map
+
+### `man/as_survey.Rd`
+- Updated by `devtools::document()` to reflect new `@param fpc` docs

--- a/man/as_survey.Rd
+++ b/man/as_survey.Rd
@@ -34,8 +34,12 @@ column (a single column, values strictly > 0).}
 variable column (a single column).}
 
 \item{fpc}{<\code{\link[tidyselect:language]{tidy-select}}> Finite population
-correction column (a single column). Accepts either total population size
-(integer) or sampling fraction (numeric, 0–1). Cannot contain \code{NA}.}
+correction column(s). For single-stage designs, supply one column.
+For multi-stage designs, supply one column per stage:
+\code{fpc = c(fpc_stage1, fpc_stage2)}. Each column accepts either total
+population size (integer, all > 1) or sampling fraction (numeric,
+all in (0, 1]). Cannot contain \code{NA}. Cannot have more columns than
+\code{ids} stages; fewer is allowed (later stages assume infinite population).}
 
 \item{nest}{Logical. If \code{TRUE}, PSU IDs are treated as nested within
 strata — i.e., the same ID value in two different strata refers to two

--- a/plans/error-messages.md
+++ b/plans/error-messages.md
@@ -129,6 +129,11 @@ against the messages defined here.
 | M-13 | scalar-content setters (`set_var_label`, `set_question_preface`, `set_var_note`, `set_universe`) | A content value is not a character scalar (wrong type or length > 1) | ERROR | `surveycore_error_label_not_scalar` | `"x" = "Label content for {.field {var_name}} must be a character scalar, not {.cls {class(val)[[1L]]}} of length {length(val)}.", "v" = "Pass a single character string, e.g. {.code {fn_name}(x, {var_name} = 'My label')}."` |
 | M-14 | all setters (convention 3) | `variable` argument is explicitly provided as `character(0)` (length 0) | WARN | `surveycore_warning_setter_empty_variables` | `"!" = "{.fn {fn_name}} was called with {.arg variable} of length 0.", "i" = "No metadata was set. Did you accidentally filter all variable names out?"` |
 | M-15 | all extractors, `extract_metadata()` | `fill` argument has an invalid value for this function | ERROR | `surveycore_error_fill_invalid` | `"x" = "{.fn {fn_name}} does not accept {.code fill = {.val {fill}}}.", "i" = "Valid values for {.fn {fn_name}}: {.val {valid_fill_values}}."` |
+| 88 | `as_survey()` | `fpc` selects more columns than `ids` stages | ERROR | `surveycore_error_fpc_too_many_stages` | `"x" = "{.arg fpc} selected {n_fpc} column(s) but {.arg ids} has only {n_ids} stage(s).", "i" = "FPC columns must correspond 1-to-1 with ID stages. Supply at most {n_ids} FPC column(s)."` |
+| 89 | `as_survey()` | `fpc` selects fewer columns than `ids` stages | WARN | `surveycore_warning_fpc_partial_stages` | `"!" = "{.arg fpc} has {n_fpc} column(s) but {.arg ids} has {n_ids} stage(s).", "i" = "Later stages assume sampling from an infinite population (no FPC)."` |
+| 90 | `as_survey()` | Stage-j FPC population size < stage-j cluster count within parent | ERROR | `surveycore_error_fpc_smaller_than_n` | `"x" = "Stage-{j} FPC column {.field {fpc_var}} has population sizes smaller than the observed cluster count in {n_bad} parent group(s).", "i" = "Population size must be >= the number of sampled units within each parent cluster."` |
+| 91 | `as_survey()` | Stage-j FPC fraction not constant within parent cluster | ERROR | `surveycore_error_fpc_not_constant` | `"x" = "Stage-{j} FPC column {.field {fpc_var}} is not constant within parent clusters.", "i" = "FPC fractions must be the same for all units within each parent cluster."` |
+| 13b | `as_survey()` | `fpc` selects >1 column (multi-stage: now allowed) / `as_survey_replicate()` | ERROR | `surveycore_error_fpc_multiple` | `"{.arg fpc} must select exactly one column, not {length(fpc_cols)}"` (only enforced for `as_survey_replicate()` and `as_survey_srs()`) |
 
 ---
 
@@ -166,7 +171,7 @@ Which test files cover which error table rows:
 
 | Test File | Error Rows Covered |
 |-----------|-------------------|
-| `test-constructors.R` | 1–24, 23b, 56–61 |
+| `test-constructors.R` | 1–24, 23b, 56–61, 88–91, 13b |
 | `test-variance-twophase.R` | 63 |
 | `test-validators.R` | 27–35 |
 | `test-metadata-system.R` | 27–30, M-2/M-7, M-3–M-15 |

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -584,3 +584,57 @@
       4     4                 1
       5     5                 1
 
+# as_survey() errors when fpc has more columns than ID stages
+
+    Code
+      as_survey(df, ids = c(psu, ssu), weights = wt, fpc = c(fpc, fpc2, fpc3))
+    Condition
+      Error in `as_survey()`:
+      x `fpc` selected 3 column(s) but `ids` has only 2 stage(s).
+      i FPC columns must correspond 1-to-1 with ID stages. Supply at most 2 FPC column(s).
+
+# as_survey() rejects NA in stage-2 FPC column [dual-pattern]
+
+    Code
+      as_survey(df, ids = c(psu, ssu), weights = wt, fpc = c(fpc, fpc2_bad))
+    Condition
+      Error in `.validate_fpc()`:
+      x `fpc` column fpc2_bad contains 1 NA value(s). FPC must be fully observed.
+      v Remove rows with missing FPC or set `fpc = NULL` to omit the correction.
+
+# as_survey() rejects nonpositive stage-2 FPC value [dual-pattern]
+
+    Code
+      as_survey(df, ids = c(psu, ssu), weights = wt, fpc = c(fpc, fpc2_bad))
+    Condition
+      Error in `as_survey()`:
+      x `fpc` column fpc2_bad has 1 non-positive value(s). FPC values must be > 0.
+      i FPC must be either population sizes (> 1) or sampling fractions (0 < f ≤ 1).
+
+# as_survey() rejects stage-2 FPC smaller than stage-2 cluster count [dual-pattern]
+
+    Code
+      as_survey(df, ids = c(psu, ssu), weights = wt, fpc = c(fpc, fpc2_bad))
+    Condition
+      Error in `as_survey()`:
+      x Stage-2 FPC column fpc2_bad has population sizes smaller than the observed cluster count in 20 parent group(s).
+      i Population size must be >= the number of sampled units within each parent cluster.
+
+# as_survey() rejects non-constant stage-2 FPC fraction within PSU [dual-pattern]
+
+    Code
+      as_survey(df, ids = c(psu, ssu), weights = wt, fpc = c(fpc, fpc2_bad))
+    Condition
+      Error in `as_survey()`:
+      x Stage-2 FPC column fpc2_bad is not constant within parent clusters.
+      i FPC fractions must be the same for all units within each parent cluster.
+
+# as_survey_replicate() still rejects multi-column fpc
+
+    Code
+      as_survey_replicate(df, weights = wt, repweights = tidyselect::all_of(
+        repwt_cols), type = "BRR", fpc = c(fpc, fpc2))
+    Condition
+      Error in `as_survey_replicate()`:
+      x `fpc` must select exactly one column, not 2
+

--- a/tests/testthat/test-constructors.R
+++ b/tests/testthat/test-constructors.R
@@ -2324,6 +2324,191 @@ test_that("as_survey() leaves weighting_history as list() for plain data.frame",
 })
 
 # =============================================================================
+# as_survey() multi-stage FPC
+# =============================================================================
+
+test_that("as_survey() accepts multi-column fpc and stores as character vector", {
+  df <- make_survey_data(n = 200, n_psu = 20, n_ssu = 5, seed = 1)
+  sc <- as_survey(
+    df,
+    ids = c(psu, ssu),
+    weights = wt,
+    strata = strata,
+    fpc = c(fpc, fpc2)
+  )
+  test_invariants(sc)
+  expect_identical(sc@variables$fpc, c("fpc", "fpc2"))
+})
+
+test_that("as_survey() stores single-column fpc as character(1) [backward compat]", {
+  df <- make_survey_data(n = 200, n_psu = 20, seed = 1)
+  sc <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc)
+  test_invariants(sc)
+  expect_identical(sc@variables$fpc, "fpc")
+})
+
+test_that("as_survey() errors when fpc has more columns than ID stages", {
+  df <- make_survey_data(n = 200, n_psu = 20, n_ssu = 5, seed = 1)
+  # Need a third distinct FPC column to trigger >2 columns for 2-stage ids
+  df$fpc3 <- df$fpc2 + 1L
+  expect_error(
+    as_survey(
+      df,
+      ids = c(psu, ssu),
+      weights = wt,
+      fpc = c(fpc, fpc2, fpc3)
+    ),
+    class = "surveycore_error_fpc_too_many_stages"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey(
+      df,
+      ids = c(psu, ssu),
+      weights = wt,
+      fpc = c(fpc, fpc2, fpc3)
+    )
+  )
+})
+
+test_that("as_survey() warns for partial FPC (stage-1 col with 2-stage ids)", {
+  df <- make_survey_data(n = 200, n_psu = 20, n_ssu = 5, seed = 1)
+  expect_warning(
+    as_survey(
+      df,
+      ids = c(psu, ssu),
+      weights = wt,
+      strata = strata,
+      fpc = fpc
+    ),
+    class = "surveycore_warning_fpc_partial_stages"
+  )
+})
+
+test_that("as_survey() rejects NA in stage-2 FPC column [dual-pattern]", {
+  df <- make_survey_data(n = 200, n_psu = 20, n_ssu = 5, seed = 1)
+  df$fpc2_bad <- df$fpc2
+  df$fpc2_bad[1L] <- NA_integer_
+  expect_error(
+    as_survey(
+      df,
+      ids = c(psu, ssu),
+      weights = wt,
+      fpc = c(fpc, fpc2_bad)
+    ),
+    class = "surveycore_error_fpc_na"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey(
+      df,
+      ids = c(psu, ssu),
+      weights = wt,
+      fpc = c(fpc, fpc2_bad)
+    )
+  )
+})
+
+test_that("as_survey() rejects nonpositive stage-2 FPC value [dual-pattern]", {
+  df <- make_survey_data(n = 200, n_psu = 20, n_ssu = 5, seed = 1)
+  df$fpc2_bad <- df$fpc2
+  df$fpc2_bad[1L] <- 0L
+  expect_error(
+    as_survey(
+      df,
+      ids = c(psu, ssu),
+      weights = wt,
+      fpc = c(fpc, fpc2_bad)
+    ),
+    class = "surveycore_error_fpc_nonpositive"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey(
+      df,
+      ids = c(psu, ssu),
+      weights = wt,
+      fpc = c(fpc, fpc2_bad)
+    )
+  )
+})
+
+test_that("as_survey() rejects stage-2 FPC smaller than stage-2 cluster count [dual-pattern]", {
+  df <- make_survey_data(n = 200, n_psu = 20, n_ssu = 5, seed = 1)
+  df$fpc2_bad <- 2L # smaller than actual SSU count per PSU (5)
+  expect_error(
+    as_survey(
+      df,
+      ids = c(psu, ssu),
+      weights = wt,
+      fpc = c(fpc, fpc2_bad)
+    ),
+    class = "surveycore_error_fpc_smaller_than_n"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey(
+      df,
+      ids = c(psu, ssu),
+      weights = wt,
+      fpc = c(fpc, fpc2_bad)
+    )
+  )
+})
+
+test_that("as_survey() rejects non-constant stage-2 FPC fraction within PSU [dual-pattern]", {
+  df <- make_survey_data(n = 200, n_psu = 20, n_ssu = 5, seed = 1)
+  set.seed(99)
+  df$fpc2_bad <- runif(nrow(df), 0.1, 0.9)
+  expect_error(
+    as_survey(
+      df,
+      ids = c(psu, ssu),
+      weights = wt,
+      fpc = c(fpc, fpc2_bad)
+    ),
+    class = "surveycore_error_fpc_not_constant"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey(
+      df,
+      ids = c(psu, ssu),
+      weights = wt,
+      fpc = c(fpc, fpc2_bad)
+    )
+  )
+})
+
+test_that("as_survey_replicate() still rejects multi-column fpc", {
+  df <- make_survey_data(
+    n = 100, n_psu = 10, n_ssu = 5, design = "replicate", seed = 1
+  )
+  repwt_cols <- grep("^repwt_", names(df), value = TRUE)
+  expect_error(
+    as_survey_replicate(
+      df,
+      weights = wt,
+      repweights = tidyselect::all_of(repwt_cols),
+      type = "BRR",
+      fpc = c(fpc, fpc2)
+    ),
+    class = "surveycore_error_fpc_multiple"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey_replicate(
+      df,
+      weights = wt,
+      repweights = tidyselect::all_of(repwt_cols),
+      type = "BRR",
+      fpc = c(fpc, fpc2)
+    )
+  )
+})
+
+
+# =============================================================================
 # make_survey_data() extension — multi-stage (n_ssu, n_unit)
 # =============================================================================
 


### PR DESCRIPTION
## Summary

- Updated `as_survey()` to accept multi-column FPC via tidy-select (e.g., `fpc = c(fpc1, fpc2)`), with each column corresponding 1-to-1 with the ID stages in `ids`
- Added stage-aware validation: population-size-vs-cluster-count and fraction-constancy checks within parent clusters
- Added 4 new error/warning classes: `surveycore_error_fpc_too_many_stages`, `surveycore_error_fpc_smaller_than_n`, `surveycore_error_fpc_not_constant`, `surveycore_warning_fpc_partial_stages`
- `@variables$fpc` now stores a character vector (length >= 1) for multi-stage designs; remains character(1) for single-stage
- 9 new test blocks covering happy path, error paths, and edge cases (all dual-pattern)

## Test plan

- [x] Multi-column FPC happy path stores correct character vector in `@variables$fpc`
- [x] Single-column FPC backward compatibility preserved
- [x] FPC with more columns than ID stages errors
- [x] FPC with fewer columns than ID stages warns
- [x] NA in any FPC column errors
- [x] Nonpositive value in any FPC column errors
- [x] FPC population size smaller than cluster count errors
- [x] Non-constant FPC fraction within parent cluster errors
- [x] `as_survey_replicate()` still rejects multi-column FPC
- [x] All 7115 tests pass
- [x] R CMD check: 0 errors, 0 warnings, 1 note (pre-approved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)