### PR TITLE
feat(classes): relax survey_nonprob validator to allow zero weights

### DIFF
--- a/R/core-classes.R
+++ b/R/core-classes.R
@@ -697,15 +697,28 @@ survey_nonprob <- S7::new_class(
         )
       }
 
-      n_bad <- sum(non_na <= 0)
-      if (n_bad > 0L) {
+      # Condition 4a — reject negative weights
+      n_neg <- sum(non_na < 0)
+      if (n_neg > 0L) {
         cli::cli_abort(
           c(
-            "x" = "Weight column {.field {weights_var}} has {n_bad} non-positive value(s).",
-            "i" = "All non-NA weights must be strictly greater than 0.",
-            "v" = "Remove or replace rows where {.field {weights_var}} is 0 or negative."
+            "x" = "Weight column {.field {weights_var}} has {n_neg} negative value(s).",
+            "i" = "All non-NA weights must be non-negative (>= 0).",
+            "v" = "Remove or replace rows where {.field {weights_var}} is negative."
           ),
-          class = "surveycore_error_weights_nonpositive"
+          class = "surveycore_error_weights_negative"
+        )
+      }
+
+      # Condition 4b — reject all-zero weights (no positive values)
+      if (!any(non_na > 0)) {
+        cli::cli_abort(
+          c(
+            "x" = "Weight column {.field {weights_var}} has no positive values.",
+            "i" = "At least one non-NA weight must be greater than 0.",
+            "v" = "Check that {.field {weights_var}} contains valid survey weights."
+          ),
+          class = "surveycore_error_weights_all_zero"
         )
       }
     }

--- a/changelog/prereq-surveyweights/nonprob-zero-weights.md
+++ b/changelog/prereq-surveyweights/nonprob-zero-weights.md
@@ -1,0 +1,25 @@
+# Changelog: Relax `survey_nonprob` Validator -- Zero Weights
+
+**Branch:** `feature/nonprob-zero-weights`
+**Date:** 2026-03-18
+
+## Summary
+
+Split the `survey_nonprob` validator condition 4 into two checks: condition 4a
+rejects negative weights (new class `surveycore_error_weights_negative`) and
+condition 4b rejects all-zero weights (reuses `surveycore_error_weights_all_zero`).
+Zero weights are now accepted when at least one positive weight exists, unblocking
+the surveywts `adjust_nonresponse()` workflow.
+
+## Files changed
+
+- `R/core-classes.R` -- Split condition 4 into 4a (negative) and 4b (all-zero)
+- `tests/testthat/test-s7-classes.R` -- Added 9 new validator tests (happy path, error paths, edge cases)
+- `tests/testthat/test-constructors.R` -- Deleted duplicate test; updated error class name
+- `tests/testthat/helper-test-data.R` -- Updated `test_invariants()` nonprob branch: `>= 0` with `any > 0`
+- `plans/error-messages.md` -- Added row 101; updated rows 10 and 33
+
+## Check results
+
+- `devtools::test()`: 7581 tests, 0 failures
+- `devtools::check()`: 0 errors, 0 warnings, 2 notes (pre-approved)

--- a/plans/error-messages.md
+++ b/plans/error-messages.md
@@ -37,7 +37,7 @@ against the messages defined here.
 | 7 | `as_survey()` | No weights, probs, or ids (SRS) | WARN | `surveycore_warning_srs_no_weights` | `"No weights or population size provided. Treating as equal-probability SRS with unknown population size. Valid: means, proportions, correlations. Invalid: population totals."` |
 | 8 | `as_survey()` | `weights` selects 0 columns | ERROR | `surveycore_error_weights_not_found` | `"{.arg weights} matched no columns in {.arg data}"` |
 | 9 | `as_survey()` | `weights` selects >1 column | ERROR | `surveycore_error_weights_multiple` | `"{.arg weights} must select exactly one column, not {length(weights_cols)}"` |
-| 10 | `as_survey()` | `weights` all zero | ERROR | `surveycore_error_weights_all_zero` | `"All values in {.arg weights} ({.field {weights_var}}) are zero or missing — no valid weights"` |
+| 10 | `as_survey()` | `weights` all zero | ERROR | `surveycore_error_weights_all_zero` | `"All values in {.arg weights} ({.field {weights_var}}) are zero or missing — no valid weights"` Note: Also thrown by `survey_nonprob` validator condition 4b (all non-NA weights are zero, no positive values). |
 | 11 | `as_survey()` | `strata` selects 0 columns | ERROR | `surveycore_error_strata_not_found` | `"{.arg strata} matched no columns in {.arg data}"` |
 | 11b | `as_survey()` | `strata` selects >1 column | ERROR | `surveycore_error_strata_multiple` | `"{.arg strata} must select exactly one column, not {length(strata_cols)}"` |
 | 12 | `as_survey()` | `strata` resolves to 1 unique value | WARN | `surveycore_warning_single_stratum` | `"{.arg strata} ({.field {strata_var}}) has only 1 unique value — stratification has no effect"` |
