### PR TITLE
feat(print): per-stage FPC display for multi-stage designs

### DIFF
--- a/R/methods-print.R
+++ b/R/methods-print.R
@@ -177,7 +177,15 @@ S7::method(print, survey_taylor) <- function(
 
     fpc_var <- x@variables$fpc
     if (!is.null(fpc_var)) {
-      cli::cli_bullets(c("*" = "FPC: {.field {fpc_var}}"))
+      if (length(fpc_var) == 1L) {
+        cli::cli_bullets(c("*" = "FPC: {.field {fpc_var}}"))
+      } else {
+        for (j in seq_along(fpc_var)) {
+          cli::cli_bullets(c(
+            "*" = "FPC (stage {j}): {.field {fpc_var[[j]]}}"
+          ))
+        }
+      }
     } else {
       cli::cli_bullets(c("*" = "FPC: not specified"))
     }

--- a/changelog/multi-stage/feature-multi-stage-print.md
+++ b/changelog/multi-stage/feature-multi-stage-print.md
@@ -1,0 +1,26 @@
+# PR 7: Update `print.survey_taylor` Per-Stage FPC Display
+
+**Branch:** `feature/multi-stage-print`
+**Merged:** 2026-03-14
+
+## Summary
+
+Updated `print.survey_taylor` to display multi-column FPC with one bullet
+per stage (e.g., `FPC (stage 1): fpc`, `FPC (stage 2): fpc2`) instead of
+collapsing all column names into a single line.
+
+## Changes
+
+### `R/methods-print.R`
+- Updated FPC display section in `print.survey_taylor`: when
+  `length(fpc_var) > 1`, renders one `FPC (stage j): col_name` bullet per
+  stage; single-column FPC unchanged (`FPC: col_name`)
+
+### `tests/testthat/test-methods-print.R`
+- Added snapshot test: 2-stage design with `fpc = c(fpc, fpc2)` shows
+  per-stage FPC bullets in `design_info = TRUE` output
+- Added content test: single-stage design still shows `FPC: fpc` (no
+  `(stage N)` suffix)
+
+### `tests/testthat/_snaps/methods-print.md`
+- Added snapshot for per-stage FPC display

--- a/tests/testthat/_snaps/methods-print.md
+++ b/tests/testthat/_snaps/methods-print.md
@@ -684,3 +684,42 @@
       10 psu_3 stratum_1   378  13.7  53.4 -0.513      1 A     FALSE                
       # i 40 more rows
 
+# print.survey_taylor shows per-stage FPC for 2-stage design
+
+    Code
+      print(sc, design_info = TRUE)
+    Message
+      
+      -- Survey Design ---------------------------------------------------------------
+      <survey_taylor> (Taylor series linearization)
+      Sample size: 200
+      
+      
+      -- Design specification --
+      
+      * IDs: psu and ssu (20 PSUs)
+      * Strata: strata (5 strata)
+      * Weights: wt
+      * Weights provided as: sampling weights
+      * FPC (stage 1): fpc
+      * FPC (stage 2): fpc2
+      * Nesting: FALSE
+      
+      Design variables: psu, ssu, wt, strata, fpc, and fpc2
+      
+    Output
+      # A tibble: 200 x 10
+         psu   strata      fpc    wt    y1      y2    y3 group ssu       fpc2
+         <chr> <chr>     <dbl> <dbl> <dbl>   <dbl> <int> <chr> <chr>    <int>
+       1 psu_1 stratum_1   365  9.09  61.7  0.606      0 A     psu_1_s1    10
+       2 psu_1 stratum_1   365 10.4   35.4  1.34       0 B     psu_1_s2    10
+       3 psu_1 stratum_1   365  8.25  51.0  0.767      0 A     psu_1_s3    10
+       4 psu_1 stratum_1   365 10.8   58.5  0.194      0 B     psu_1_s4    10
+       5 psu_1 stratum_1   365  7.70  33.8  1.14       1 C     psu_1_s5    10
+       6 psu_1 stratum_1   365  9.43  64.1  0.0139     1 B     psu_1_s1    10
+       7 psu_1 stratum_1   365 10.6   44.6 -1.11       0 C     psu_1_s2    10
+       8 psu_1 stratum_1   365 10.1   52.8 -0.0252     0 B     psu_1_s3    10
+       9 psu_1 stratum_1   365 11.6   48.1 -0.164      0 B     psu_1_s4    10
+      10 psu_1 stratum_1   365  9.75  65.8  0.370      0 C     psu_1_s5    10
+      # i 190 more rows
+

--- a/tests/testthat/test-methods-print.R
+++ b/tests/testthat/test-methods-print.R
@@ -823,3 +823,31 @@ test_that("summary.survey_twophase() with Phase 1 strata covers the Strata line"
   out <- capture.output(summary(sc), type = "message")
   expect_true(any(grepl("Strata|strata", out)))
 })
+
+
+# ── Multi-stage FPC display ──────────────────────────────────────────────────
+
+test_that("print.survey_taylor shows per-stage FPC for 2-stage design", {
+  df <- make_survey_data(n = 200, n_psu = 20, n_ssu = 5, seed = 1)
+  sc <- as_survey(
+    df,
+    ids = c(psu, ssu),
+    weights = wt,
+    strata = strata,
+    fpc = c(fpc, fpc2)
+  )
+  test_invariants(sc)
+  withr::local_options(list(width = 80L, cli.width = 80L))
+  expect_snapshot(print(sc, design_info = TRUE))
+})
+
+test_that("print.survey_taylor shows single FPC line for 1-stage design", {
+  d <- make_taylor_design()
+  test_invariants(d)
+  withr::local_options(list(width = 80L, cli.width = 80L))
+  out <- capture.output(print(d, design_info = TRUE), type = "message")
+  # Should show single "FPC: fpc" line, not "FPC (stage 1):"
+
+  expect_true(any(grepl("FPC: fpc$", out)))
+  expect_false(any(grepl("FPC \\(stage", out)))
+})


### PR DESCRIPTION
## Summary
- Updated `print.survey_taylor` to show per-stage FPC bullets when `@variables$fpc` has multiple columns (e.g., `FPC (stage 1): fpc`, `FPC (stage 2): fpc2`)
- Single-stage FPC display unchanged (`FPC: fpc`)
- Added snapshot test for 2-stage FPC and content test verifying single-stage is unaffected

## Test plan
- [x] Snapshot test: 2-stage design shows per-stage FPC bullets in `design_info = TRUE`
- [x] Content test: single-stage design shows `FPC: fpc` without `(stage N)` suffix
- [x] All 879 existing print/summary tests pass (no regressions)
- [x] Full suite: 7273 tests pass, 0 failures
- [x] R CMD check: 0 errors (vignette warnings are pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)