### PR TITLE
fix(glm): correct weight indexing for non-contiguous NAs with na.omit

### DIFF
--- a/R/glm.R
+++ b/R/glm.R
@@ -954,7 +954,11 @@ survey_glm <- function(
     vcov = vcov_mat,
     fitted_values = as.numeric(stats::fitted(fit)),
     residuals = as.numeric(stats::residuals(fit, type = "working")),
-    weights = as.numeric(wt_fit[seq_len(length(stats::fitted(fit)))]),
+    weights = if (!is.null(na_idx)) {
+      as.numeric(wt_fit[-na_idx])
+    } else {
+      as.numeric(wt_fit)
+    },
     design = design,
     degf = degf_val,
     family = as.list(fam),

--- a/changelog/audit/fix-glm-weights-na-contiguous.md
+++ b/changelog/audit/fix-glm-weights-na-contiguous.md
@@ -1,0 +1,17 @@
+# fix(glm): correct weight indexing for non-contiguous NAs with na.omit
+
+**Date**: 2026-03-16
+**Branch**: fix/glm-weights-na-contiguous
+**Phase**: Audit remediation
+
+## Changes
+
+- Fixed incorrect weight vector indexing in `survey_glm()` when `na.action = na.omit` drops non-contiguous rows
+- Previously, `wt_fit[seq_len(length(fitted(fit)))]` always took the first N weights, which is wrong when dropped rows are non-contiguous
+- Now uses `wt_fit[-na_idx]` to select weights corresponding to rows actually used in the fit
+- Added 2 new tests covering non-contiguous NA weight correctness and equivalence with manually-cleaned data
+
+## Files Modified
+
+- `R/glm.R` — replaced `seq_len(length(fitted(fit)))` with `na_idx`-aware indexing at the `survey_glm_fit()` constructor call
+- `tests/testthat/test-glm.R` — added 2 tests for non-contiguous NA weight correctness

--- a/tests/testthat/test-glm.R
+++ b/tests/testthat/test-glm.R
@@ -1124,3 +1124,44 @@ test_that("survey_glm() accepts multi-stage design without error [smoke]", {
   )
   expect_no_error(survey_glm(y1 ~ y2, design = sc))
 })
+
+# ── Audit: non-contiguous NA weight indexing fix ──────────────────────────────
+
+test_that("survey_glm() @weights correct with non-contiguous NAs and na.omit", {
+  df <- make_survey_data(n = 200L, seed = 42)
+  # Inject NAs at non-contiguous positions in the response
+  na_positions <- c(3L, 7L, 15L, 42L, 100L)
+  df$y1[na_positions] <- NA_real_
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
+  fit <- survey_glm(d, y1 ~ y2, na.action = na.omit)
+
+  test_glm_fit_invariants(fit)
+
+  # Number of weights must equal number of fitted values
+  expect_equal(length(fit@weights), length(fit@fitted_values))
+
+  # Weights should correspond to the non-NA rows' weights
+  non_na_mask <- !seq_len(nrow(df)) %in% na_positions
+  expected_weights <- df$wt[non_na_mask]
+  expect_equal(fit@weights, expected_weights, tolerance = 1e-10)
+})
+
+test_that("survey_glm() with non-contiguous na.omit matches clean-data fit", {
+  df <- make_survey_data(n = 200L, seed = 42)
+  na_positions <- c(3L, 7L, 15L, 42L, 100L)
+  df$y1[na_positions] <- NA_real_
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
+  fit_na <- survey_glm(d, y1 ~ y2, na.action = na.omit)
+
+  # Fit on manually cleaned data
+  df_clean <- df[!is.na(df$y1), ]
+  d_clean <- as_survey(
+    df_clean, ids = psu, weights = wt, strata = strata, nest = TRUE
+  )
+  fit_clean <- survey_glm(d_clean, y1 ~ y2)
+
+  expect_equal(
+    fit_na@coefficients, fit_clean@coefficients, tolerance = 1e-10
+  )
+  expect_equal(fit_na@weights, fit_clean@weights, tolerance = 1e-10)
+})


### PR DESCRIPTION
## What this does

Fixes a bug in `survey_glm()` where the `@weights` slot of the returned `survey_glm_fit` object contained incorrect weights when `na.action = na.omit` dropped non-contiguous rows. The old code used `seq_len(length(fitted(fit)))` which always took the first N weights from the domain weight vector, rather than the weights corresponding to the rows actually used in the fit. The fix uses `na_idx`-aware negative indexing to select the correct weights.

## Technical changes

- **New functions:** None
- **New tests:** 2 new test cases (non-contiguous NA weight correctness + equivalence with manually-cleaned data)
- **Modified files:** `R/glm.R`, `tests/testthat/test-glm.R`, `changelog/audit/fix-glm-weights-na-contiguous.md`
- **Plan section:** `fix/glm-weights-na-contiguous` — PR 7 from `plans/impl-audit-remaining.md`

## Spec coverage

**From `plans/impl-audit-remaining.md` PR 7:**
- [x] New test: non-contiguous NAs with `na.action = na.omit` produces correct `@weights` (length == n_complete, values from correct rows)
- [x] New test: `survey_glm()` with NAs produces same coefficients as fitting on manually-cleaned data
- [x] Existing GLM tests unchanged (479 pass, 0 fail)
- [x] `devtools::check()` 0/0/3 (3 notes are pre-existing: .git, timestamps, archive/)

## Test results

`devtools::test()`: 7617 tests, 0 failures
`devtools::check()`: 0 errors, 0 warnings, 3 notes

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)