### PR TITLE
fix(constructors): allow survey_srs and survey_replicate as two-phase phase-1

### DIFF
--- a/R/core-constructors.R
+++ b/R/core-constructors.R
@@ -976,9 +976,12 @@ as_survey_replicate <- function(
 #' strict subset indicated by a logical column. Uses a tidy-select interface
 #' for all Phase 2 design variable arguments.
 #'
-#' @param phase1 A `survey_taylor` object representing the Phase 1 design.
+#' @param phase1 A survey design object (inheriting from `survey_base`)
+#'   representing the Phase 1 design. Accepts `survey_taylor`,
+#'   `survey_srs`, or `survey_replicate` objects.
 #'   Its `@data` must contain ALL rows from both phases, plus a logical
-#'   indicator column for Phase 2 membership. Create with [as_survey()].
+#'   indicator column for Phase 2 membership. Create with [as_survey()],
+#'   [as_survey_srs()], or [as_survey_replicate()].
 #' @param ids2 <[`tidy-select`][tidyselect::language]> Phase 2 cluster ID
 #'   column(s). For single-stage Phase 2: `ids2 = psu2`. For multi-stage:
 #'   `ids2 = c(psu2, ssu2)`. Omit if Phase 2 has no within-stratum
@@ -1064,16 +1067,19 @@ as_survey_twophase <- function(
   call <- match.call()
   method <- match.arg(method)
 
-  # ── Error 19: phase1 must be a survey_taylor object ─────────────────────────
+  # ── Error 19: phase1 must be a survey design object ─────────────────────────
 
-  if (!S7::S7_inherits(phase1, survey_taylor)) {
+  if (!S7::S7_inherits(phase1, survey_base)) {
     cli::cli_abort(
       c(
         "x" = paste0(
-          "{.arg phase1} must be a {.cls survey_taylor} object, not ",
-          "{.cls {class(phase1)[[1L]]}}."
+          "{.arg phase1} must be a survey design object ",
+          "({.cls survey_base}), not {.cls {class(phase1)[[1L]]}}."
         ),
-        "i" = "Create it first with {.fn as_survey}."
+        "i" = paste0(
+          "Create it first with {.fn as_survey}, ",
+          "{.fn as_survey_srs}, or {.fn as_survey_replicate}."
+        )
       ),
       class = "surveycore_error_phase1_class"
     )

--- a/changelog/audit/fix-twophase-phase1-type-restriction.md
+++ b/changelog/audit/fix-twophase-phase1-type-restriction.md
@@ -1,0 +1,22 @@
+# fix(constructors): allow survey_srs and survey_replicate as two-phase phase-1
+
+**Date**: 2026-03-16
+**Branch**: fix/twophase-phase1-type-restriction
+**Phase**: Audit remediation
+
+## Changes
+
+- Relaxed `as_survey_twophase()` phase-1 type check from `survey_taylor` to `survey_base`, allowing `survey_srs` and `survey_replicate` phase-1 designs
+- Updated error message (row 19) to reference `survey_base` instead of `survey_taylor`
+- Added acceptance tests for `survey_srs` and `survey_replicate` phase-1
+- Added oracle tests comparing SRS phase-1 two-phase estimates against `survey` package
+- Added smoke test for `survey_replicate` phase-1 two-phase estimation
+
+## Files Modified
+
+- `R/core-constructors.R` — relaxed type check from `survey_taylor` to `survey_base`; updated roxygen `@param phase1` docs
+- `man/as_survey_twophase.Rd` — regenerated from roxygen
+- `tests/testthat/test-constructors.R` — replaced replicate rejection test with acceptance test; added SRS acceptance test; added plain list rejection test
+- `tests/testthat/test-variance-twophase.R` — added SRS phase-1 oracle tests for means and totals; added replicate phase-1 smoke test
+- `tests/testthat/_snaps/constructors.md` — updated snapshot for new error message text
+- `plans/error-messages.md` — updated row 19 description

--- a/man/as_survey_twophase.Rd
+++ b/man/as_survey_twophase.Rd
@@ -15,9 +15,12 @@ as_survey_twophase(
 )
 }
 \arguments{
-\item{phase1}{A \code{survey_taylor} object representing the Phase 1 design.
+\item{phase1}{A survey design object (inheriting from \code{survey_base})
+representing the Phase 1 design. Accepts \code{survey_taylor},
+\code{survey_srs}, or \code{survey_replicate} objects.
 Its \verb{@data} must contain ALL rows from both phases, plus a logical
-indicator column for Phase 2 membership. Create with \code{\link[=as_survey]{as_survey()}}.}
+indicator column for Phase 2 membership. Create with \code{\link[=as_survey]{as_survey()}},
+\code{\link[=as_survey_srs]{as_survey_srs()}}, or \code{\link[=as_survey_replicate]{as_survey_replicate()}}.}
 
 \item{ids2}{<\code{\link[tidyselect:language]{tidy-select}}> Phase 2 cluster ID
 column(s). For single-stage Phase 2: \code{ids2 = psu2}. For multi-stage:

--- a/plans/error-messages.md
+++ b/plans/error-messages.md
@@ -47,7 +47,7 @@ against the messages defined here.
 | 16 | `as_survey_replicate()` | `repweights` selects 0 columns | ERROR | `surveycore_error_repweights_empty` | `"{.arg repweights} must select at least one column"` |
 | 17 | `as_survey_replicate()` | `scale`/`rscales` length mismatch | ERROR | `surveycore_error_rscales_length` | `"Length of {.arg rscales} ({length(rscales)}) must equal number of replicate weights ({n_rep})"` |
 | 18 | `as_survey_replicate()` | `type` not in valid set | ERROR | *(handled by match.arg)* | `"'{type}' is not a valid replicate type. Choose from: {.val {valid_types}}"` |
-| 19 | `as_survey_twophase()` | `phase1` is not a `survey_taylor` | ERROR | `surveycore_error_phase1_class` | `"{.arg phase1} must be a {.cls survey_taylor} object, not {.cls {class(phase1)[[1]]}}. Create it first with {.fn as_survey}."` |
+| 19 | `as_survey_twophase()` | `phase1` is not a survey design object | ERROR | `surveycore_error_phase1_class` | `"{.arg phase1} must be a survey design object ({.cls survey_base}), not {.cls {class(phase1)[[1]]}}. Create it first with {.fn as_survey}, {.fn as_survey_srs}, or {.fn as_survey_replicate}."` |
 | 20 | `as_survey_twophase()` | `subset` not provided (missing) | ERROR | `surveycore_error_subset_missing` | `"{.arg subset} is required: a logical column indicating Phase 2 membership"` |
 | 21 | `as_survey_twophase()` | `subset` selects >1 column | ERROR | `surveycore_error_subset_multiple` | `"{.arg subset} must select exactly one column, not {length(subset_cols)}"` |
 | 22 | `as_survey_twophase()` | `subset` column is not logical | ERROR | `surveycore_error_subset_not_logical` | `"{.arg subset} column {.field {subset_var}} must be logical, not {.cls {class(data[[subset_var]])}}"` |

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -158,14 +158,14 @@
       # i 190 more rows
       # i 1 more variable: phase2_prob <dbl>
 
-# as_survey_twophase() errors when phase1 is not a survey_taylor [row 19]
+# as_survey_twophase() errors when phase1 is a data.frame [row 19]
 
     Code
       as_survey_twophase(df, subset = subset)
     Condition
       Error in `as_survey_twophase()`:
-      x `phase1` must be a <survey_taylor> object, not <data.frame>.
-      i Create it first with `as_survey()`.
+      x `phase1` must be a survey design object (<survey_base>), not <data.frame>.
+      i Create it first with `as_survey()`, `as_survey_srs()`, or `as_survey_replicate()`.
 
 # as_survey_twophase() errors when subset is not provided [row 20]
 

--- a/tests/testthat/test-constructors.R
+++ b/tests/testthat/test-constructors.R
@@ -1173,8 +1173,8 @@ test_that("as_survey_twophase() snapshot: method = 'simple' + clustered Phase 1 
 
 # ── Error paths ───────────────────────────────────────────────────────────────
 
-# Row 19: phase1 is not a survey_taylor
-test_that("as_survey_twophase() errors when phase1 is not a survey_taylor [row 19]", {
+# Row 19: phase1 is not a survey design object
+test_that("as_survey_twophase() errors when phase1 is a data.frame [row 19]", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 19L)
   expect_error(
     as_survey_twophase(df, subset = subset),
@@ -1183,19 +1183,35 @@ test_that("as_survey_twophase() errors when phase1 is not a survey_taylor [row 1
   expect_snapshot(error = TRUE, as_survey_twophase(df, subset = subset))
 })
 
-test_that("as_survey_twophase() errors when phase1 is a survey_replicate [row 19]", {
-  df <- make_survey_data(n = 100, n_psu = 10L, design = "replicate", seed = 20L)
+test_that("as_survey_twophase() errors when phase1 is a plain list [row 19]", {
+  expect_error(
+    as_survey_twophase(list(a = 1), subset = a),
+    class = "surveycore_error_phase1_class"
+  )
+})
+
+test_that("as_survey_twophase() accepts survey_srs phase-1", {
+  df <- make_survey_data(n = 200, design = "twophase", seed = 42L)
+  phase1 <- suppressWarnings(as_survey_srs(df, weights = wt))
+  tp <- as_survey_twophase(phase1, subset = subset)
+  test_invariants(tp)
+  expect_true(S7::S7_inherits(tp, survey_twophase))
+})
+
+test_that("as_survey_twophase() accepts survey_replicate phase-1", {
+  df <- make_survey_data(
+    n = 100, n_psu = 10L, design = "replicate", seed = 20L
+  )
+  df$in_phase2 <- c(rep(TRUE, 50), rep(FALSE, 50))
   phase_rep <- as_survey_replicate(
     df,
     weights = wt,
     repweights = starts_with("repwt_"),
     type = "JK1"
   )
-  # phase1 class error fires before subset is resolved — bare name doesn't matter
-  expect_error(
-    as_survey_twophase(phase_rep, subset = in_phase2),
-    class = "surveycore_error_phase1_class"
-  )
+  tp <- as_survey_twophase(phase_rep, subset = in_phase2)
+  test_invariants(tp)
+  expect_true(S7::S7_inherits(tp, survey_twophase))
 })
 
 # Row 20: subset not provided

--- a/tests/testthat/test-variance-twophase.R
+++ b/tests/testthat/test-variance-twophase.R
@@ -535,3 +535,86 @@ test_that(".twophase_total() NA path fires when all domain values are NA", {
   result <- surveycore:::.twophase_total(sc, "y1", na.rm = FALSE)
   expect_true(is.na(result$total))
 })
+
+# ── Section 6: SRS / replicate phase-1 designs ──────────────────────────────
+
+test_that("two-phase with survey_srs phase-1 matches survey [oracle]", {
+  skip_if_not_installed("survival")
+  skip_if_not_installed("survey")
+
+  # Use the pbc dataset: SRS phase-1 (no clusters, no strata)
+  data("pbc", package = "survival", envir = environment())
+  pbc_ph1        <- subset(pbc, !is.na(trt))
+  pbc_ph1$in_ph2 <- !is.na(pbc_ph1$chol)
+  pbc_ph1$wt     <- 1
+
+  ph1_sc <- as_survey_srs(pbc_ph1, weights = wt)
+  d_sc   <- as_survey_twophase(ph1_sc, subset = in_ph2, method = "approx")
+
+  d_sv <- survey::twophase(
+    id     = list(~1, ~1),
+    data   = pbc_ph1,
+    subset = ~in_ph2,
+    method = "approx"
+  )
+
+  sc_est <- get_means(d_sc, chol, variance = c("se", "ci"))
+  sv_est <- survey::svymean(~chol, d_sv, na.rm = TRUE)
+
+  expect_equal(sc_est$mean,    coef(sv_est)[["chol"]], tolerance = 1e-10)
+  expect_equal(sc_est$se,      as.numeric(survey::SE(sv_est)), tolerance = 1e-8)
+  expect_equal(sc_est$ci_low,  confint(sv_est)[1], tolerance = 1e-6)
+  expect_equal(sc_est$ci_high, confint(sv_est)[2], tolerance = 1e-6)
+})
+
+test_that("two-phase with survey_srs phase-1 get_totals matches survey [oracle]", {
+  skip_if_not_installed("survival")
+  skip_if_not_installed("survey")
+
+  data("pbc", package = "survival", envir = environment())
+  pbc_ph1        <- subset(pbc, !is.na(trt))
+  pbc_ph1$in_ph2 <- !is.na(pbc_ph1$chol)
+  pbc_ph1$wt     <- 1
+
+  ph1_sc <- as_survey_srs(pbc_ph1, weights = wt)
+  d_sc   <- as_survey_twophase(ph1_sc, subset = in_ph2, method = "approx")
+
+  d_sv <- survey::twophase(
+    id     = list(~1, ~1),
+    data   = pbc_ph1,
+    subset = ~in_ph2,
+    method = "approx"
+  )
+
+  sc_est <- get_totals(d_sc, chol, variance = c("se", "ci"))
+  sv_est <- survey::svytotal(~chol, d_sv, na.rm = TRUE)
+
+  expect_equal(sc_est$total,   coef(sv_est)[["chol"]], tolerance = 1e-10)
+  expect_equal(sc_est$se,      as.numeric(survey::SE(sv_est)), tolerance = 1e-8)
+  expect_equal(sc_est$ci_low,  confint(sv_est)[1], tolerance = 1e-6)
+  expect_equal(sc_est$ci_high, confint(sv_est)[2], tolerance = 1e-6)
+})
+
+test_that("two-phase with survey_replicate phase-1 constructs and estimates", {
+  # No direct survey:: oracle for replicate phase-1 twophase, but verify
+
+  # construction succeeds and estimation produces finite results
+  df <- make_survey_data(
+    n = 100, n_psu = 10L, design = "replicate", seed = 801L
+  )
+  df$in_phase2 <- c(rep(TRUE, 50), rep(FALSE, 50))
+
+  phase_rep <- as_survey_replicate(
+    df,
+    weights = wt,
+    repweights = starts_with("repwt_"),
+    type = "JK1"
+  )
+  tp <- as_survey_twophase(phase_rep, subset = in_phase2, method = "approx")
+
+  expect_true(S7::S7_inherits(tp, survey_twophase))
+
+  result <- get_means(tp, y1, variance = "se")
+  expect_true(is.finite(result$mean[[1L]]))
+  expect_gte(result$se[[1L]], 0)
+})


### PR DESCRIPTION
## What this does

Relaxes the `as_survey_twophase()` phase-1 type check from `survey_taylor` to `survey_base`, enabling valid use cases like SRS phase-1 frames (Lumley 2010) and replicate-weight phase-1 designs. The variance engine in `R/variance-twophase.R` already handles these design types correctly via `NULL` guards on `ids`/`strata`/`nest` keys.

## Technical changes

- **Modified files:** `R/core-constructors.R`, `man/as_survey_twophase.Rd`, `plans/error-messages.md`, `tests/testthat/test-constructors.R`, `tests/testthat/test-variance-twophase.R`, `tests/testthat/_snaps/constructors.md`
- **New tests:** 6 new test cases (2 constructor acceptance, 1 constructor rejection, 3 variance oracle/smoke)
- **Plan section:** `fix/twophase-phase1-type-restriction` — PR 5 from `plans/impl-audit-remaining.md`

## Spec coverage

**From `plans/impl-audit-remaining.md` PR 5:**
- [x] `as_survey_twophase(phase1 = srs_design, ...)` no longer errors
- [x] `as_survey_twophase(phase1 = replicate_design, ...)` no longer errors
- [x] `as_survey_twophase(phase1 = data.frame(...))` still errors
- [x] Oracle test: SRS phase-1 two-phase mean SE matches `survey` at 1e-8
- [x] Existing Taylor phase-1 tests unchanged
- [x] `devtools::check()` 0/0/≤3 (notes are pre-existing)

## Test results

`devtools::test()`: 7646 tests, 0 failures
`devtools::check()`: 0 errors, 0 warnings, 3 notes (pre-existing)

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)