@@ -62,7 +62,7 @@ against the messages defined here.
 | 30 | `set_val_labels()` | Some data values lack a label | WARN | `surveycore_warning_missing_labels` | `"Not all values of {.field {var_name}} are labeled. Unlabeled values: {.val {missing}}"` |
 | 31 | S7 validator (`survey_taylor`) | Design variable not in data | ERROR | `surveycore_error_design_var_missing` | `"Design variable(s) not found in {.arg data}: {.field {missing}}"` |
 | 32 | S7 validator (`survey_taylor`) | Weight column not numeric | ERROR | `surveycore_error_weights_not_numeric` | `"Weight column {.field {weights_var}} must be numeric, not {.cls {class(wt_col)}}"` |
-| 33 | S7 validator (`survey_taylor`) | Weight column has non-positive values | ERROR | `surveycore_error_weights_nonpositive` | `"Weight column {.field {weights_var}} has {n_bad} non-positive value(s). All non-NA weights must be > 0."` |
+| 33 | S7 validator (`survey_taylor`, `survey_replicate`) | Weight column has non-positive values | ERROR | `surveycore_error_weights_nonpositive` | `"Weight column {.field {weights_var}} has {n_bad} non-positive value(s). All non-NA weights must be > 0."` Note: No longer thrown by `survey_nonprob` validator (see row 101, `surveycore_error_weights_negative`). |
 | 34 | S7 validator (`survey_taylor`) | Design variable is a list-column | ERROR | `surveycore_error_design_var_list` | `"Design variable {.field {var}} is a list-column. Design variables must be atomic vectors."` |
 | 35 | S7 validator (all) | PSU appears in multiple strata | WARN | `surveycore_warning_psu_multi_strata` | `"Some PSUs appear in more than one stratum: {.val {head(multi_strata_psus, 5)}}. If PSUs are nested within strata, set {.code nest = TRUE}."` |
 | 36 | `update_design()` | Any design variable update | WARN | *(inform, not warn)* | `"Survey design updated. This may affect statistical validity. Updated: {.field {changed_vars}}"` |
@@ -144,6 +144,7 @@ against the messages defined here.
 | 98 | `get_diffs()` | `clean()` output missing intercept | ERROR | `surveycore_error_reference_row_not_found` | `"Reference row not found in model output. Expected exactly one intercept row."` |
 | 99 | `get_diffs()` | `show_pct_change = TRUE` and ref mean is 0 | WARN | `surveycore_warning_pct_change_zero_ref` | `"Reference group mean is 0; percentage change is undefined."` |
 | 100 | `get_diffs()` | `treats` column not a factor | WARN | `surveycore_warning_treats_coerced` | `"{.field {treats_name}} coerced to factor."` |
+| 101 | S7 validator (`survey_nonprob`) | Weight column has negative values | ERROR | `surveycore_error_weights_negative` | `"x" = "Weight column {.field {weights_var}} has {n_neg} negative value(s)."`, `"i" = "All non-NA weights must be non-negative (>= 0)."`, `"v" = "Remove or replace rows where {.field {weights_var}} is negative."` |
 
 ---
 

--- a/tests/testthat/helper-test-data.R
+++ b/tests/testthat/helper-test-data.R
@@ -284,8 +284,12 @@ test_invariants <- function(design) {
         label = "weight column has at least one non-NA value"
       )
       testthat::expect_true(
-        all(wt_col[!is.na(wt_col)] > 0),
-        label = "weight column has all positive non-NA values"
+        all(wt_col[!is.na(wt_col)] >= 0),
+        label = "weight column has all non-negative non-NA values"
+      )
+      testthat::expect_true(
+        any(wt_col[!is.na(wt_col)] > 0),
+        label = "weight column has at least one positive non-NA value"
       )
     }
 

--- a/tests/testthat/test-constructors.R
+++ b/tests/testthat/test-constructors.R
@@ -1794,25 +1794,6 @@ test_that("survey_nonprob validator rejects missing weight column in @data", {
   )
 })
 
-test_that("survey_nonprob validator rejects non-numeric weight column", {
-  df <- data.frame(y = 1:5, w = letters[1:5])
-  expect_error(
-    survey_nonprob(
-      data = df,
-      variables = list(
-        weights = "w",
-        probs_provided = FALSE,
-        ids = NULL,
-        strata = NULL,
-        fpc = NULL,
-        nest = FALSE,
-        visible_vars = NULL
-      )
-    ),
-    class = "surveycore_error_weights_not_numeric"
-  )
-})
-
 test_that("survey_nonprob validator rejects all-NA weight column", {
   df <- data.frame(y = 1:5, w = NA_real_)
   expect_error(
@@ -1832,7 +1813,7 @@ test_that("survey_nonprob validator rejects all-NA weight column", {
   )
 })
 
-test_that("survey_nonprob validator rejects non-positive weight column", {
+test_that("survey_nonprob validator rejects negative weights", {
   df <- data.frame(y = 1:5, w = c(1, -1, 1, 1, 1))
   expect_error(
     survey_nonprob(
@@ -1847,7 +1828,7 @@ test_that("survey_nonprob validator rejects non-positive weight column", {
         visible_vars = NULL
       )
     ),
-    class = "surveycore_error_weights_nonpositive"
+    class = "surveycore_error_weights_negative"
   )
 })
 

--- a/tests/testthat/test-s7-classes.R
+++ b/tests/testthat/test-s7-classes.R
@@ -764,3 +764,153 @@ test_that("survey_nonprob validator rejects non-numeric weight column", {
     class = "surveycore_error_weights_not_numeric"
   )
 })
+
+# ── survey_nonprob validator: zero weights ────────────────────────────────────
+
+test_that("survey_nonprob allows zero weights after post-construction assignment", {
+  df <- data.frame(x = 1:5, w = c(1, 2, 3, 4, 5))
+  obj <- as_survey_nonprob(df, weights = w)
+  new_data <- obj@data
+  new_data$w <- c(1, 0, 0, 4, 0)
+  obj@data <- new_data
+  test_invariants(obj)
+  expect_equal(sum(obj@data$w == 0), 3L)
+})
+
+test_that("survey_nonprob validator accepts zero weights with at least one positive", {
+  df <- data.frame(x = 1:5, w = c(1, 0, 0, 2, 0))
+  obj <- survey_nonprob(
+    data = df,
+    variables = list(
+      weights        = "w",
+      probs_provided = FALSE,
+      ids            = NULL,
+      strata         = NULL,
+      fpc            = NULL,
+      nest           = FALSE,
+      visible_vars   = NULL
+    )
+  )
+  test_invariants(obj)
+  expect_s3_class(obj@data, "data.frame")
+  expect_equal(sum(obj@data$w == 0), 3L)
+})
+
+test_that("survey_nonprob validator rejects negative weights", {
+  df <- data.frame(x = 1:3, w = c(1, -0.5, 2))
+  expect_error(
+    survey_nonprob(
+      data = df,
+      variables = list(
+        weights        = "w",
+        probs_provided = FALSE,
+        ids            = NULL,
+        strata         = NULL,
+        fpc            = NULL,
+        nest           = FALSE,
+        visible_vars   = NULL
+      )
+    ),
+    class = "surveycore_error_weights_negative"
+  )
+})
+
+test_that("survey_nonprob validator rejects all-zero weights", {
+  df <- data.frame(x = 1:3, w = c(0, 0, 0))
+  expect_error(
+    survey_nonprob(
+      data = df,
+      variables = list(
+        weights        = "w",
+        probs_provided = FALSE,
+        ids            = NULL,
+        strata         = NULL,
+        fpc            = NULL,
+        nest           = FALSE,
+        visible_vars   = NULL
+      )
+    ),
+    class = "surveycore_error_weights_all_zero"
+  )
+})
+
+test_that("survey_nonprob validator accepts single positive weight among zeros", {
+  df <- data.frame(x = 1:5, w = c(0, 0, 0, 0, 0.001))
+  obj <- survey_nonprob(
+    data = df,
+    variables = list(
+      weights        = "w",
+      probs_provided = FALSE,
+      ids            = NULL,
+      strata         = NULL,
+      fpc            = NULL,
+      nest           = FALSE,
+      visible_vars   = NULL
+    )
+  )
+  test_invariants(obj)
+})
+
+test_that("survey_nonprob validator accepts mix of zeros and NAs with one positive", {
+  df <- data.frame(x = 1:4, w = c(0, NA, 1, 0))
+  obj <- survey_nonprob(
+    data = df,
+    variables = list(
+      weights        = "w",
+      probs_provided = FALSE,
+      ids            = NULL,
+      strata         = NULL,
+      fpc            = NULL,
+      nest           = FALSE,
+      visible_vars   = NULL
+    )
+  )
+  test_invariants(obj)
+})
+
+test_that("survey_nonprob validator rejects mix of zeros and negatives", {
+  df <- data.frame(x = 1:3, w = c(0, -1, 0))
+  expect_error(
+    survey_nonprob(
+      data = df,
+      variables = list(
+        weights        = "w",
+        probs_provided = FALSE,
+        ids            = NULL,
+        strata         = NULL,
+        fpc            = NULL,
+        nest           = FALSE,
+        visible_vars   = NULL
+      )
+    ),
+    class = "surveycore_error_weights_negative"
+  )
+})
+
+test_that("survey_nonprob validator rejects all-zero weights with NAs", {
+  df <- data.frame(x = 1:3, w = c(0, NA, 0))
+  expect_error(
+    survey_nonprob(
+      data = df,
+      variables = list(
+        weights        = "w",
+        probs_provided = FALSE,
+        ids            = NULL,
+        strata         = NULL,
+        fpc            = NULL,
+        nest           = FALSE,
+        visible_vars   = NULL
+      )
+    ),
+    class = "surveycore_error_weights_all_zero"
+  )
+})
+
+test_that("test_invariants() passes for survey_nonprob with zero weights", {
+  df <- data.frame(x = 1:5, w = c(1, 2, 3, 4, 5))
+  obj <- as_survey_nonprob(df, weights = w)
+  new_data <- obj@data
+  new_data$w <- c(1, 0, 0, 2, 0)
+  obj@data <- new_data
+  expect_no_error(test_invariants(obj))
+})


### PR DESCRIPTION
## What this does

Relaxes the `survey_nonprob` S7 validator to accept zero weights when at least one positive weight exists. This is a prerequisite for surveywts `adjust_nonresponse()`, which sets nonrespondent weights to 0 on `survey_nonprob` objects. Previously, the validator rejected all non-positive weights with a single check; now it splits into two: condition 4a rejects negative weights (new error class), and condition 4b rejects all-zero weights (no positive values).

## Technical changes

- **Modified:** `R/core-classes.R` — Split `survey_nonprob` validator condition 4 into 4a (negative → `surveycore_error_weights_negative`) and 4b (all-zero → `surveycore_error_weights_all_zero`)
- **Modified:** `tests/testthat/helper-test-data.R` — Updated `test_invariants()` nonprob branch: `>= 0` with `any > 0`
- **Modified:** `tests/testthat/test-s7-classes.R` — Added 9 new validator tests
- **Modified:** `tests/testthat/test-constructors.R` — Deleted duplicate test; updated error class name
- **Modified:** `plans/error-messages.md` — Added row 101 + updated rows 10 and 33
- **New error class:** `surveycore_error_weights_negative` (row 101)
- **New tests:** 9 new test cases (happy path, error paths, edge cases)
- **Plan section:** `feature/nonprob-zero-weights` — PR 1 from `plans/impl-nonprob-zero-weights.md`

## Spec coverage

**From `plans/spec-nonprob-zero-weights.md`:**
- [x] `survey_nonprob` validator condition 4 split into 4a (negative) and 4b (all-zero)
- [x] Zero weights accepted by `survey_nonprob` validator when at least one positive weight exists
- [x] Negative weights rejected with `surveycore_error_weights_negative`
- [x] All-zero weights (no positive) rejected with `surveycore_error_weights_all_zero`
- [x] `survey_taylor` and `survey_replicate` validators unchanged (strict > 0)
- [x] `test_invariants()` updated: `>= 0` with `any > 0` for `survey_nonprob` path only
- [x] `plans/error-messages.md` updated with row 101 + row 10 note + row 33 update
- [x] All existing `survey_nonprob` weight tests updated per action table
- [x] New happy-path, workflow-path, and edge-case tests for zero-weight `survey_nonprob` objects

## Test results

`devtools::test()`: 7581 tests, 0 failures
`devtools::check()`: 0 errors, 0 warnings, 2 notes (pre-approved)

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)