### PR TITLE
chore(release): bump version to 0.6.1

### DIFF
--- a/.claude/rules/github-strategy.md
+++ b/.claude/rules/github-strategy.md
@@ -11,7 +11,7 @@
 |----------|--------|
 | Branching model | `develop` integration branch — features → `develop`; `develop` → `main` for releases |
 | Branch naming | `feature/`, `fix/`, `hotfix/`, `docs/`, `chore/`, `refactor/` |
-| Merge strategy | Squash and merge everywhere |
+| Merge strategy | Squash for feature → develop; regular merge for develop → main |
 | Commit format | Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `chore:`) |
 | PR granularity | One PR per logical unit of work |
 | Versioning | `X.Y.Z.9000` on `develop`; `X.Y.Z` on `main` after release |
@@ -106,9 +106,14 @@ feat(analysis): implement survey_glm() with Wald confidence intervals (#42)
 
 ## Merge Strategy
 
-**Squash and merge** on all PRs. GitHub settings: allow squash only; auto-delete head branches.
+**Feature → develop:** Squash and merge. `develop` history = one squash commit per
+feature PR.
 
-`main` history = one commit per release. `develop` history = one commit per feature PR.
+**Develop → main (releases only):** Regular merge. `main` history = one merge commit per
+release, plus the feature-level squash commits from develop. This avoids the SHA
+divergence that squash merges create between the two branches.
+
+GitHub settings: allow both squash merges and merge commits; auto-delete head branches.
 
 ---
 

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -117,8 +117,25 @@
       "Bash(R:*)",
       "Bash(Rscript 2:*)",
       "WebFetch(domain:gdfe.co)",
-      "Bash(sed:*)"
-    ]
+      "Bash(sed:*)",
+      "Bash(/tmp/sampsize_check.txt:*)",
+      "Read(//tmp/**)",
+      "Bash(/tmp/scaling_factor.txt:*)",
+      "Bash(Rscript -e \"devtools::test\\(\\)\" 2>&1 | tail -20)",
+      "Bash(Rscript -e \"devtools::test\\(\\)\" 2>&1 | tail -15)",
+      "Bash(Rscript -e \"devtools::check\\(\\)\" 2>&1 | tail -10)",
+      "Bash(Rscript -e 'devtools::test\\(\\)' 2>&1 | tail -30)",
+      "Bash(grep -r \"filter\\(\" /Users/jacobdennen/surveycore/tests/testthat/test-analysis-*.R | head -20)",
+      "Bash(Rscript -e 'devtools::test\\(\\)')",
+      "Bash(Rscript -e 'testthat::snapshot_accept\\(\"methods-print\"\\)' 2>&1)",
+      "Bash(grep -n \"\\\\.validate_shared_args\\(\" /Users/jacobdennen/surveycore/R/analysis-*.R)",
+      "Bash(for f:*)",
+      "Bash(Rscript -e 'devtools::document\\(\\)')",
+      "Bash(Rscript -e 'devtools::check\\(\\)')",
+      "Bash(grep -n \"^\\\\.resolve_tidy_select\\\\s*<-\" /Users/jacobdennen/surveycore/R/*.R)",
+      "Bash(Rscript -e \"devtools::check\\(\\)\" 2>&1)"
+    ],
+    "defaultMode": "bypassPermissions"
   },
   "outputStyle": "default"
 }

--- a/.claude/skills/auto-ship/SKILL.md
+++ b/.claude/skills/auto-ship/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: auto-ship
+description: >
+  Drives a surveycore implementation plan end-to-end — TDD implementation,
+  spec compliance + code quality review, changelog, commit, PR, CI monitoring,
+  and squash-merge to develop — with no manual handoffs. Analyzes the plan for
+  independent sections and dispatches them as parallel subagents; dependent
+  sections are processed in sequence. Stops only for spec ambiguity or
+  unrecoverable CI failures. Trigger when the user says "auto-ship", "ship the
+  plan", "drive the plan", "drive it", "hands-off", "do it all", or "run the
+  plan". Also trigger when the user says any of those phrases combined with a
+  plan file path, phase number, or section description.
+---
+
+# auto-ship
+
+Orchestrates a full plan execution loop. Delegates each section to a section
+subagent (`references/section-subagent.md`) that handles the complete lifecycle:
+branch → implement → review → changelog → commit → PR → CI → merge.
+
+---
+
+## Entry Check
+
+```bash
+git branch --show-current
+```
+
+Must be on `develop`. If on `main` or any feature branch: stop and tell the user.
+
+---
+
+## Step 1: Read the Plan
+
+Ask for the implementation plan path if not provided. Read it. Extract all
+unchecked `- [ ]` sections. For each, record:
+- Branch name (e.g., `feature/foo` from the `- [ ] PR N:` line)
+- One-line description
+- Any explicit dependency markers in the text (`"requires PR N"`,
+  `"depends on"`, `"after PR N"`)
+
+If all sections are `[x]`: report "Plan complete — nothing to ship." and stop.
+
+---
+
+## Step 2: Baseline Check
+
+```r
+devtools::test()
+devtools::check()
+```
+
+Both must pass before dispatching any subagent. If either fails: stop and
+report the failure. Do not proceed.
+
+---
+
+## Step 3: Build Execution Order
+
+Group the unchecked sections into **batches** using topological sort:
+
+1. **Batch 1** — all sections with no dependencies on other unchecked sections
+2. **Batch 2** — sections whose only dependencies are fully in Batch 1
+3. Continue until all sections are placed
+
+Sections with no dependency markers are assumed independent.
+
+**Parallel safety check** — before placing two sections in the same batch,
+verify they don't both modify the same shared files. A section will modify a
+shared file if its spec or plan text mentions:
+- New error or warning classes → modifies `plans/error-messages.md`
+- New exported functions → modifies `_pkgdown.yml`
+
+If two sections in the same batch would both modify the same shared file, move
+the one with fewer dependencies to the next batch. Err on the side of
+sequential — a false "conflict" costs one extra round; a false "safe" causes
+a merge conflict that blocks both PRs.
+
+Report the execution plan to the user before dispatching:
+
+> "Found N unchecked sections. Execution order:
+> - Batch 1 (parallel): feature/foo, feature/bar
+> - Batch 2 (sequential): feature/baz (requires feature/foo)
+>
+> Starting Batch 1 now."
+
+---
+
+## Step 4: Dispatch Batch
+
+For each section in the current batch, spawn a **section subagent**
+(see `references/section-subagent.md`). Dispatch all sections in the batch
+simultaneously using `run_in_background: true`.
+
+Provide each subagent with:
+- Full section text (copy it; do not make the subagent re-read the file)
+- Branch name to create
+- Spec file path(s) relevant to this section (from the plan text)
+- Implementation plan file path
+- Paths to rule files: `code-style.md`, `testing-surveycore.md`,
+  `plans/error-messages.md`
+- Today's date
+
+---
+
+## Step 5: Handle Results
+
+Each subagent returns one of:
+
+| Result | Action |
+|--------|--------|
+| `COMPLETE: <pr-url>` | Mark section `[x]` in the plan on `develop`; record PR URL |
+| `BLOCKED: spec — <question>` | Ask the user the exact question; re-dispatch subagent with the answer |
+| `BLOCKED: ci-fail — <summary>` | Report to user with full details; stop this section; continue others |
+| `BLOCKED: check-fail — <summary>` | Report to user with full details; stop this section; continue others |
+
+**Marking `[x]` in the plan:** after a section returns `COMPLETE`, check out
+`develop`, pull, edit the plan file to change that section's `- [ ]` to
+`- [x]`, and commit directly to `develop`:
+
+```bash
+git checkout develop
+git pull origin develop
+# edit plan file
+git add <plan-file>
+git commit -m "chore(plan): mark feature/X complete"
+```
+
+Do NOT include the [x] mark in the feature branch commit — doing it here avoids
+merge conflicts when parallel subagents both modify the plan file.
+
+When all sections in a batch are resolved (COMPLETE or BLOCKED-and-stopped),
+advance to the next batch. Report any BLOCKED sections and continue — don't
+let one stuck section hold up independent work.
+
+---
+
+## Step 6: Advance
+
+Repeat Steps 4–5 for each remaining batch. Pull `develop` before each new
+batch starts so subagents branch from the latest state.
+
+---
+
+## Step 7: Done
+
+When all batches are resolved:
+
+> "Plan complete."
+>
+> "Merged: [list of PR URLs]"
+>
+> If any sections were BLOCKED:
+> "Blocked (needs attention): [list of section names and reasons]"
+
+---
+
+## Spec Ambiguity Protocol
+
+When a subagent returns `BLOCKED: spec — [question]`:
+
+1. Show the user the exact question, attributed to the section
+2. Wait for the answer
+3. Re-dispatch the same section subagent with the answer appended to the
+   section text
+4. The subagent resumes from pre-implementation checks, not from scratch

--- a/.claude/skills/auto-ship/references/pr-body-guide.md
+++ b/.claude/skills/auto-ship/references/pr-body-guide.md
@@ -1,0 +1,101 @@
+# PR Body Guide
+
+Every PR created by auto-ship uses this two-part format. The plain English
+section comes first because it's what a reviewer reads to decide if this PR
+is what they expected. The technical section is for audit and review.
+
+---
+
+## Section 1: Plain English (required, always first)
+
+2–4 sentences explaining what this section adds in terms any developer can
+understand — not just survey statistics experts. Focus on:
+
+- What you can now do that you couldn't before
+- What problem it solves for the end user
+- Any meaningful limitations or caveats
+
+**Good:**
+> This PR adds weighted linear regression for survey data. Before this, you
+> had to call `survey::svyglm()` directly and convert the output manually.
+> Now `survey_glm()` handles the full workflow and returns a tidy tibble with
+> coefficients, standard errors, and Wald confidence intervals.
+
+**Too vague:**
+> This PR implements Phase 2 regression functionality.
+
+**Too technical:**
+> Implements Taylor linearization variance estimation for GLM score equations
+> using the Binder (1983) sandwich estimator.
+
+---
+
+## Section 2: Technical changes
+
+Bullet list of what changed:
+
+- **New functions:** `foo()`, `bar()` (include all exported functions added)
+- **New tests:** N new test cases in `tests/testthat/test-X.R`
+- **New error classes:** `surveycore_error_X`, `surveycore_warning_Y`
+  (omit this line if no new error classes)
+- **Modified files:** list every R and test file changed
+- **Plan section:** `feature/branch-name` — section N from `plans/impl-X.md`
+
+---
+
+## Section 3: Spec coverage
+
+Copy the relevant section header and bullet points from the spec. Mark each
+as checked. This lets reviewers verify completeness without reading the spec.
+
+```
+**From `plans/spec-X.md §N.Title`:**
+- [x] behavior 1
+- [x] behavior 2
+- [x] error condition A — `surveycore_error_X`
+```
+
+If the spec section is long, include only the items that have corresponding
+code changes in this PR.
+
+---
+
+## Section 4: Test results
+
+```
+`devtools::test()`: N tests, 0 failures
+`devtools::check()`: 0 errors, 0 warnings, N notes
+```
+
+---
+
+## Full template
+
+```markdown
+## What this does
+
+[2–4 sentence plain English description]
+
+## Technical changes
+
+- **New functions:** ...
+- **New tests:** N new test cases
+- **New error classes:** ... *(omit if none)*
+- **Modified files:** ...
+- **Plan section:** `feature/X` — section N from `plans/impl-X.md`
+
+## Spec coverage
+
+**From `plans/spec-X.md §N.Title`:**
+- [x] ...
+- [x] ...
+
+## Test results
+
+`devtools::test()`: N tests, 0 failures
+`devtools::check()`: 0 errors, 0 warnings, N notes
+
+---
+
+🤖 Generated with [Claude Code](https://claude.ai/claude-code)
+```

--- a/.claude/skills/auto-ship/references/section-subagent.md
+++ b/.claude/skills/auto-ship/references/section-subagent.md
@@ -1,0 +1,256 @@
+# Section Subagent
+
+You are the implementation agent for **one section** of a surveycore
+implementation plan. You own the complete lifecycle for that section:
+
+```
+branch → implement → review → changelog → commit → PR → CI → merge
+```
+
+You will be given the full section text, branch name, spec path(s), and plan
+file path. You may also receive a user clarification if this is a re-dispatch
+after a spec ambiguity.
+
+**Return exactly one of these status codes when you finish:**
+
+| Code | Meaning |
+|------|---------|
+| `COMPLETE: <pr-url>` | Section is merged to develop |
+| `BLOCKED: spec — <question>` | Spec has an ambiguity; needs user input before proceeding |
+| `BLOCKED: ci-fail — <summary>` | CI failed after 3 fix attempts; include the full error |
+| `BLOCKED: check-fail — <summary>` | devtools::check() fails locally after 3 attempts |
+
+---
+
+## Phase 1: Branch
+
+```bash
+git checkout develop
+git pull origin develop
+git checkout -b <branch-name>
+```
+
+---
+
+## Phase 2: Spec Check
+
+Read the spec section(s) provided. Verify before writing a single line of code:
+
+- Every function's behavior is fully specified (inputs, outputs, errors)
+- All error conditions exist in `plans/error-messages.md`
+- All argument types and defaults are defined
+- All edge cases are explicitly handled
+
+**If anything is ambiguous or underspecified:**
+
+Return immediately: `BLOCKED: spec — [describe exactly what is unclear and
+what decision needs to be made]`
+
+Do NOT guess. Do NOT assume and proceed. An incorrect assumption here means
+the wrong code gets merged.
+
+---
+
+## Phase 3: Update `plans/error-messages.md`
+
+If the spec defines new error or warning classes, add them to
+`plans/error-messages.md` **before** writing any code that uses them.
+
+---
+
+## Phase 4: TDD Implementation
+
+```
+NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST
+```
+
+1. Write the test file (all test categories from the spec: happy path, error
+   paths, edge cases)
+2. Run `devtools::test()` — **confirm all new tests fail** (red phase)
+   - If a new test unexpectedly passes before any source is written, stop and
+     investigate before proceeding
+3. Write the R source to make the tests pass
+4. Run `devtools::document()` if any roxygen2 tags changed
+5. Update `_pkgdown.yml` if any new functions were exported — match the
+   `@family` tag used in roxygen
+
+---
+
+## Phase 5: Verify
+
+```r
+devtools::test()
+devtools::check()
+```
+
+Required results: `devtools::test()` — no failures; `devtools::check()` —
+0 errors, 0 warnings, ≤2 notes.
+
+After **3 failed attempts on the same failure**, stop:
+Return `BLOCKED: check-fail — [exact error output and what was tried]`
+
+---
+
+## Phase 6: Two-Stage Review
+
+Run these checks yourself before proceeding. Fix anything that fails, then
+re-run `devtools::test()` + `devtools::check()`.
+
+### Spec compliance
+
+- [ ] Every function signature matches the spec's argument table
+- [ ] Every error class from the spec's error table fires in the code
+- [ ] Every output column matches the output contract
+- [ ] No behavior added beyond what the spec describes
+
+### Code quality
+
+- [ ] No `UseMethod()` on S7 objects — uses `S7::S7_inherits()` instead
+- [ ] `class=` on every `cli_abort()` and `cli_warn()` call
+- [ ] No `@importFrom` anywhere — all external calls use `::`
+- [ ] `test_invariants(design)` is the first assertion in every constructor
+      test block
+- [ ] Dual pattern (`class=` + snapshot) on all Layer 3 errors
+
+---
+
+## Phase 7: Changelog Entry
+
+Read `.claude/skills/changelog-workflow.md` for the canonical format.
+
+Create `changelog/phase-{X}/{branch-name}.md`. Derive the Changes bullets
+from `git log develop..HEAD --oneline`. Phase number comes from the branch
+name or plan context.
+
+---
+
+## Phase 8: Commit
+
+Stage **specific files by name** — never `git add -A` or `git add .`.
+
+Always include:
+- New/modified R source files
+- New/modified test files
+- `plans/error-messages.md` (if modified)
+- `_pkgdown.yml` (if modified)
+- `changelog/phase-{X}/{branch-name}.md`
+
+Do NOT include the implementation plan file — the orchestrator marks `[x]`
+on develop after the merge.
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(scope): short description
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+Conventional Commit types: `feat`, `fix`, `docs`, `test`, `chore`, `refactor`.
+Scopes: `classes`, `constructors`, `metadata`, `validators`, `variance`,
+`analysis`, `utils`.
+
+---
+
+## Phase 9: Push
+
+```bash
+git push -u origin <branch-name>
+```
+
+---
+
+## Phase 10: Create PR
+
+Read `references/pr-body-guide.md` for the body format. Auto-create — no
+approval gate needed.
+
+```bash
+gh pr create \
+  --base develop \
+  --title "<conventional-commit-title>" \
+  --body "$(cat <<'EOF'
+<body from pr-body-guide.md>
+EOF
+)"
+```
+
+Capture the PR number and URL for use in CI monitoring and the final return.
+
+---
+
+## Phase 11: Monitor CI
+
+```bash
+# Wait for run to appear (may take ~15s after push)
+gh run list --branch <branch-name> --limit 3
+
+# Watch until completion
+gh run watch <run-id> --exit-status > /dev/null 2>&1
+echo "CI exit: $?"
+```
+
+**If CI passes:** proceed to rebase check (Phase 12).
+
+**If CI fails:** enter the CI fix loop (see below). After 3 failed attempts:
+Return `BLOCKED: ci-fail — [paste the last 40 lines from gh run view <run-id> --log-failed]`
+
+---
+
+## CI Fix Loop (max 3 total attempts)
+
+1. Diagnose the failure:
+   ```bash
+   gh run view <run-id> --log-failed 2>&1 | tail -40
+   ```
+2. Reproduce locally: `devtools::test()` and/or `devtools::check()`
+3. Fix the issue in source or test files
+4. Verify locally — both checks must pass before pushing
+5. Commit the fix (**new commit, never amend**):
+   ```bash
+   git commit -m "fix(scope): address CI failure — <brief reason>"
+   ```
+6. Push: `git push origin <branch-name>`
+7. Wait for the new CI run to appear and complete
+8. If it passes: proceed to Phase 12. If it fails: repeat (up to 3 total).
+
+---
+
+## Phase 12: Rebase Check
+
+Before merging, ensure the branch is up to date with develop (another section
+may have merged while CI was running):
+
+```bash
+git fetch origin develop
+BEHIND=$(git log HEAD..origin/develop --oneline | wc -l | tr -d ' ')
+```
+
+If `BEHIND > 0`:
+
+```bash
+git rebase origin/develop
+git push --force-with-lease origin <branch-name>
+```
+
+Then wait for CI to complete again on the rebased push before merging.
+
+If rebase conflicts occur: resolve them, then `git rebase --continue`.
+
+---
+
+## Phase 13: Merge
+
+```bash
+gh pr merge <pr-number> --squash --delete-branch
+```
+
+Switch back to develop:
+
+```bash
+git checkout develop
+git pull origin develop
+```
+
+Return: `COMPLETE: <pr-url>`

--- a/.claude/skills/implementation-workflow/SKILL.md
+++ b/.claude/skills/implementation-workflow/SKILL.md
@@ -7,7 +7,8 @@ description: >
   "draft the plan", "review the plan", "resolve plan issues", or "implementation
   plan". Always runs after spec-workflow is complete. Has three stages: Stage 1
   (draft plan), Stage 2 (adversarial review), Stage 3 (resolve + decisions log).
-  After the plan is approved, hand off to /r-implement.
+  After the plan is approved, hand off to /r-implement (section-by-section
+  with manual oversight) or /auto-ship (fully autonomous end-to-end execution).
 ---
 
 # Surveyverse Implementation Workflow
@@ -21,7 +22,10 @@ packages). Three stages, always in order:
 2. **Stage 2 — Review:** Adversarial batch pass; saves all issues to a file
 3. **Stage 3 — Resolve:** Interactively work through issues and log decisions
 
-After the plan is approved, hand off to `/r-implement`.
+After the plan is approved, hand off to:
+- `/r-implement` — section-by-section with manual oversight between sections
+- `/auto-ship` — fully autonomous: implements, commits, PRs, monitors CI, and
+  merges each section without manual handoffs
 
 ```dot
 digraph impl_stages {
@@ -29,7 +33,7 @@ digraph impl_stages {
     S1 [label="Stage 1\nDraft Plan", shape=box];
     S2 [label="Stage 2\nAdversarial Review", shape=box];
     S3 [label="Stage 3\nResolve + Log", shape=box];
-    done [label="→ /r-implement", shape=doublecircle];
+    done [label="→ /r-implement\nor /auto-ship", shape=doublecircle];
 
     S1 -> S2;
     S2 -> S3 [label="issues found"];
@@ -40,9 +44,10 @@ digraph impl_stages {
 ```
 
 <HARD-GATE>
-Do not hand off to `/r-implement` until Stage 3 is complete, all issues in
-`plans/plan-review-{id}.md` are resolved, and `plans/decisions-{id}.md` is
-populated. No implementation begins until the plan is fully approved.
+Do not hand off to `/r-implement` or `/auto-ship` until Stage 3 is complete,
+all issues in `plans/plan-review-{id}.md` are resolved, and
+`plans/decisions-{id}.md` is populated. No implementation begins until the
+plan is fully approved.
 </HARD-GATE>
 
 ---

--- a/.claude/skills/merge-main/SKILL.md
+++ b/.claude/skills/merge-main/SKILL.md
@@ -56,6 +56,11 @@ git status
 
 **If not on `develop`: STOP.** Tell the user to `git checkout develop` first.
 
+**Check GitHub merge settings:** The repo must have "Allow merge commits" enabled
+(GitHub → Settings → General → Pull Requests). Both squash and regular merge can be
+active simultaneously. If only squash is enabled, the `--merge` flag in Step 8 will
+fail — ask the user to enable merge commits before proceeding.
+
 **If working tree is not clean:** report what's uncommitted. Ask the user
 whether to stash or commit the changes before proceeding.
 
@@ -261,7 +266,7 @@ Wait for confirmation. Do not merge without it.
 On confirmation:
 
 ```bash
-gh pr merge <pr-number> --squash --subject "chore(release): bump version to X.Y.Z (#N)"
+gh pr merge <pr-number> --merge
 ```
 
 Mark the CI task complete:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: surveycore
 Title: Core Survey Analysis Infrastructure
-Version: 0.6.0
+Version: 0.6.0.9000
 Authors@R:
     person(
         "Jacob", "Dennen", 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: surveycore
 Title: Core Survey Analysis Infrastructure
-Version: 0.6.0.9000
+Version: 0.6.1
 Authors@R:
     person(
         "Jacob", "Dennen", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# surveycore 0.6.1
+
+## Bug fixes
+
+* `survey_nonprob` validator now accepts zero weights when at least one positive
+  weight exists, unblocking the surveywts `adjust_nonresponse()` workflow.
+  Previously, any zero weight triggered an error. Negative weights are still
+  rejected.
+
 # surveycore 0.6.0
 
 ## Breaking changes

--- a/R/core-classes.R
+++ b/R/core-classes.R
@@ -697,15 +697,28 @@ survey_nonprob <- S7::new_class(
         )
       }
 
-      n_bad <- sum(non_na <= 0)
-      if (n_bad > 0L) {
+      # Condition 4a — reject negative weights
+      n_neg <- sum(non_na < 0)
+      if (n_neg > 0L) {
         cli::cli_abort(
           c(
-            "x" = "Weight column {.field {weights_var}} has {n_bad} non-positive value(s).",
-            "i" = "All non-NA weights must be strictly greater than 0.",
-            "v" = "Remove or replace rows where {.field {weights_var}} is 0 or negative."
+            "x" = "Weight column {.field {weights_var}} has {n_neg} negative value(s).",
+            "i" = "All non-NA weights must be non-negative (>= 0).",
+            "v" = "Remove or replace rows where {.field {weights_var}} is negative."
           ),
-          class = "surveycore_error_weights_nonpositive"
+          class = "surveycore_error_weights_negative"
+        )
+      }
+
+      # Condition 4b — reject all-zero weights (no positive values)
+      if (!any(non_na > 0)) {
+        cli::cli_abort(
+          c(
+            "x" = "Weight column {.field {weights_var}} has no positive values.",
+            "i" = "At least one non-NA weight must be greater than 0.",
+            "v" = "Check that {.field {weights_var}} contains valid survey weights."
+          ),
+          class = "surveycore_error_weights_all_zero"
         )
       }
     }

--- a/changelog/prereq-surveyweights/nonprob-zero-weights.md
+++ b/changelog/prereq-surveyweights/nonprob-zero-weights.md
@@ -1,0 +1,25 @@
+# Changelog: Relax `survey_nonprob` Validator -- Zero Weights
+
+**Branch:** `feature/nonprob-zero-weights`
+**Date:** 2026-03-18
+
+## Summary
+
+Split the `survey_nonprob` validator condition 4 into two checks: condition 4a
+rejects negative weights (new class `surveycore_error_weights_negative`) and
+condition 4b rejects all-zero weights (reuses `surveycore_error_weights_all_zero`).
+Zero weights are now accepted when at least one positive weight exists, unblocking
+the surveywts `adjust_nonresponse()` workflow.
+
+## Files changed
+
+- `R/core-classes.R` -- Split condition 4 into 4a (negative) and 4b (all-zero)
+- `tests/testthat/test-s7-classes.R` -- Added 9 new validator tests (happy path, error paths, edge cases)
+- `tests/testthat/test-constructors.R` -- Deleted duplicate test; updated error class name
+- `tests/testthat/helper-test-data.R` -- Updated `test_invariants()` nonprob branch: `>= 0` with `any > 0`
+- `plans/error-messages.md` -- Added row 101; updated rows 10 and 33
+
+## Check results
+
+- `devtools::test()`: 7581 tests, 0 failures
+- `devtools::check()`: 0 errors, 0 warnings, 2 notes (pre-approved)

--- a/plans/decisions-get-diffs.md
+++ b/plans/decisions-get-diffs.md
@@ -1,0 +1,257 @@
+# Decisions Log — surveycore get-diffs
+
+This file records planning decisions made during get-diffs.
+Each entry corresponds to one planning session.
+
+---
+
+## 2026-03-16 — Methodology lock: get_diffs() estimation paths, inference, and output
+
+### Context
+
+Resolved 7 judgment calls from the methodology review (24 issues total).
+Decisions covered: p-value distribution consistency, column label strategy,
+domain filtering counts, AME scale choice, p-value adjustment scope,
+domain+groups interaction, and unweighted n documentation.
+
+### Questions & Decisions
+
+**Q: Issue 9 — Should p-values use t-distribution (clean path) or
+Z-distribution (marginaleffects path)?**
+- Options considered:
+  - **[A] Document inconsistency:** Add `.meta$pvalue_distribution` key, warn on marginaleffects path.
+  - **[B] Force design-based df on marginaleffects:** Pass `df` argument to `avg_slopes()` / `avg_predictions()`.
+  - **[C] Do nothing:** Silent inconsistency.
+- **Decision:** [B] — Force design-based df on all marginaleffects calls.
+- **Rationale:** Full t-distribution consistency across both paths. `marginaleffects` supports the `df` argument (v0.18.0+). Users get identical inference regardless of which internal path is triggered.
+
+**Q: Issue 11 — Should column labels differentiate by estimation path
+(coefficient vs AME)?**
+- Options considered:
+  - **[A] Dynamic labels:** "Difference relative to {ref}" vs "Avg. Marginal Effect vs {ref}".
+  - **[B] Metadata only:** Generic labels + `.meta$estimate_scale`.
+  - **[C] Do nothing.**
+- **Decision:** Hybrid — generic label ("Difference relative to {ref}") for all paths + `.meta$estimate_scale` key.
+- **Rationale:** "Avg. Marginal Effect" is jargon that non-researchers won't understand. "Difference" is accurate for both paths. `.meta$estimate_scale` serves programmatic consumers.
+
+**Q: Issue 16 — Should `n` count in-domain rows only or all rows when domain
+filtering is active?**
+- Options considered:
+  - **[A] In-domain only:** Count rows where `..surveycore_domain.. == TRUE`.
+  - **[B] Both counts:** Total n + `.meta$n_domain`.
+  - **[C] Do nothing.**
+- **Decision:** [A] — In-domain counts only.
+- **Rationale:** `n` should reflect the observations actually used for inference. Consistent with SE and p-value computation.
+
+**Q: Issue 19 — Should non-gaussian families report AMEs (response scale) or
+coefficients (link scale)?**
+- Options considered:
+  - **[A] Document AME as default:** Explain rationale in docs.
+  - **[B] Add `scale` argument:** `"ame"` (default) or `"link"`.
+  - **[C] Do nothing.**
+- **Decision:** Both [A] and [B] — add `scale = c("ame", "link")` argument with AME as default, document the rationale and the deviation from `survey` package convention.
+- **Rationale:** AMEs are more interpretable for non-technical audiences (Gomila 2021). `scale = "link"` available for academic reporting needs. `exponentiate` argument deferred as a separate future enhancement.
+
+**Q: Issue 20 — When `group` is active, should p-value adjustment apply
+within each group or globally?**
+- Options considered:
+  - **[A] Within-group:** Each group's comparisons adjusted independently.
+  - **[B] Global:** All comparison rows pooled across groups.
+  - **[C] Do nothing.**
+- **Decision:** [A] — Within-group adjustment.
+- **Rationale:** Standard for exploratory subgroup analysis in survey research (Alosh et al. 2014). Each subgroup is a separate research question. Documented that users wanting global adjustment can apply `p.adjust()` manually.
+
+**Q: Issue 18 — Should spec clarify domain + @groups interaction?**
+- Options considered:
+  - **[A] Add clarification.**
+  - **[C] Do nothing.**
+- **Decision:** [A] — Added clarifying sentence.
+- **Rationale:** Low cost, prevents ambiguity about uniform domain filter application across group strata.
+
+**Q: Issue 24 — Should spec document that `n` is unweighted and for QA?**
+- Options considered:
+  - **[A] Document only.**
+  - **[B] Add `n_eff` column.**
+  - **[C] Do nothing.**
+- **Decision:** [A] — Document that `n` is unweighted for QA/small-cell detection; inference uses weighted data.
+- **Rationale:** `n_eff` adds a column most users won't need. Documentation prevents misinterpretation without adding output complexity.
+
+### Outcome
+
+Spec updated to v1.1. All 24 methodology review issues resolved (17
+unambiguous fixes applied, 7 judgment calls decided). Methodology locked.
+
+---
+
+## 2026-03-17 — Code review resolution: API consistency, DRY, and link-scale semantics
+
+### Context
+
+Resolved 14 issues from the Stage 3 code/architecture review (0 blocking,
+9 required, 5 suggestions). Decisions covered: Phase 1 API uniformity
+(name_style, label_values, label_vars, min_cell_n, n_weighted), DRY
+violations (error classes, meta construction), correctness (df computation),
+link-scale output semantics, and test plan gaps.
+
+### Questions & Decisions
+
+**Q: Issue 8 — What should `mean` and `pct_change` show when
+`scale = "link"` + non-gaussian family?**
+- Options considered:
+  - **[A] Conditional labels:** Show link-scale means with label "Mean (link scale)"; suppress `pct_change`.
+  - **[B] Force marginaleffects:** Route all non-gaussian through marginaleffects regardless of scale.
+  - **[D] Suppress both columns:** Omit `mean` and `pct_change` entirely when link + non-gaussian.
+- **Decision:** [D] — Suppress `mean` and `pct_change` when `scale = "link"` and family is non-gaussian. Reference row still appears with `estimate = 0`.
+- **Rationale:** The `mean` column exists to provide contextual understanding ("agreement went from 40% to 55%"). Link-scale means (e.g., log-odds of -0.85) do not serve this purpose. Users choosing `scale = "link"` are technical users who want raw coefficients and do not need the contextual scaffolding. `pct_change` as a ratio of link-scale values is statistically meaningless.
+
+**Q: Issue 10 — Should `label_values` and `label_vars` be included?**
+- Options considered:
+  - **[A] Add min_cell_n only:** Other three omitted as no-ops.
+  - **[B] Add all four:** Full API uniformity.
+- **Decision:** [B] — Add all four (`min_cell_n`, `n_weighted`, `label_values`, `label_vars`).
+- **Rationale:** `label_values` is NOT a no-op for `get_diffs()` — the `treats` and `group` columns contain categorical values with metadata labels. `label_values = TRUE` (default) shows "Control", "Message A"; `label_values = FALSE` shows raw codes. This is meaningful behavior, not a uniformity shim.
+
+### Outcome
+
+Spec updated to v1.2. All 14 code review issues resolved (all accepted
+recommended option or a new option D for Issue 8). Spec is approved for
+implementation.
+
+---
+
+## 2026-03-17 — Code review Pass 2 resolution: survey_srs removal, broom collision, labeling, edge cases
+
+### Context
+
+Resolved 7 issues from the Stage 3 Pass 2 code review (2 blocking, 3 required,
+2 suggestions). Issues arose from the `survey_srs` class removal, a broom
+naming collision unique to `get_diffs()`, unspecified labeling mechanisms, and
+edge case documentation gaps.
+
+### Questions & Decisions
+
+**Q: Issue 15 — `survey_srs` listed as supported but removed from codebase?**
+- Options considered:
+  - **[A] Remove references:** Remove `survey_srs` from Section I table and `"srs"` from Section IV `design_type`.
+  - **[C] Do nothing.**
+- **Decision:** [A] — Remove all `survey_srs` references.
+- **Rationale:** Spec must match the codebase. SRS designs are now `survey_taylor` objects.
+
+**Q: Issue 16 — `name_style = "broom"` creates duplicate `estimate` columns?**
+- Options considered:
+  - **[A] Exclude `mean` from broom rename:** Skip `mean` in `.apply_name_style()` when `estimate` already present.
+  - **[B] Rename `mean` to `fitted_mean`:** Structural API change.
+  - **[C] Do nothing.**
+- **Decision:** [A] — Exclude `mean` from broom renaming.
+- **Rationale:** The `mean` column in `get_diffs()` is contextual (treatment-level mean), not the point estimate. `estimate` already holds the point estimate in broom convention. Phase 1 functions never have both columns simultaneously, so `.apply_name_style()` was never designed for this case. The fix is isolated and non-breaking.
+
+**Q: Issue 17 — `treats` column labeling mechanism unspecified?**
+- Options considered:
+  - **[A] Apply `.apply_group_labels()` post-assembly:** Treat `treats` like group columns for labeling.
+  - **[B] Apply labels before GLM fit:** Changes model term names.
+  - **[C] Do nothing.**
+- **Decision:** [A] — Apply `.apply_group_labels()` post-assembly.
+- **Rationale:** Reuses existing Phase 1 infrastructure. Applying labels before GLM fit would change model term names and complicate `clean()` parsing.
+
+**Q: Issue 18 — `n_weighted` for reference row not specified?**
+- Options considered:
+  - **[A] Add to reference row contract:** Sum of weights for reference level.
+  - **[C] Do nothing.**
+- **Decision:** [A] — Add `n_weighted` to Reference Row Contract.
+- **Rationale:** Completes the contract. Consistent with Phase 1/Phase 2 patterns for observation counts on reference rows.
+
+**Q: Issue 21 — `group` with 1 unique value — singular matrix or degenerate?**
+- Options considered:
+  - **[A] Fix test expectation:** Update edge case to expect `surveycore_error_singular_model_matrix`.
+  - **[B] Detect and drop interaction:** Fall back to no-group case with warning.
+  - **[C] Do nothing.**
+- **Decision:** [A] — Fix the test expectation.
+- **Rationale:** The error already exists in `survey_glm()`. Option B is a nice enhancement but adds complexity; can be a follow-up.
+
+### Outcome
+
+Spec updated to v1.3. All 7 Pass 2 issues resolved (2 blocking, 3 required,
+2 suggestions). Spec is approved for implementation.
+
+---
+
+## 2026-03-17 — Code review Pass 3 resolution: marginaleffects type arg, variance restriction, execution flow
+
+### Context
+
+Resolved 7 issues from the Stage 3 Pass 3 code review (1 blocking, 4 required,
+2 suggestions). Primary finding: `avg_slopes()` missing `type = "link"` when
+`scale = "link"` on the marginaleffects path, causing response-scale AMEs to be
+silently mislabeled as link-scale coefficients.
+
+### Questions & Decisions
+
+**Q: Issue 22 — `avg_slopes()` returns response-scale AMEs when user requests
+`scale = "link"` via marginaleffects path?**
+- Options considered:
+  - **[A] Add `type` argument:** Pass `type = "link"` or `"response"` based on `scale`.
+  - **[B] Disallow `scale = "link"` with covariates/groups:** Simpler but reduces functionality.
+  - **[C] Do nothing.**
+- **Decision:** [A] — Add `type` argument to all `avg_slopes()` and `avg_predictions()` calls.
+- **Rationale:** Maintains full functionality. Technical users who chose `scale = "link"` (per Issue 19 decision) should get link-scale coefficients regardless of whether covariates/groups force the marginaleffects path. One-line change per call site.
+
+**Q: Issue 23 — `.validate_shared_args()` accepts all 6 variance types but
+`get_diffs()` only supports `"se"` and `"ci"`?**
+- Options considered:
+  - **[A] Restrict valid set:** Pass `valid_variance = c("se", "ci")`.
+  - **[B] Expand support:** Compute var/cv/moe from SE.
+  - **[C] Do nothing.**
+- **Decision:** [A] — Restrict the valid set.
+- **Rationale:** SEs and CIs come from `clean()` or marginaleffects — the Phase 1 variance types are not computed. Expansion can be a follow-up if needed.
+
+### Outcome
+
+Spec updated to v1.4. All 7 Pass 3 issues resolved (1 blocking, 4 required,
+2 suggestions — 1 suggestion already resolved in prior pass). Spec is approved
+for implementation.
+
+---
+
+## 2026-03-17 — Implementation plan review resolution: task granularity, test coverage, registration pattern
+
+### Context
+
+Resolved 13 issues from the adversarial plan review (1 blocking, 5 required,
+6 suggestions, 1 already resolved). Issues covered: S3 method registration
+pattern, dead code in print method, coverage criteria, mega-task splitting,
+missing numerical tests, pct_change rounding test, vague assertions, test
+phase organization, skip guard hygiene, @groups integration, and n computation
+source.
+
+### Questions & Decisions
+
+**Q: Issue 1 — Should `print.survey_diffs()` use `registerS3method()` in
+zzz.R or roxygen `@method` + `@export`?**
+- Options considered:
+  - **[A]** Roxygen `@method print survey_diffs` + `@export` (matching `print.survey_result()` pattern).
+  - **[B]** `registerS3method()` in `zzz.R`.
+- **Decision:** [A] — Use roxygen registration.
+- **Rationale:** `survey_diffs` is a plain S3 class, not S7. `zzz.R` dynamic registration is only needed for S7 namespaced classes (e.g., `"surveycore::survey_glm_fit"`). Consistency with existing `print.survey_result()`.
+
+**Q: Issue 2 — Should the print method map include `"nonprob"` as a display
+name?**
+- Options considered:
+  - **[A]** Remove — `.build_meta()` never produces `"nonprob"`.
+  - **[B]** Keep as defensive code.
+- **Decision:** [A] — Remove dead entry. Future `.build_meta()` rename tracked in `plans/future/rename-nonprob-design-type.md`.
+- **Rationale:** Map should match what `.build_meta()` actually produces. If the mapping changes, update both at the same time.
+
+**Q: Issue 13 — Should `clean()` be called with `n = TRUE`, or should `n`
+always be computed separately from `design@data`?**
+- Options considered:
+  - **[A]** Always compute `n` from `design@data` (one path).
+  - **[B]** Use `clean()`'s `n_obs` for non-domain, separate for domain.
+- **Decision:** [A] — One `n` computation path.
+- **Rationale:** DRY. Avoids conditional logic. Domain-aware counting from `design@data` is correct in all cases.
+
+### Outcome
+
+Implementation plan updated with all 13 fixes. Plan is approved for
+implementation starting with PR 1 (`feature/diffs-infrastructure`).
+
+---

--- a/plans/decisions-nonprob-zero-weights.md
+++ b/plans/decisions-nonprob-zero-weights.md
@@ -1,0 +1,135 @@
+# Decisions Log — surveycore nonprob-zero-weights
+
+This file records planning decisions made during nonprob-zero-weights.
+Each entry corresponds to one planning session.
+
+---
+
+## 2026-03-18 — Code review resolution (Stage 4)
+
+### Context
+
+Resolved 10 issues from the adversarial code review of the
+`nonprob-zero-weights` spec (2 blocking, 3 required, 5 suggestions).
+
+### Questions & Decisions
+
+**Q: Should happy-path tests use the raw `survey_nonprob()` constructor or the
+real workflow (`as_survey_nonprob()` + `@data<-` assignment)?**
+- Options considered:
+  - **Option A:** Workflow tests use `as_survey_nonprob()` then mutate weights
+    to zero via `@data<-`; error-path tests use raw constructor with full
+    `variables` list.
+  - **Option B:** All tests use raw constructor with complete `variables` list.
+- **Decision:** Option A — two test categories: workflow tests (real path) and
+  validator tests (raw constructor for Layer 1 coverage).
+- **Rationale:** The entire feature exists so surveywts can assign zero weights
+  via `@data<-`. Testing the workflow path is the most important validation.
+  Raw constructor tests complement by proving validator logic in isolation.
+
+**Q: Should the spec include an explicit action table for existing tests?**
+- Options considered:
+  - **Option A:** Table listing each existing test, its layer (1 or 3), and
+    required action (update/unchanged/delete).
+  - **Option B:** Keep the prose description ("tests with negative inputs
+    should change class").
+- **Decision:** Option A — explicit table with line numbers and actions.
+- **Rationale:** The Layer 1 vs Layer 3 distinction is subtle. Line 1672
+  (`as_survey_nonprob()`, Layer 3) must remain unchanged because
+  `.validate_weights()` still rejects zeros. Line 1835 (`survey_nonprob()`,
+  Layer 1) must change class. A table prevents the implementer from updating
+  the wrong tests.
+
+**Q: Should the `test_invariants()` change be scoped explicitly?**
+- Options considered:
+  - **Option A:** Add note: "Update only the `survey_nonprob` branch (~line 287);
+    main branch (~line 359) retains `> 0`."
+  - **Option B:** Let implementer infer from code.
+- **Decision:** Option A — explicit scoping.
+- **Rationale:** `test_invariants()` has two separate weight-check branches
+  separated by an early return. Updating the wrong branch would silently allow
+  zero weights in `survey_taylor`/`survey_replicate` tests.
+
+### Outcome
+
+Spec updated to version 0.2 (approved). All blocking and required issues
+resolved with explicit scoping, full `variables` lists, workflow tests, and
+an action table for existing tests. Ready for `/implementation-workflow`.
+
+---
+
+## 2026-03-18 — Code review Pass 2 resolution (Stage 4)
+
+### Context
+
+Resolved 2 remaining suggestions from the Pass 2 code review. All 10 Pass 1
+issues had already been addressed in the spec.
+
+### Questions & Decisions
+
+**Q: Should we add an edge-case test for all-zero weights with NAs (`c(0, NA, 0)`)?**
+- Options considered:
+  - **Option A:** Add the test — covers the condition 3/4b boundary where
+    non-NA values exist but none are positive.
+  - **Option B:** Do nothing — existing tests cover the individual paths.
+- **Decision:** Option A — add the test.
+- **Rationale:** Conditions 3 and 4b share the same error class with different
+  messages. Testing the exact boundary between them is cheap insurance
+  (`engineering-preferences.md §4` — handle more edge cases, not fewer).
+
+**Q: Should the action table note a test rename at line 1835?**
+- Options considered:
+  - **Option A:** Add rename note alongside the class change.
+  - **Option B:** Let implementer infer the rename.
+- **Decision:** Option A — explicit rename note.
+- **Rationale:** Test names should describe the behavior they verify. After
+  the change, "rejects non-positive" is inaccurate since zeros are no longer
+  rejected for `survey_nonprob`.
+
+### Outcome
+
+Spec updated to version 0.3 (approved). Two suggestions resolved: added
+all-zero-with-NAs edge-case test and test rename note. Spec is fully approved
+and ready for `/implementation-workflow`.
+
+---
+
+## 2026-03-18 — Implementation plan review resolution (Stage 3)
+
+### Context
+
+Resolved 2 issues from the adversarial review of the implementation plan
+(0 blocking, 1 required, 1 suggestion).
+
+### Questions & Decisions
+
+**Q: Should B9's failure reason be corrected to reflect the dual-stage failure?**
+- Options considered:
+  - **Option A:** Correct B9 to note that the S7 validator rejects zeros on
+    `@data<-` first, then after the validator fix `test_invariants()` still
+    requires `> 0`.
+  - **Option B:** Do nothing — the test fails either way.
+- **Decision:** Option A — fix the description.
+- **Rationale:** Accurate failure reasons prepare the implementer for the
+  two-stage dependency between the validator change and `test_invariants()`.
+
+**Q: Should sections D and E be swapped to fix the TDD progression?**
+- Options considered:
+  - **Option A:** Swap D and E — update `test_invariants()` first (safe because
+    existing nonprob weights are all positive), then implement the validator
+    change so all 9 new tests go GREEN at once.
+  - **Option B:** Split D2 into D2a/D2b to document partial pass expectations.
+  - **Option C:** Do nothing — implementer discovers the issue.
+- **Decision:** Option A — swap sections D and E.
+- **Rationale:** Relaxing `test_invariants()` from `> 0` to `>= 0 && any > 0`
+  is safe to do first — all existing nonprob test data uses positive weights.
+  This gives a clean RED → GREEN progression where the validator change (now
+  section E) is the single point where all tests go green.
+
+### Outcome
+
+Implementation plan updated: B9 failure reason corrected, sections D and E
+swapped for clean TDD progression. Plan is fully approved and ready for
+implementation.
+
+---

--- a/plans/error-messages.md
+++ b/plans/error-messages.md
@@ -37,7 +37,7 @@ against the messages defined here.
 | 7 | `as_survey()` | No weights, probs, or ids (SRS) | WARN | `surveycore_warning_srs_no_weights` | `"No weights or population size provided. Treating as equal-probability SRS with unknown population size. Valid: means, proportions, correlations. Invalid: population totals."` |
 | 8 | `as_survey()` | `weights` selects 0 columns | ERROR | `surveycore_error_weights_not_found` | `"{.arg weights} matched no columns in {.arg data}"` |
 | 9 | `as_survey()` | `weights` selects >1 column | ERROR | `surveycore_error_weights_multiple` | `"{.arg weights} must select exactly one column, not {length(weights_cols)}"` |
-| 10 | `as_survey()` | `weights` all zero | ERROR | `surveycore_error_weights_all_zero` | `"All values in {.arg weights} ({.field {weights_var}}) are zero or missing — no valid weights"` |
+| 10 | `as_survey()` | `weights` all zero | ERROR | `surveycore_error_weights_all_zero` | `"All values in {.arg weights} ({.field {weights_var}}) are zero or missing — no valid weights"` Note: Also thrown by `survey_nonprob` validator condition 4b (all non-NA weights are zero, no positive values). |
 | 11 | `as_survey()` | `strata` selects 0 columns | ERROR | `surveycore_error_strata_not_found` | `"{.arg strata} matched no columns in {.arg data}"` |
 | 11b | `as_survey()` | `strata` selects >1 column | ERROR | `surveycore_error_strata_multiple` | `"{.arg strata} must select exactly one column, not {length(strata_cols)}"` |
 | 12 | `as_survey()` | `strata` resolves to 1 unique value | WARN | `surveycore_warning_single_stratum` | `"{.arg strata} ({.field {strata_var}}) has only 1 unique value — stratification has no effect"` |
@@ -62,7 +62,7 @@ against the messages defined here.
 | 30 | `set_val_labels()` | Some data values lack a label | WARN | `surveycore_warning_missing_labels` | `"Not all values of {.field {var_name}} are labeled. Unlabeled values: {.val {missing}}"` |
 | 31 | S7 validator (`survey_taylor`) | Design variable not in data | ERROR | `surveycore_error_design_var_missing` | `"Design variable(s) not found in {.arg data}: {.field {missing}}"` |
 | 32 | S7 validator (`survey_taylor`) | Weight column not numeric | ERROR | `surveycore_error_weights_not_numeric` | `"Weight column {.field {weights_var}} must be numeric, not {.cls {class(wt_col)}}"` |
-| 33 | S7 validator (`survey_taylor`) | Weight column has non-positive values | ERROR | `surveycore_error_weights_nonpositive` | `"Weight column {.field {weights_var}} has {n_bad} non-positive value(s). All non-NA weights must be > 0."` |
+| 33 | S7 validator (`survey_taylor`, `survey_replicate`) | Weight column has non-positive values | ERROR | `surveycore_error_weights_nonpositive` | `"Weight column {.field {weights_var}} has {n_bad} non-positive value(s). All non-NA weights must be > 0."` Note: No longer thrown by `survey_nonprob` validator (see row 101, `surveycore_error_weights_negative`). |
 | 34 | S7 validator (`survey_taylor`) | Design variable is a list-column | ERROR | `surveycore_error_design_var_list` | `"Design variable {.field {var}} is a list-column. Design variables must be atomic vectors."` |
 | 35 | S7 validator (all) | PSU appears in multiple strata | WARN | `surveycore_warning_psu_multi_strata` | `"Some PSUs appear in more than one stratum: {.val {head(multi_strata_psus, 5)}}. If PSUs are nested within strata, set {.code nest = TRUE}."` |
 | 36 | `update_design()` | Any design variable update | WARN | *(inform, not warn)* | `"Survey design updated. This may affect statistical validity. Updated: {.field {changed_vars}}"` |
@@ -144,6 +144,7 @@ against the messages defined here.
 | 98 | `get_diffs()` | `clean()` output missing intercept | ERROR | `surveycore_error_reference_row_not_found` | `"Reference row not found in model output. Expected exactly one intercept row."` |
 | 99 | `get_diffs()` | `show_pct_change = TRUE` and ref mean is 0 | WARN | `surveycore_warning_pct_change_zero_ref` | `"Reference group mean is 0; percentage change is undefined."` |
 | 100 | `get_diffs()` | `treats` column not a factor | WARN | `surveycore_warning_treats_coerced` | `"{.field {treats_name}} coerced to factor."` |
+| 101 | S7 validator (`survey_nonprob`) | Weight column has negative values | ERROR | `surveycore_error_weights_negative` | `"x" = "Weight column {.field {weights_var}} has {n_neg} negative value(s)."`, `"i" = "All non-NA weights must be non-negative (>= 0)."`, `"v" = "Remove or replace rows where {.field {weights_var}} is negative."` |
 
 ---
 

--- a/plans/future/rename-nonprob-design-type.md
+++ b/plans/future/rename-nonprob-design-type.md
@@ -1,0 +1,26 @@
+# Future: Rename `survey_nonprob` design_type from "calibrated" to "nonprob"
+
+**Status:** Not started
+**Scope:** Small refactor PR targeting `develop`
+
+## Problem
+
+`.build_meta()` in `R/analysis-helpers.R` maps `survey_nonprob` to
+`design_type = "calibrated"`. This is a leftover from when the class was named
+`survey_calibrated`. The class has since been renamed to `survey_nonprob`, but
+the design_type string was never updated.
+
+## What to change
+
+1. `R/analysis-helpers.R` line ~351: change `"calibrated"` to `"nonprob"`
+2. `R/analysis-meta.R` (`print.survey_diffs()` and `print.survey_result()`):
+   update display name maps to use `"nonprob" -> "Non-probability"`
+3. `R/glm-methods.R`: check for any branching on `design_type` strings
+4. Update all snapshot tests that capture `design_type = "calibrated"`
+5. Update any downstream code that branches on `design_type == "calibrated"`
+
+## Why not now
+
+This affects all six existing `get_*()` functions, their snapshots, and any
+code branching on the `"calibrated"` string. It's a cross-cutting rename that
+should be its own PR, not bundled into `get_diffs()`.

--- a/plans/impl-nonprob-zero-weights.md
+++ b/plans/impl-nonprob-zero-weights.md
@@ -1,0 +1,114 @@
+# Implementation Plan: Allow Zero Weights in `survey_nonprob`
+
+**Spec:** `plans/spec-nonprob-zero-weights.md` (v0.3, Approved)
+**Review:** `plans/spec-review-nonprob-zero-weights.md` (Pass 2 — 0 blocking, 0 required)
+**Date:** 2026-03-18
+
+---
+
+## Overview
+
+This plan delivers the three deliverables from the spec: relax the
+`survey_nonprob` S7 validator to allow zero weights (split condition 4 into
+4a/4b), update `test_invariants()` for the nonprob branch, and register the
+new `surveycore_error_weights_negative` error class. This is a single PR —
+the scope is small (one source file edit, one test helper edit, one test file
+update, one error table update) and all changes are tightly coupled.
+
+---
+
+## PR Map
+
+- [x] PR 1: `feature/nonprob-zero-weights` — Relax `survey_nonprob` validator to allow zero weights; update tests and error table
+
+---
+
+## PR 1: Relax `survey_nonprob` Validator — Zero Weights
+
+**Branch:** `feature/nonprob-zero-weights`
+**Depends on:** none
+
+### Files (in TDD order — tests first):
+
+1. `plans/error-messages.md` — Add row 101 (`surveycore_error_weights_negative`); update rows 10 and 33
+2. `tests/testthat/test-s7-classes.R` — Add new validator tests; no existing tests to modify in this file (line 748 unchanged)
+3. `tests/testthat/test-constructors.R` — Delete duplicate test at line 1797; update test at line 1835 (class + name); existing tests at lines 1672 and 1816 unchanged
+4. `R/core-classes.R` — Split condition 4 into 4a (negative → error) and 4b (all-zero → error)
+5. `tests/testthat/helper-test-data.R` — Update `test_invariants()` nonprob branch (line ~287)
+
+### Step-by-step task list
+
+#### A. Error table update
+
+- [ ] **A1.** Read `plans/error-messages.md` rows 10 and 33 to confirm current state.
+- [ ] **A2.** Update row 33: change Function column from `S7 validator (survey_taylor)` to `S7 validator (survey_taylor, survey_replicate)`. Add note: "No longer thrown by `survey_nonprob` validator (see row 101, `surveycore_error_weights_negative`)."
+- [ ] **A3.** Update row 10: add note that `surveycore_error_weights_all_zero` is also thrown by the `survey_nonprob` validator condition 4b (all non-NA weights are zero, no positive values).
+- [ ] **A4.** Add row 101: `surveycore_error_weights_negative` — thrown by `survey_nonprob` validator (condition 4a), condition: any non-NA weight is negative (< 0). Full message template per spec §V.
+
+#### B. Write failing tests (RED phase)
+
+- [ ] **B1.** In `test-s7-classes.R`, add the **workflow path** test: create via `as_survey_nonprob()` with positive weights, then mutate weights to include zeros via `@data<-`, call `test_invariants()`, assert 3 zeros. (This will fail because the current validator rejects zeros.)
+- [ ] **B2.** In `test-s7-classes.R`, add the **happy-path validator** test: raw `survey_nonprob()` with `w = c(1, 0, 0, 2, 0)` and full `variables` list. Call `test_invariants()` and assert 3 zeros. (Will fail — current validator rejects zeros.)
+- [ ] **B3.** In `test-s7-classes.R`, add the **error-path condition 4a** test: raw `survey_nonprob()` with `w = c(1, -0.5, 2)` and full `variables` list. `expect_error(class = "surveycore_error_weights_negative")`. (Will fail — current code throws `surveycore_error_weights_nonpositive`.)
+- [ ] **B4.** In `test-s7-classes.R`, add the **error-path condition 4b** test: raw `survey_nonprob()` with `w = c(0, 0, 0)` and full `variables` list. `expect_error(class = "surveycore_error_weights_all_zero")`. (Will fail — current code throws `surveycore_error_weights_nonpositive`.)
+- [ ] **B5.** In `test-s7-classes.R`, add **edge case**: single positive among zeros `w = c(0, 0, 0, 0, 0.001)`, full `variables` list. Call `test_invariants()`. (Will fail.)
+- [ ] **B6.** In `test-s7-classes.R`, add **edge case**: mix of zeros and NAs with one positive `w = c(0, NA, 1, 0)`, full `variables` list. Call `test_invariants()`. (Will fail.)
+- [ ] **B7.** In `test-s7-classes.R`, add **edge case**: mix of zeros and negatives `w = c(0, -1, 0)`, full `variables` list. `expect_error(class = "surveycore_error_weights_negative")`. (Will fail.)
+- [ ] **B8.** In `test-s7-classes.R`, add **edge case**: all-zero weights with NAs `w = c(0, NA, 0)`, full `variables` list. `expect_error(class = "surveycore_error_weights_all_zero")`. (Will fail.)
+- [ ] **B9.** In `test-s7-classes.R`, add **`test_invariants()` verification** test: create via `as_survey_nonprob()`, mutate weights to include zeros via `@data<-`, `expect_no_error(test_invariants(obj))`. (Will fail — current `survey_nonprob` validator rejects zeros on `@data<-` assignment. After E1, will continue to fail because `test_invariants()` still requires `> 0`, fixed in D1.)
+- [ ] **B10.** Run `devtools::test(filter = "s7-classes")` to confirm all new tests fail (RED). Do NOT proceed until all new tests fail as expected.
+
+#### C. Update existing tests
+
+- [ ] **C1.** In `test-constructors.R`, **delete** the duplicate test at line 1797 (`"survey_nonprob validator rejects non-numeric weight column"` — duplicate of `test-s7-classes.R` line 748).
+- [ ] **C2.** In `test-constructors.R`, **update** the test at line 1835: rename from `"survey_nonprob validator rejects non-positive weight column"` to `"survey_nonprob validator rejects negative weights"`; change `class` from `"surveycore_error_weights_nonpositive"` to `"surveycore_error_weights_negative"`. Keep input data `w = c(1, -1, 1, 1, 1)` — it has negatives, which is correct for this test.
+- [ ] **C3.** Verify these tests remain **unchanged** (do not modify):
+  - `test-constructors.R:1672` — `as_survey_nonprob() rejects non-positive weights` (Layer 3, `.validate_weights()` still rejects zeros)
+  - `test-constructors.R:1816` — `survey_nonprob validator rejects all-NA weight column` (unchanged)
+  - `test-constructors.R:1936` — `as_survey_nonprob() rejects non-numeric weight column` (unchanged)
+  - `test-s7-classes.R:748` — `survey_nonprob validator rejects non-numeric weight column` (unchanged)
+
+#### D. Update `test_invariants()` (safe relaxation — no test impact)
+
+- [ ] **D1.** In `tests/testthat/helper-test-data.R`, locate the `survey_nonprob` branch weight check at line ~287. Replace `all(wt_col[!is.na(wt_col)] > 0)` with two assertions:
+  - `all(wt_col[!is.na(wt_col)] >= 0)` — "weight column has all non-negative non-NA values"
+  - `any(wt_col[!is.na(wt_col)] > 0)` — "weight column has at least one positive non-NA value"
+- [ ] **D2.** Verify the **main branch** weight check (~line 359) is **NOT modified** — it must retain strict `> 0` for `survey_taylor`, `survey_replicate`, `survey_twophase`.
+- [ ] **D3.** Run `devtools::test(filter = "s7-classes")` and `devtools::test(filter = "constructors")` — all existing tests must still pass (relaxing `> 0` to `>= 0 && any > 0` is safe because all existing nonprob test data has positive weights).
+
+#### E. Implement validator change (GREEN phase)
+
+- [ ] **E1.** In `R/core-classes.R`, locate the `survey_nonprob` validator condition 4 (lines ~700–710). Replace the single `<= 0` check with two checks:
+  - **Condition 4a** — reject negative weights (`< 0`): `n_neg <- sum(non_na < 0)`, error class `surveycore_error_weights_negative`, message per spec §III.
+  - **Condition 4b** — reject all-zero weights (`!any(non_na > 0)`): error class `surveycore_error_weights_all_zero`, message per spec §III.
+- [ ] **E2.** Run `devtools::test(filter = "s7-classes")` to confirm all 9 new tests pass (GREEN). Run `devtools::test(filter = "constructors")` to confirm existing tests still pass (especially the unchanged ones from C3).
+
+#### F. Full test suite + quality gates
+
+- [ ] **F1.** Run `devtools::test()` — full suite. All tests must pass, including all existing `survey_taylor` and `survey_replicate` tests (which are unchanged).
+- [ ] **F2.** Run `devtools::check()` — 0 errors, 0 warnings, ≤2 pre-approved notes.
+- [ ] **F3.** Run `devtools::document()` — no roxygen changes expected, but confirm NAMESPACE and man/ are in sync.
+- [ ] **F4.** Verify 98%+ line coverage is maintained.
+
+### Acceptance criteria
+
+- [ ] `survey_nonprob` validator condition 4 split into 4a (negative) and 4b (all-zero)
+- [ ] Zero weights accepted by `survey_nonprob` validator when at least one positive weight exists
+- [ ] Negative weights rejected with `surveycore_error_weights_negative`
+- [ ] All-zero weights (no positive) rejected with `surveycore_error_weights_all_zero`
+- [ ] `survey_taylor` and `survey_replicate` validators unchanged (strict > 0)
+- [ ] `test_invariants()` updated: `>= 0` with `any > 0` for `survey_nonprob` path only
+- [ ] `plans/error-messages.md` updated with row 101 + row 10 note + row 33 update
+- [ ] All existing `survey_nonprob` weight tests updated per action table
+- [ ] New happy-path, workflow-path, and edge-case tests for zero-weight `survey_nonprob` objects
+- [ ] `R CMD check`: 0 errors, 0 warnings, ≤2 notes
+- [ ] 98%+ line coverage maintained
+- [ ] No snapshot changes needed (all new tests use `class=` only per Layer 1 convention)
+
+### Notes
+
+- **Do NOT modify `.validate_weights()` in `R/core-validators.R`.** It retains the `<= 0` check. The constructor still requires positive weights at creation time; zeros only arise from post-construction operations.
+- **Do NOT modify the `survey_taylor` or `survey_replicate` validators.** They retain strict positivity (`> 0`).
+- The `test_invariants()` main branch (~line 359 in `helper-test-data.R`) is separated from the `survey_nonprob` branch by an early `return(invisible(design))` at ~line 301. Only the nonprob branch is modified.
+- The test at `test-constructors.R:1672` (`as_survey_nonprob() rejects non-positive weights`) uses `as_survey_nonprob()` which goes through `.validate_weights()`. That validator still rejects zeros with `surveycore_error_weights_nonpositive`. This test is **unchanged**.
+- No existing snapshots are affected. New S7 validator tests use `class=` only per Layer 1 convention — no snapshot.

--- a/plans/plan-review-get-diffs.md
+++ b/plans/plan-review-get-diffs.md
@@ -1,0 +1,272 @@
+# Plan Review: get-diffs
+
+## Plan Review: get-diffs — Pass 1 (2026-03-17)
+
+### New Issues
+
+#### Section: PR Map
+
+No issues found.
+
+---
+
+#### Section: PR 1 — Diffs Infrastructure
+
+**Issue 1: `print.survey_diffs()` registration inconsistent with existing pattern**
+Severity: REQUIRED
+Violates consistency principle from `code-style.md` and existing precedent in `analysis-meta.R`.
+
+Task 6.4 registers `print.survey_diffs` via `registerS3method()` in `R/zzz.R`. But
+`survey_diffs` is a plain S3 class (class vector `c("survey_diffs", "survey_result",
+"tbl_df", "tbl", "data.frame")`) — NOT an S7 class. The existing `print.survey_result()`
+in `R/analysis-meta.R` uses roxygen `@method print survey_result` + `@export`, which
+generates `S3method(print, survey_result)` in NAMESPACE. Standard S3 dispatch works.
+
+The `registerS3method()` in `zzz.R` is only needed for S7 namespaced classes (e.g.,
+`"surveycore::survey_glm_fit"`) because their class strings contain `::`, making
+NAMESPACE `S3method()` directives impossible.
+
+Options:
+- **[A]** Use `@method print survey_diffs` + `@export` in roxygen block above the function in `R/analysis-meta.R`, matching the `print.survey_result` pattern. Remove the `zzz.R` registration task (6.4). — Effort: low, Risk: low, Impact: consistency with existing codebase
+- **[B]** Keep `registerS3method()` in `zzz.R` as the plan specifies — it works but is unnecessary for S3 classes. — Effort: none, Risk: low, Impact: inconsistent but functional
+- **[C] Do nothing** — plan works as-is, but creates a precedent of registering plain S3 methods in `zzz.R`
+
+**Recommendation: [A]** — Matches the existing `print.survey_result()` pattern exactly. `zzz.R` should only contain S7 namespaced registrations.
+
+---
+
+**Issue 2: Dead display name in `print.survey_diffs()` design type map**
+Severity: SUGGESTION
+Spec coverage: Section VIII.
+
+Task 6.3 lists `"nonprob" → "Non-probability"` in the design type display names. But
+`.build_meta()` in `R/analysis-helpers.R` (line 351) maps `survey_nonprob` to
+`design_type = "calibrated"`, never `"nonprob"`. The `"nonprob"` entry is dead code.
+
+Options:
+- **[A]** Remove `"nonprob"` from the map; keep only `"calibrated" → "Calibrated"`. — Effort: low, Risk: low, Impact: no dead code
+- **[B]** Keep both as a defensive measure in case `.build_meta()` changes later. — Effort: none, Risk: low, Impact: dead code stays
+- **[C] Do nothing** — harmless dead code but violates over-engineering principle
+
+**Recommendation: [A]** — The map should match what `.build_meta()` actually produces. If the mapping changes later, update the print method at the same time.
+
+---
+
+**Issue 3: 98%+ line coverage missing from PR 1 acceptance criteria**
+Severity: REQUIRED
+Violates `testing-standards.md` coverage target and spec Quality Gates (Section X).
+
+PR 1 acceptance criteria list specific test assertions but not the overall coverage
+requirement. The spec Quality Gates explicitly require "98%+ line coverage on
+`analysis-diffs.R` and `analysis-diffs-helpers.R`." PR 1 introduces
+`analysis-diffs-helpers.R` — its coverage should be verified.
+
+Options:
+- **[A]** Add "98%+ line coverage on `R/analysis-diffs-helpers.R`" to PR 1 acceptance criteria. — Effort: low, Risk: low, Impact: matches project standards
+- **[B] Do nothing** — coverage checked at PR 2 when all tests exist. Risk: under-tested helper ships in PR 1.
+
+**Recommendation: [A]** — PR 1 introduces a new source file; its coverage should be verified before merge.
+
+---
+
+#### Section: PR 2 — `get_diffs()` Function
+
+**Issue 4: Tasks B.18 and C.9 are mega-tasks (14+ implementation steps bundled)**
+Severity: BLOCKING
+Violates implementation-workflow task granularity: "Each task in the plan should be one action (2–5 minutes)."
+
+Task B.18 says: "Implement the clean path in `R/analysis-diffs.R` (spec Sections 3.8, 3.10–3.12, VII Steps 9–22)." That is 14 distinct implementation steps bundled into a single task. `/r-implement` processes tasks one at a time and needs clear "done" criteria for each. Similarly, C.9 bundles the entire marginaleffects path implementation.
+
+This is the most critical issue in the plan. An implementer hitting B.18 would have to implement the entire estimation pipeline, output assembly, rounding, name styling, meta attachment, column labels, and class assignment in one shot — with no checkpoints.
+
+Options:
+- **[A]** Split B.18 into ~8 sub-tasks (one per logical step group):
+  - B.18a: Call `survey_glm()` and extract estimates via `clean()` (Steps 9–11)
+  - B.18b: Compute domain-aware `n` per treatment level (Step 12)
+  - B.18c: Apply `pval_adj` for no-group case (Step 13)
+  - B.18d: Check link-scale suppression + compute `pct_change` (Steps 14–15)
+  - B.18e: Assign stars + assemble output tibble in column order (Steps 16–17)
+  - B.18f: Apply `label_values`, decimals rounding, name_style (Steps 17a–19)
+  - B.18g: Attach `.meta` via `.make_result_tibble()` (Step 20)
+  - B.18h: Attach column-level labels + set S3 class + return (Steps 21–22)
+  Split C.9 similarly into ~4 sub-tasks.
+  — Effort: medium, Risk: low, Impact: implementable in granular steps
+- **[B]** Keep as-is but add inline sub-step comments. — Effort: low, Risk: medium (implementer still has no checkpoints), Impact: slightly clearer
+- **[C] Do nothing** — `/r-implement` will struggle with a 14-step task
+
+**Recommendation: [A]** — This matches the workflow's 2–5 minute task granularity. Each sub-task has a clear "done" state (e.g., "survey_glm() called and estimates extracted" vs. "column labels attached").
+
+---
+
+**Issue 5: Three numerical oracle tests from spec missing in plan**
+Severity: REQUIRED
+Spec coverage gap: Section IX numerical tests.
+
+The spec lists 7 numerical tests; the plan (Phase F) implements only 4. Missing:
+
+1. **Poisson AME vs `survey::svyglm` + `marginaleffects`** — spec row "Poisson AME vs survey::svyglm + marginaleffects"; plan Phase F has no Poisson test.
+2. **SRS full covariance matrix verification** — spec row "SRS full covariance matrix verification"; plan has no off-diagonal vcov test.
+3. **Replicate domain convergence** — spec row "Replicate domain convergence"; plan has no tight-domain replicate stress test.
+
+Options:
+- **[A]** Add F.6 (Poisson AME), F.7 (SRS vcov off-diagonal), F.8 (replicate domain convergence) to Phase F. — Effort: low, Risk: low, Impact: full spec coverage
+- **[B]** Defer 2 and 3 (SRS vcov, replicate convergence) since they test Phase 2 infrastructure, not `get_diffs()` itself. Add only Poisson AME. — Effort: low, Risk: low, Impact: most value per effort
+- **[C] Do nothing** — 3 spec-required tests are missing
+
+**Recommendation: [A]** — The spec explicitly lists them. Add all three.
+
+---
+
+**Issue 6: Missing test for `pct_change` rounding at `decimals + 2`**
+Severity: REQUIRED
+Spec coverage gap: Section 3.12.
+
+The spec says: "`pct_change`: round to `decimals + 2` (more precision for proportions)."
+No test in the plan verifies this behavior. B.3 tests `show_pct_change = TRUE` but not
+with `decimals`. B.8 tests `decimals` but not with `show_pct_change`. The combination is
+untested, and the `decimals + 2` rule is a non-obvious implementation detail that needs
+explicit coverage.
+
+Options:
+- **[A]** Add a test (B.8a or extend B.8): `get_diffs(d, dv, treats, show_pct_change = TRUE, decimals = 2)` — assert `pct_change` is rounded to 4 places, not 2. — Effort: low, Risk: low, Impact: covers a spec requirement that's easy to get wrong
+- **[B] Do nothing** — `pct_change` rounding correctness is not verified
+
+**Recommendation: [A]** — The `decimals + 2` rule is non-obvious and needs a test.
+
+---
+
+**Issue 7: 98%+ line coverage missing from PR 2 acceptance criteria**
+Severity: REQUIRED
+Same as Issue 3 but for PR 2. The spec Quality Gates require "98%+ line coverage on
+`analysis-diffs.R`" — PR 2's acceptance criteria don't list this.
+
+Options:
+- **[A]** Add "98%+ line coverage on `R/analysis-diffs.R`" to PR 2 acceptance criteria. — Effort: low, Risk: low, Impact: matches project standards
+- **[B] Do nothing** — coverage checked implicitly via `devtools::check()` and existing CI
+
+**Recommendation: [A]** — Explicit acceptance criteria prevent ambiguity.
+
+---
+
+**Issue 8: D.3 assertion is vague ("matches nonprob pattern")**
+Severity: REQUIRED
+Unverifiable acceptance criterion (Lens 3).
+
+Task D.3 says: "Assert: `.meta$design_type` matches nonprob pattern." But `.build_meta()`
+maps `survey_nonprob` to `design_type = "calibrated"`, not `"nonprob"`. The assertion
+should say: `.meta$design_type == "calibrated"`.
+
+Options:
+- **[A]** Change D.3 assertion to: `expect_identical(meta(result)$design_type, "calibrated")`. — Effort: low, Risk: low, Impact: verifiable assertion
+- **[B] Do nothing** — implementer will figure it out, but the acceptance criterion is ambiguous
+
+**Recommendation: [A]** — Acceptance criteria must be objectively verifiable.
+
+---
+
+**Issue 9: C.5 (`scale = "link" + non-gaussian`) placed under Phase C but uses clean path**
+Severity: SUGGESTION
+Task ordering / clarity concern.
+
+Per the routing logic (spec Section 7.2), `scale = "link"` + non-gaussian + no covariates
++ no group uses the **clean path** (not marginaleffects). But C.5 is listed under "Phase C:
+Marginaleffects path", which could mislead the implementer into thinking it tests the
+marginaleffects code.
+
+C.5 is really testing link-scale suppression behavior (Section 3.2) on the clean path. The
+test should verify `.meta$estimate_method == "coefficient"` (clean path), not
+`"avg_slopes"`.
+
+Options:
+- **[A]** Move C.5 to Phase B (after B.16) and rename to "link-scale suppression on clean path". Add `.meta$estimate_method == "coefficient"` assertion. — Effort: low, Risk: low, Impact: clearer phase organization
+- **[B]** Keep in Phase C but add a note that this test exercises the clean path despite being in the marginaleffects section. Add `.meta$estimate_method == "coefficient"` assertion. — Effort: low, Risk: low, Impact: less misleading
+- **[C] Do nothing** — implementer may misunderstand which path is tested
+
+**Recommendation: [B]** — Moving across phases is more disruptive than a clarifying note. But the `.meta` assertion must be added regardless.
+
+---
+
+**Issue 10: `match.arg(scale)` not mentioned in any implementation task**
+Severity: SUGGESTION
+Completeness concern.
+
+The spec (Section 7.2) shows `scale <- match.arg(scale)` but no task in the plan
+explicitly mentions this call. It would naturally happen in B.18 (Step 10) but since
+the plan describes Steps 9–22 as a single task, the detail is lost.
+
+Options:
+- **[A]** If B.18 is split (per Issue 4), include `match.arg(scale)` in the sub-task for Step 10. — Effort: free (comes with the split), Risk: low
+- **[B] Do nothing** — `match.arg()` is idiomatic R; the implementer will know to add it
+
+**Recommendation: [A]** — Addressed naturally if Issue 4 is resolved.
+
+---
+
+**Issue 11: `skip_if_not_installed("marginaleffects")` becomes no-op after Imports move**
+Severity: SUGGESTION
+
+Phase H moves `marginaleffects` from Suggests to Imports. After this, it's always
+installed in `devtools::check()` environments. Tests gated with
+`skip_if_not_installed("marginaleffects")` will never skip — they're effectively ungated.
+This is harmless but misleading.
+
+Options:
+- **[A]** After H.1, remove `skip_if_not_installed("marginaleffects")` from all new test files. Keep `skip_if_not_installed("survey")` (still in Suggests). — Effort: low, Risk: low, Impact: honest test gating
+- **[B]** Keep the skips as defensive code. — Effort: none, Risk: low, Impact: misleading but harmless
+- **[C] Do nothing** — no functional impact
+
+**Recommendation: [A]** — Test skips should reflect reality. A skip that never fires is confusing.
+
+---
+
+**Issue 12: No explicit test for `@groups` integration**
+Severity: SUGGESTION
+Spec coverage: Section 3.15.
+
+The spec says `design@groups` (from `group_by()`) are combined with the `group` argument
+via `.resolve_groups()`. No test verifies this for `get_diffs()` specifically. The Phase 1
+functions have `@groups` tests, and `.resolve_groups()` is tested, but a direct test
+provides confidence that the wiring works end-to-end.
+
+Options:
+- **[A]** Add a test in Phase D (D.5 or similar), gated with `skip_if_not_installed("surveytidy")`: `group_by(design, group_var) |> get_diffs(dv, treats)`. Assert group column appears in output. — Effort: low, Risk: low, Impact: explicit coverage
+- **[B]** Rely on Phase 1 tests + `.resolve_groups()` unit tests. — Effort: none, Risk: low (indirect coverage)
+- **[C] Do nothing** — `@groups` integration is indirectly tested
+
+**Recommendation: [A]** — End-to-end integration test is cheap and valuable.
+
+---
+
+**Issue 13: Plan uses `clean(fit, n = TRUE)` but computes `n` separately**
+Severity: SUGGESTION
+Efficiency / clarity concern.
+
+The plan's Step 11 calls `clean(fit, ..., n = TRUE)` to get `n_obs` per factor level.
+Step 12 then separately computes domain-aware `n` per treatment level. If `n_obs` from
+`clean()` is not used (because domain-aware counting is needed in all cases), passing
+`n = TRUE` wastes computation.
+
+For the clean path without domain estimation, `clean()`'s `n_obs` equals the domain-aware
+count (no domain means all rows are in-domain). But the plan should be explicit about which
+source of `n` to use in which case.
+
+Options:
+- **[A]** Always compute `n` separately (Step 12). Call `clean(fit, n = FALSE)`. Simplifies logic — one `n` computation path for all cases. — Effort: low, Risk: low, Impact: clearer, no wasted computation
+- **[B]** Use `clean()`'s `n_obs` for non-domain cases; compute separately only when `..surveycore_domain..` exists. — Effort: low, Risk: low, Impact: matches spec Section 3.8 step 4
+- **[C] Do nothing** — minor efficiency issue; implementation will sort it out
+
+**Recommendation: [A]** — One path is simpler than conditional logic. Always computing `n` from `design@data` is the DRY approach.
+
+---
+
+## Summary (Pass 1)
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 1 |
+| REQUIRED | 5 |
+| SUGGESTION | 6 |
+
+**Total issues:** 12
+
+**Overall assessment:** The plan is well-structured with good TDD discipline and correct PR boundaries. The single blocking issue (mega-tasks B.18 and C.9) must be resolved before implementation — `/r-implement` cannot process a 14-step task as one action. The required issues are straightforward fixes: missing numerical tests, a missing rounding test, vague assertion text, and coverage criteria. Once the blocking issue is split and the required issues addressed, the plan is ready to implement.

--- a/plans/plan-review-nonprob-zero-weights.md
+++ b/plans/plan-review-nonprob-zero-weights.md
@@ -1,0 +1,108 @@
+# Plan Review: nonprob-zero-weights — Pass 1 (2026-03-18)
+
+### New Issues
+
+#### Section: PR Map
+
+No issues found. Single PR is appropriate — the scope (one source file, one test helper, two test files, one error table) is tightly coupled and too small to split.
+
+#### Section: PR 1 — Files List
+
+No issues found. All five files are listed with accurate line number references. Verified against current source:
+
+- `R/core-classes.R` lines 700–710: confirmed `<= 0` check with `surveycore_error_weights_nonpositive`
+- `tests/testthat/helper-test-data.R` line 287: confirmed `all(wt_col[!is.na(wt_col)] > 0)`
+- `tests/testthat/test-constructors.R` line 1797: confirmed duplicate of `test-s7-classes.R:748`
+- `tests/testthat/test-constructors.R` line 1835: confirmed `surveycore_error_weights_nonpositive`
+- `tests/testthat/test-constructors.R` line 1672: confirmed Layer 3 test with `as_survey_nonprob()`
+- `tests/testthat/test-s7-classes.R` line 748: confirmed existing nonprob non-numeric test
+- `plans/error-messages.md` row 33: confirmed `S7 validator (survey_taylor)` with `surveycore_error_weights_nonpositive`
+- `plans/error-messages.md` row 10: confirmed `surveycore_error_weights_all_zero`
+- `plans/error-messages.md` last row: 100 (row 101 available for new class)
+
+#### Section: A — Error Table Update
+
+No issues found. Steps A1–A4 are precise, match the spec §V exactly, and correctly assign row 101.
+
+#### Section: B — Write Failing Tests (RED Phase)
+
+**Issue 1: B9's stated failure reason is inaccurate**
+Severity: SUGGESTION
+Lens 4 (Spec Coverage — accuracy of plan description)
+
+B9 says the test "Will fail — current `test_invariants()` requires `> 0`." But the test creates an object via `as_survey_nonprob()` and then assigns zero weights via `@data<-`. The S7 validator fires on `@data<-` and rejects zeros **before** `test_invariants()` is ever reached. The stated failure reason describes what would happen after D1 (validator fixed) but before E1 (`test_invariants()` fixed) — not the actual RED-phase failure.
+
+Options:
+- **[A]** Correct B9: "Will fail — current `survey_nonprob` validator rejects zeros on `@data<-` assignment. After D1, will continue to fail because `test_invariants()` still requires `> 0` (fixed in E1)." — Effort: low, Risk: low, Impact: accurate mental model for implementer
+- **[B] Do nothing** — The test fails either way; the reason is secondary.
+
+**Recommendation: A** — The dual-stage failure is the interesting part and prepares the implementer for the D2 ordering issue (see Issue 2).
+
+---
+
+#### Section: C — Update Existing Tests
+
+No issues found. C1 (delete duplicate), C2 (update class + rename), and C3 (verify unchanged) are correctly specified. The C2 rename to `"survey_nonprob validator rejects negative weights"` correctly incorporates spec review Issue 12.
+
+#### Section: D — Implement Validator Change (GREEN Phase)
+
+**Issue 2: D2 claims all new tests pass after D1, but 5 of 9 require E1**
+Severity: REQUIRED
+Violates TDD progression accuracy
+
+D2 says: "Run `devtools::test(filter = "s7-classes")` to confirm new tests pass."
+
+After D1 (validator change), the following tests still fail because they call `test_invariants()`, which retains the strict `> 0` check until E1:
+
+| Step | Test | Post-D1 Status | Reason |
+|------|------|----------------|--------|
+| B1 | Workflow path (zero weights via `@data<-`) | FAIL | `test_invariants()` rejects zeros |
+| B2 | Happy-path validator (raw constructor with zeros) | FAIL | `test_invariants()` rejects zeros |
+| B3 | Error-path 4a (negative weights) | PASS | Error thrown before `test_invariants()` |
+| B4 | Error-path 4b (all-zero weights) | PASS | Error thrown before `test_invariants()` |
+| B5 | Edge: single positive among zeros | FAIL | `test_invariants()` rejects zeros |
+| B6 | Edge: zeros + NAs + one positive | FAIL | `test_invariants()` rejects zeros |
+| B7 | Edge: zeros + negatives | PASS | Error thrown before `test_invariants()` |
+| B8 | Edge: all-zero + NAs | PASS | Error thrown before `test_invariants()` |
+| B9 | `test_invariants()` verification | FAIL | `test_invariants()` rejects zeros |
+
+Only 4 of 9 new tests pass after D1. The remaining 5 need E1 (`test_invariants()` update) to pass. An implementer following D2 literally will see 5 unexpected failures and may incorrectly conclude the validator change is wrong.
+
+Options:
+- **[A]** Reorder: swap D and E so `test_invariants()` is updated before the validator. E1 is safe to do first — relaxing from `> 0` to `>= 0 && any > 0` doesn't break any existing tests (existing nonprob objects have all-positive weights, which satisfy both constraints). Then D2 can correctly say "all new tests pass." — Effort: low, Risk: low, Impact: clean TDD progression
+- **[B]** Split D2 into two: "D2a. Run `devtools::test(filter = "s7-classes")` — confirm error-path tests B3, B4, B7, B8 pass. Tests B1, B2, B5, B6, B9 will still fail (pending E1 — `test_invariants()` update)." Then at E3: "all 9 new tests pass (GREEN)." — Effort: low, Risk: low, Impact: accurate expectations at each step
+- **[C] Do nothing** — Implementer discovers the ordering issue and recovers.
+
+**Recommendation: A** — Reordering is the cleanest fix. `test_invariants()` relaxation is safe to apply first because it doesn't change behavior for any existing test data (all existing nonprob weights are positive). This gives a proper RED → GREEN progression where D (now the last code change) is the point where all tests go green.
+
+---
+
+#### Section: E — Update `test_invariants()` (GREEN Phase)
+
+No issues found. E1 correctly targets only the `survey_nonprob` branch (line ~287). E2 correctly protects the main branch (line ~359). The separation via `return(invisible(design))` at line 301 is accurately documented.
+
+#### Section: F — Full Test Suite + Quality Gates
+
+No issues found. F1–F4 cover the full suite, R CMD check, `devtools::document()`, and coverage. The "no roxygen changes expected" note in F3 is accurate — only the validator body changes, no roxygen blocks.
+
+#### Section: Acceptance Criteria
+
+No issues found. All 12 criteria are objectively verifiable and map 1:1 to spec §VII Quality Gates. The "No snapshot changes needed" criterion is accurate — all new tests are Layer 1 (`class=` only).
+
+#### Section: Notes
+
+No issues found. The four guardrails (don't modify `.validate_weights()`, don't modify `survey_taylor`/`survey_replicate`, `test_invariants()` branch scoping, `test-constructors.R:1672` unchanged) are critical and correctly stated.
+
+---
+
+## Summary (Pass 1)
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 0 |
+| REQUIRED | 1 |
+| SUGGESTION | 1 |
+
+**Total issues:** 2
+
+**Overall assessment:** The plan is well-structured, closely tracks the spec, and all file/line references are verified accurate against the current codebase. The one required issue is a TDD ordering problem: step D2 claims all new tests pass after the validator change, but 5 of 9 tests also depend on the `test_invariants()` update in step E1. Swapping sections D and E (updating `test_invariants()` first, then the validator) gives a clean RED → GREEN progression. Once that's resolved, the plan is ready for implementation.

--- a/plans/spec-get-diffs.md
+++ b/plans/spec-get-diffs.md
@@ -1,0 +1,988 @@
+# surveycore — `get_diffs()`: Treatment Effect Estimation
+
+**Version:** 1.5
+**Date:** March 2026
+**Status:** Approved — Stage 4 complete (methodology-locked, code-reviewed, Pass 3 resolved)
+
+---
+
+## Document Purpose
+
+This document is the authoritative specification for the `get_diffs()` function
+in the surveycore package. It defines the API contract, estimation paths, output
+structure, error conditions, and testing requirements. Implementation must follow
+these rules exactly. Where a rule is already defined in `code-style.md`,
+`r-package-conventions.md`, or `surveycore-conventions.md`, this document
+references those rules rather than restating them.
+
+**Reference documents:**
+- `SOPs/treatment_effects.md` — Standard Operating Procedures for message
+  testing analysis. `get_diffs()` is the primary implementation of this SOP.
+- `archive/phase-2/spec-phase-2.md` — Phase 2 spec; `get_diffs()` builds on
+  `survey_glm()`, `clean()`, and the marginaleffects extension interface.
+
+---
+
+## I. Scope
+
+### What This Delivers
+
+| Component | Description |
+|---|---|
+| `get_diffs()` | Exported function: treatment effect estimation via survey-weighted regression |
+| `survey_diffs` S3 class | Result tibble with column-level labels and `.meta` |
+| `print.survey_diffs()` | Custom print method: 4 header lines + tibble body (overrides `print.survey_result()`) |
+| `.stars_pval()` | Internal helper: significance star assignment |
+| `DIFFS_META_KEYS` | Constant: function-specific meta keys for `.make_result_tibble()` validation |
+
+### What This Does NOT Deliver
+
+- **Pairwise (Tukey-style) comparisons** — all-vs-all treatment comparisons are
+  a separate function (`get_pairwise()` or similar). `get_diffs()` is
+  Dunnett-style: all treatment levels compared to one reference level.
+- **Combined bivariate + multivariate output** — future feature. Currently the
+  analyst calls `get_diffs()` twice (once without covariates, once with).
+- **Multiple DVs in one call** — one DV per call. P-value adjustment across DVs
+  is the analyst's responsibility.
+- **Auto-detection of logistic threshold** — the analyst controls the family via
+  `...` (passed to `survey_glm()`). `get_diffs()` does not inspect the
+  control-group rate and switch families automatically.
+- **Column-level labels on other `get_*()` functions** — backporting column
+  labels to `get_means()`, `get_freqs()`, etc. is a separate PR.
+
+### Supported Design Classes
+
+All four surveycore design classes are supported. `get_diffs()` delegates to
+`survey_glm()`, which handles variance estimation for each design type (see
+Phase 2 spec §I). SRS designs are represented as `survey_taylor` objects
+(created via `as_survey()` with no `ids` or `strata`).
+
+| Class | Supported |
+|---|---|
+| `survey_taylor` | Yes |
+| `survey_replicate` | Yes |
+| `survey_twophase` | Yes |
+| `survey_nonprob` | Yes |
+
+### Prerequisites
+
+| Prerequisite | What `get_diffs()` Needs |
+|---|---|
+| Phase 2 complete | `survey_glm()`, `clean()`, `survey_glm_fit` S7 class |
+| Phase 2 marginaleffects extension | `avg_slopes()` and `avg_predictions()` dispatch on `survey_glm_fit` |
+| `marginaleffects` in Imports | Required for multivariate, non-gaussian, and grouped paths |
+
+---
+
+## II. Architecture
+
+### 2.1 File Organization
+
+```
+R/
+├── analysis-diffs.R              # get_diffs() exported function + inline estimation logic
+├── analysis-diffs-helpers.R      # .stars_pval()
+├── analysis-helpers.R            # DIFFS_META_KEYS (added alongside existing *_META_KEYS)
+
+tests/testthat/
+├── test-analysis-diffs.R                  # get_diffs() happy paths + error paths + edge cases
+├── test-analysis-diffs-numerical.R        # Oracle tests vs tidysurvey/manual computation
+└── test-analysis-diffs-marginaleffects.R  # avg_slopes/avg_predictions path tests
+                                           #   (gated with skip_if_not_installed)
+```
+
+### 2.2 Internal Helpers
+
+All internal helpers are not exported and prefixed with `.`, per `code-style.md §4`.
+
+#### `.stars_pval(p)`
+
+Assigns significance stars to a numeric vector of p-values.
+
+```r
+.stars_pval <- function(p) {
+  # Cutpoints: *** < 0.001, ** < 0.01, * < 0.05, . < 0.1, "" otherwise
+  # NA p-values → ""
+  # Returns: character vector same length as p
+}
+```
+
+#### Meta construction
+
+`get_diffs()` builds `meta_args` inline (matching the Phase 1 pattern in
+`get_means()`, `get_freqs()`, etc.) and passes them to `.build_meta()` via
+`.make_result_tibble()`. No separate `.build_diffs_meta()` helper is needed.
+See Section IV for the full `.meta` contract.
+
+#### `DIFFS_META_KEYS`
+
+Defined in `analysis-helpers.R` alongside the other `*_META_KEYS` constants.
+Contains the function-specific keys required in `meta_args`. Note that
+`conf_level` and `call` are **not** included here — they are common fields
+always present in `meta_args` (passed by the caller), not function-specific
+keys. The `*_META_KEYS` constants list only the keys that
+`.make_result_tibble()` validates as function-specific requirements.
+`.build_meta()` auto-injects `design_type` and `n_respondents`.
+
+```r
+DIFFS_META_KEYS <- c(
+  "group", "x", "treats", "covariates", "family", "link",
+  "pval_adj", "estimate_method", "mean_method", "estimate_scale"
+)
+```
+
+Passed to `.make_result_tibble()` for validation via
+`stopifnot(all(required_meta_keys %in% names(meta_args)))`.
+
+#### Estimation path logic
+
+The clean path (Section 3.8) and marginaleffects path (Section 3.9) are
+implemented inline in `get_diffs()`, not extracted into separate helpers.
+The logic is specific to `get_diffs()` and has no second call site.
+
+#### Column-level labels
+
+Column-level `label` attributes (Section 5.5) are attached inline in
+`get_diffs()` after assembly. This will be extracted into a shared helper
+when column labels are backported to the other `get_*()` functions (separate
+PR, listed in "What This Does NOT Deliver").
+
+---
+
+## III. `get_diffs()` — Function Specification
+
+### 3.1 Signature
+
+```r
+get_diffs <- function(
+  design,
+  x,
+  treats,
+  group       = NULL,
+  covariates  = NULL,
+  ref_level   = NULL,
+  pval_adj    = NULL,
+  show_means  = TRUE,
+  show_pct_change = FALSE,
+  scale       = c("ame", "link"),
+  variance    = "ci",
+  conf_level  = 0.95,
+  min_cell_n  = 30L,
+  n_weighted  = FALSE,
+  decimals    = NULL,
+  na.rm       = TRUE,
+  label_values = TRUE,
+  name_style  = "surveycore",
+  ...
+)
+```
+
+### 3.2 Link-Scale Suppression Rule
+
+> **When `scale = "link"` and family is non-gaussian**, the `mean` and
+> `pct_change` columns are suppressed (omitted from output entirely).
+> Link-scale means (e.g., predicted log-odds) do not serve the contextual
+> purpose of the `mean` column, and link-scale ratios are not meaningful.
+> The reference row is still included with `estimate = 0`. When `show_means
+> = TRUE`, the reference row appears without a `mean` column. This rule
+> applies uniformly across all estimation paths.
+
+All subsequent references to suppression of `mean` or `pct_change` cite
+this section rather than restating the rule.
+
+### 3.3 Argument Table
+
+| Argument | Type | Default | Description |
+|---|---|---|---|
+| `design` | `survey_base` subclass | (required) | Survey design object from `as_survey()`, `as_survey_replicate()`, etc. |
+| `x` | tidy-select (single) | (required) | Dependent variable. Must resolve to exactly one numeric column (0/1 binary or continuous). |
+| `treats` | tidy-select (single) | (required) | Treatment variable. Must resolve to exactly one column. Coerced to factor if not already. |
+| `group` | tidy-select | `NULL` | Subgroup variable(s) for interaction analysis. When provided, `get_diffs()` fits `x ~ treats * group + covariates` and reports effects by group. Combined with `@groups` if set. |
+| `covariates` | character vector | `NULL` | Additional model terms as strings. Supports interactions (`"age * gender"`), polynomials (`"poly(edu, 2)"`), and transformations (`"log(income)"`). When provided, forces the `avg_slopes()` / `avg_predictions()` estimation path. |
+| `ref_level` | character(1) | `NULL` | Reference level of `treats` for comparisons. If `NULL`, defaults to first factor level. Must match an existing level. |
+| `pval_adj` | character(1) | `NULL` | P-value adjustment method. Passed to `stats::p.adjust()`. Options: `"holm"`, `"hochberg"`, `"hommel"`, `"bonferroni"`, `"BH"`, `"BY"`, `"fdr"`, `"none"`. `NULL` = no adjustment. |
+| `show_means` | logical | `TRUE` | If `TRUE`, includes a `mean` column and a reference row with `estimate = 0` and `mean = reference_mean`. Subject to link-scale suppression (Section 3.2). |
+| `show_pct_change` | logical | `FALSE` | If `TRUE`, includes a `pct_change` column: `estimate / reference_mean`. Subject to link-scale suppression (Section 3.2). |
+| `variance` | character | `"ci"` | Which uncertainty columns to include. One or more of: `"se"`, `"ci"`. `NULL` = no uncertainty columns. |
+| `conf_level` | numeric(1) | `0.95` | Confidence level for intervals. Must be in (0, 1). |
+| `min_cell_n` | integer(1) | `30L` | Minimum unweighted cell size before `surveycore_warning_small_cell` fires. |
+| `n_weighted` | logical | `FALSE` | If `TRUE`, includes an `n_weighted` column: sum of weights for each treatment level (within group if applicable). |
+| `decimals` | integer(1) or `NULL` | `NULL` | If non-NULL, rounds all numeric output columns. |
+| `scale` | character(1) | `"ame"` | Scale for treatment effect estimates. `"ame"` (default): average marginal effects on the response scale (e.g., probability differences for logistic). `"link"`: coefficients on the link scale (e.g., log-odds for logistic). For Gaussian/identity models, both scales are identical. See Section 3.9 for rationale. |
+| `na.rm` | logical | `TRUE` | If `TRUE`, drops rows with NA in `x`, `treats`, or `group` columns before fitting. Translated to `na.action = stats::na.omit` when calling `survey_glm()`. If `FALSE`, translated to `na.action = stats::na.fail`. |
+| `label_values` | logical | `TRUE` | If `TRUE` (default), the `treats` and `group` columns display value labels from metadata (e.g., "Control", "Message A") instead of raw codes (e.g., 1, 2). When `FALSE`, raw values are used. Applied post-assembly via `.apply_group_labels()` from `analysis-helpers.R`, treating `treats` identically to group columns for labeling purposes. Output type is `factor` when labels are applied, `character` otherwise (matching Phase 1 group column behavior). |
+| `name_style` | character(1) | `"surveycore"` | Column naming convention. `"surveycore"` (default) or `"broom"`. When `"broom"`, columns are renamed via `.apply_name_style(result, "broom", exclude = "mean")`. The `mean` column is excluded because `estimate` already holds the point estimate; renaming both to `"estimate"` would create duplicate columns. See `.apply_name_style()` changes below. |
+| `...` | | | Passed to `survey_glm()`. Common uses: `family = quasibinomial()`, `control = list(maxit = 50)`. |
+
+**`.apply_name_style()` change:** Add an `exclude` parameter (default `NULL`)
+to `.apply_name_style()` in `analysis-helpers.R`. When non-NULL, columns in
+`exclude` are removed from `to_rename` before applying the broom map. This is
+backward-compatible — all existing `get_*()` call sites pass only 2 arguments
+and are unaffected. `get_diffs()` passes `exclude = "mean"`.
+
+### 3.4 Argument Order Rationale
+
+Per `code-style.md §4`: `design` (data, first) → `x`, `treats` (required NSE) →
+`group` (optional NSE) → `covariates`, `ref_level`, `pval_adj` (optional scalar,
+configuration) → `show_means`, `show_pct_change`, `variance`, `conf_level`,
+`decimals`, `na.rm` (optional scalar, formatting/control) → `...`.
+
+### 3.5 Estimation Paths
+
+`get_diffs()` determines the estimation path based on three conditions:
+
+| Condition | Path | Estimates from | Means from |
+|---|---|---|---|
+| No covariates + `gaussian()` family + no group | **Clean path** | `clean()` coefficients | Intercept from `clean()` |
+| Non-gaussian family (any config) | **Marginaleffects path** | `avg_slopes()` | `avg_predictions()` |
+| Covariates present (any family) | **Marginaleffects path** | `avg_slopes()` | `avg_predictions()` |
+| Group present (any family, any covariates) | **Marginaleffects path** | `avg_slopes(by = group)` | `avg_predictions(by = c(treats, group))` |
+
+**Family detection:** After calling `survey_glm()`, inspect `fit@family$family`.
+If it equals `"gaussian"`, the family is gaussian. All other values (including
+`"binomial"`, `"quasibinomial"`, `"poisson"`, `"Gamma"`, etc.) trigger the
+marginaleffects path.
+
+**Path recorded in `.meta`:** `.meta$estimate_method` and `.meta$mean_method`
+record which path was used (see Section IV).
+
+### 3.6 Formula Construction
+
+`get_diffs()` constructs a formula from its arguments and passes it to
+`survey_glm()`. The user never writes a formula.
+
+| Configuration | Formula built |
+|---|---|
+| No covariates, no group | `x ~ treats` |
+| Covariates, no group | `x ~ treats + cov1 + cov2 + ...` |
+| No covariates, with group | `x ~ treats * group` |
+| Covariates, with group | `x ~ treats * group + cov1 + cov2 + ...` |
+
+**Implementation:**
+
+```r
+# Build the RHS terms
+rhs_terms <- treats_name
+if (length(group_names) > 0) {
+  # Interaction: treats * group1 * group2 ...
+  rhs_terms <- paste(c(treats_name, group_names), collapse = " * ")
+}
+if (!is.null(covariates)) {
+  rhs_terms <- paste(c(rhs_terms, covariates), collapse = " + ")
+}
+formula <- stats::reformulate(rhs_terms, response = x_name)
+```
+
+Note: when `covariates` contains interaction terms (e.g., `"age * gender"`),
+`reformulate()` inserts them as formula terms correctly because R parses `*`
+inside formula expressions.
+
+**Interaction model semantics:** When `group` is provided, the formula
+includes `treats:group` interaction terms. This allows the treatment effect
+to differ by subgroup:
+
+```
+x ~ treats + group + treats:group + covariates
+dY/d(treats) = beta_treats + beta_interact * I(group = g)
+```
+
+`marginaleffects::avg_slopes(by = group)` correctly incorporates the
+interaction when computing group-specific average marginal effects. Note that
+hypothesis testing on the interaction coefficient itself (i.e., whether the
+treatment effect significantly differs across groups) requires inspecting
+`summary(fit)` directly — `get_diffs()` reports the treatment effects within
+each group, not the interaction contrast.
+
+### 3.7 Reference Level Handling
+
+1. Resolve `treats` to a character name via `rlang::as_name(rlang::ensym(treats))`.
+2. Coerce the treats column to factor if not already (using `as.factor()`; do NOT
+   drop unused levels at this stage — the user may have intentionally defined levels).
+   **Handling of unused levels:** Factor levels with zero observations after
+   `na.action` are silently omitted from the output. They produce no rows in the
+   result because `glm()` excludes them from the model matrix.
+3. If `ref_level` is `NULL`, set it to `levels(data[[treats_name]])[1]`.
+4. If `ref_level` is non-NULL, validate it exists in `levels(data[[treats_name]])`.
+   If not found, error with `surveycore_error_ref_level_not_found`.
+5. **Force treatment contrasts:** After coercion and releveling, explicitly set
+   `contrasts(design@data[[treats_name]]) <- stats::contr.treatment(nlevels(design@data[[treats_name]]))`.
+   This ensures the clean path's intercept-as-reference-mean interpretation is
+   always correct, regardless of global contrast settings (`options(contrasts = ...)`
+   or per-factor `contrasts<-()`). Without this, non-treatment contrasts (Helmert,
+   sum, etc.) silently produce wrong reference means and treatment effects.
+6. Use `stats::relevel()` to set the reference level before fitting.
+
+### 3.8 Estimation: Clean Path (Bivariate + Gaussian + No Group)
+
+This path avoids the `marginaleffects` dependency for the simplest case.
+
+1. Fit: `fit <- survey_glm(design, formula, na.action = na_action, ...)`
+2. Tidy: `tidy_result <- clean(fit, conf_level = conf_level, include_reference = TRUE, n = TRUE)`
+   The `clean()` function returns `std_error` and CI bounds computed from
+   `fit@vcov`, which is the design-based Binder sandwich variance (per Phase 2
+   spec Section VIII). Variance computation is design-class-specific — Taylor,
+   replicate, two-phase, SRS, and nonprob each use their own sandwich formula.
+3. Extract reference row (intercept): the row where `term == "(Intercept)"`.
+   **Defensive validation:** If zero or multiple rows match
+   `term == "(Intercept)"`, error with
+   `surveycore_error_reference_row_not_found`. This guards against degenerate
+   fits or unexpected `clean()` output changes.
+   - `reference_mean <- tidy_result$estimate` for this row (the intercept IS the
+     reference group mean for a factor-only model).
+
+**Coefficient = AME equivalence:** This clean path produces treatment effects
+identical to the marginaleffects path (AMEs) **only when**: (a) family is
+Gaussian with identity link, (b) the model has a single factor predictor (no
+covariates), and (c) no interactions. The routing logic (Section VII, Step 10)
+guarantees these conditions. If the routing conditions change, the clean path
+must be re-validated.
+4. Extract treatment rows: all rows where `reference_row == FALSE` and
+   `term != "(Intercept)"`. The reference level row (`reference_row == TRUE`,
+   `estimate = NA`) is discarded — it is not used in the output.
+   - `estimate` = coefficient (difference from reference mean).
+   - `mean` = `reference_mean + estimate` (the treatment group mean).
+   - `se` = `tidy_result$std_error`.
+   - `ci_low` / `ci_high` = `tidy_result$conf_low` / `tidy_result$conf_high`.
+   - `p_value` = `tidy_result$p_value`.
+   - `n` = `tidy_result$n_obs`.
+5. Build the reference row (when `show_means = TRUE`):
+   - `{treats_name}` = ref_level
+   - `estimate` = 0
+   - `mean` = reference_mean
+   - `n` = unweighted count of reference-level observations
+   - `se`, `ci_low`, `ci_high`, `p_value` = NA
+   - `pct_change` = NA
+   - `stars` = ""
+6. Bind reference row (first) + treatment rows.
+
+### 3.9 Estimation: Marginaleffects Path
+
+Used when covariates are present, family is non-gaussian, or group is active.
+
+**Methodological Note — Variance Chain:** The marginaleffects path computes
+SEs via the delta method applied to the design-based sandwich variance:
+
+1. `marginaleffects::avg_slopes()` calls `vcov()` on the `survey_glm_fit`
+   object, which returns the Binder sandwich variance registered via the
+   Phase 2 `get_vcov()` extension method.
+2. For non-gaussian families, the numerical Jacobian of the inverse link
+   function converts from linear predictor scale to response scale.
+3. The delta method combines the Jacobian with the design-based `vcov` to
+   produce SEs for the average marginal effect.
+
+This hybrid — design-based variance estimation (accounting for clustering,
+stratification, and weights) combined with model-based Jacobian (capturing
+the nonlinear link function) — is the standard approach for survey-weighted
+marginal effects (Binder 1983, JASA 78(382):626-631).
+
+**AME as default scale (deviation from survey package):** For non-gaussian
+families, `get_diffs()` defaults to reporting average marginal effects (AMEs)
+on the response scale (e.g., probability differences for logistic), not
+coefficients on the link scale (e.g., log-odds). This departs from
+`survey::svyglm()` convention and is intentional: AMEs are more interpretable
+for treatment effect reporting, particularly for non-technical audiences
+(Gomila 2021, J. Exp. Psych: General 150(3):700-709). Users who need
+link-scale coefficients can set `scale = "link"`. Document in roxygen
+`@details`: "By default, non-gaussian models report average marginal effects
+on the response scale. Set `scale = 'link'` for coefficients on the link
+scale (e.g., log-odds for logistic regression)."
+
+#### 3.9.1 Common Parameters for All Marginaleffects Calls
+
+Three parameters are shared across all `avg_slopes()` and `avg_predictions()`
+calls in this path. They are defined once here; code blocks below use the
+variable names without re-explaining.
+
+```r
+# Residual df: design-based, clamped to >= 1
+p <- length(coef(fit))
+res_df <- max(1, fit@degf - (p - 1L))
+
+# Scale-aware type: "link" when user requests link scale, "response" otherwise
+me_type <- if (scale == "link") "link" else "response"
+```
+
+- **`df = res_df`** — passes design-based residual degrees of freedom so
+  marginaleffects uses the t-distribution (not Z) for p-values and CIs,
+  matching the clean path exactly. Uses `fit@degf` (authoritative post-fit
+  source). The `max(1, ...)` clamping prevents `NaN` from `qt()` when df
+  would be non-positive (matching `.glm_confint()` and `glm-clean.R`).
+  Without this, marginaleffects defaults to Z-distribution (infinite df),
+  producing narrower CIs and smaller p-values. All df values are numeric
+  (double), never integer — replicate designs return non-integer `degf`
+  (e.g., 99.0 for 100 BRR replicates). Document in roxygen `@details`:
+  "All p-values and confidence intervals use the t-distribution with
+  design-based residual degrees of freedom, regardless of estimation path."
+- **`type = me_type`** — `"link"` when `scale = "link"`, `"response"`
+  otherwise. Without this, `avg_slopes()` defaults to `type = "response"`,
+  returning response-scale AMEs even when the user requested link-scale
+  coefficients.
+- **`wts = TRUE`** — enables survey-weight-aware averaging within
+  marginaleffects. Required for correct population-weighted marginal effects.
+
+#### 3.9.2 Estimates (Treatment Effects)
+
+**Without group:**
+```r
+slopes <- marginaleffects::avg_slopes(
+  fit, variables = treats_name, type = me_type, wts = TRUE, df = res_df
+)
+```
+
+**With group:**
+```r
+slopes <- marginaleffects::avg_slopes(
+  fit, variables = treats_name, by = group_names,
+  type = me_type, wts = TRUE, df = res_df
+)
+```
+
+Returns one row per non-reference treatment level (× group when grouped).
+Columns used: `estimate`, `std.error`, `p.value`, `conf.low`, `conf.high`.
+
+#### 3.9.3 Means (Absolute Levels)
+
+When link-scale suppression applies (Section 3.2), skip `avg_predictions()`
+entirely.
+
+**Without group:**
+```r
+preds <- marginaleffects::avg_predictions(
+  fit, by = treats_name, type = me_type, wts = TRUE, df = res_df
+)
+```
+
+**With group:**
+```r
+preds <- marginaleffects::avg_predictions(
+  fit, by = c(treats_name, group_names),
+  type = me_type, wts = TRUE, df = res_df
+)
+```
+
+Returns one row per treatment level (× group). The `estimate` column is the
+weighted average predicted outcome for that level.
+
+#### 3.9.4 Assembly
+
+1. Left-join `slopes` and `preds` on treatment level (+ group if applicable).
+2. For the reference level: `preds` has a row but `slopes` does not.
+   When `show_means = TRUE`, include the reference row with `estimate = 0`,
+   `mean = preds$estimate`, and `p_value = NA`.
+3. Map marginaleffects column names to `survey_diffs` output names:
+   - `slopes$estimate` → `estimate`
+   - `slopes$std.error` → `se`
+   - `slopes$conf.low` → `ci_low`
+   - `slopes$conf.high` → `ci_high`
+   - `slopes$p.value` → `p_value`
+   - `preds$estimate` → `mean`
+4. Compute `n` per treatment level (+ group) — see Section 5.2 for the
+   domain-aware counting rule.
+
+### 3.10 P-Value Adjustment
+
+Applied after estimation, before star assignment.
+
+1. Identify comparison rows (exclude reference row where `estimate == 0`).
+2. **When `group` is active:** Apply `stats::p.adjust(p_values, method = pval_adj)`
+   separately within each group stratum. The multiple testing correction
+   applies to comparisons against the reference within a group, not across
+   groups. This is standard for exploratory subgroup analysis in survey
+   research, where each subgroup represents a separate research question
+   (Alosh et al. 2014, Statistics in Medicine). Document in roxygen
+   `@details`: "When `group` is active, p-value adjustment is applied
+   independently within each group. For global adjustment across all
+   comparisons, apply `stats::p.adjust()` to the result manually."
+   **When `group` is not active:** Apply `stats::p.adjust()` to all
+   comparison rows.
+3. If `variance` includes `"ci"`, the CI bounds are NOT recalculated after
+   p-value adjustment (they reflect the original unadjusted confidence level).
+   This matches standard practice. Document in roxygen `@details`:
+   "Confidence intervals reflect the specified `conf_level` and are not
+   affected by p-value adjustment."
+4. When `pval_adj` is non-NULL, record it in `.meta$pval_adj`.
+
+### 3.11 Percentage Change Calculation
+
+When `show_pct_change = TRUE` (subject to link-scale suppression per
+Section 3.2):
+
+```r
+pct_change <- estimate / reference_mean
+```
+
+- Reference row: `pct_change = NA` (no change from self).
+- If `reference_mean == 0`, `pct_change = NA` and fire
+  `surveycore_warning_pct_change_zero_ref`.
+
+**Limitations:** Only the point estimate `pct_change` is reported. SE and CI
+are not computed for `pct_change`; users requiring confidence intervals for
+the ratio should apply the delta method to `estimate` and `reference_mean`
+externally. Percentage change is substantively interpretable only when
+`reference_mean` is a meaningful nonzero baseline. For outcomes with baseline
+near zero, consider reporting the absolute difference (`estimate`) instead.
+
+### 3.12 Rounding
+
+When `decimals` is non-NULL, round these columns:
+- `estimate`, `mean`, `se`, `ci_low`, `ci_high`, `p_value`: round to `decimals`
+  via `.apply_decimals(result, decimals)`.
+- `pct_change`: round to `decimals + 2` (more precision for proportions).
+  **Implementation note:** Round `pct_change` separately *after*
+  `.apply_decimals()` runs on all other columns. `.apply_decimals()` rounds
+  all double columns uniformly, so `pct_change` must be excluded from that
+  pass (e.g., temporarily set to `NA`, or round manually after the call).
+
+### 3.13 `na.rm` Translation
+
+**Validation:** `na.rm` is validated by `.validate_shared_args()` (called as
+the first step in `get_diffs()`). Non-logical values (e.g., `NA`, `"yes"`, `42`)
+trigger `surveycore_error_na_rm_not_logical`. This also validates `variance`,
+`conf_level`, `name_style`, and `decimals`. `get_diffs()` passes
+`valid_variance = c("se", "ci")` to `.validate_shared_args()` because SEs and
+CIs come from `clean()` or `marginaleffects` — the additional variance types
+(`"var"`, `"cv"`, `"moe"`, `"deff"`) supported by Phase 1's `.add_variance_cols()`
+are not computed by `get_diffs()`.
+
+| `na.rm` | Behavior |
+|---|---|
+| `TRUE` (default) | Rows with NA in `x`, `treats`, or any `group` column are silently dropped before fitting. Passes `na.action = stats::na.omit` to `survey_glm()`. |
+| `FALSE` | NA values cause an error. Passes `na.action = stats::na.fail` to `survey_glm()`, which triggers `surveycore_error_na_in_data`. |
+
+### 3.14 Domain Estimation
+
+`get_diffs()` does not accept a `domain` or `subset` argument. Domain estimation
+is handled upstream via `surveytidy::filter()` before calling `get_diffs()`.
+`survey_glm()` respects the domain mask set by `filter()`.
+
+### 3.15 `@groups` Integration
+
+If `design@groups` is set (via `surveytidy::group_by()`), those groups are
+combined with the `group` argument, per the Phase 1 pattern (see
+`.resolve_groups()` in `analysis-helpers.R`). However, for `get_diffs()`, all
+resolved group variables receive interaction terms with `treats` in the
+formula. When both domain filtering and `@groups` are active, the domain
+filter is applied uniformly to all group strata. The GLM is fit on rows
+matching both the domain condition and non-missing group values.
+
+---
+
+## IV. `.meta` Contract
+
+The `.meta` attribute on `survey_diffs` is a named list with these keys:
+
+| Key | Type | Description |
+|---|---|---|
+| `design_type` | character(1) | `"taylor"`, `"replicate"`, `"twophase"`, or `"calibrated"` |
+| `conf_level` | numeric(1) | Confidence level used |
+| `call` | language | Matched call to `get_diffs()` |
+| `n_respondents` | integer(1) | `nrow(design@data)` — total rows in the design object as passed to `get_diffs()`, before `na.action`. This includes out-of-domain rows (they are still in `@data` after `filter()`). |
+| `group` | named list | One entry per group variable; `list()` when no groups. Each entry: `list(variable_label, question_preface, value_labels)` |
+| `x` | named list | One entry for the DV. Structure: `list({x_name} = list(variable_label, question_preface, value_labels))` |
+| `treats` | named list | Treatment variable metadata. Built by calling `.extract_var_meta(design, treats_name)` (returns `list(variable_label, question_preface, value_labels)`) and appending `name = treats_name` and `ref_level = ref_level`. Final structure: `list(variable_label, question_preface, value_labels, name, ref_level)` |
+| `covariates` | character or `NULL` | Character vector of covariate terms, or `NULL` if none |
+| `family` | character(1) | GLM family name (e.g., `"gaussian"`, `"quasibinomial"`) |
+| `link` | character(1) | Link function name (e.g., `"identity"`, `"logit"`) |
+| `pval_adj` | character(1) or `NULL` | P-value adjustment method, or `NULL` |
+| `estimate_method` | character(1) | `"coefficient"` or `"avg_slopes"` |
+| `mean_method` | character(1) | `"intercept"` or `"avg_predictions"` |
+| `estimate_scale` | character(1) | `"coefficient"` (clean path or `scale = "link"`) or `"ame"` (marginaleffects path with `scale = "ame"`). For non-gaussian families with `scale = "ame"`, the estimate is on the response scale (e.g., probability difference for logistic). With `scale = "link"`, always `"coefficient"`. |
+
+**Accessing:** `meta(result)` — the `meta()` generic from `analysis-meta.R`.
+
+**Construction:** Uses `.extract_var_meta()` and `.build_group_meta()` from
+`analysis-helpers.R` for `group`, `x`, and `treats` entries. The `treats`
+entry is built by calling `.extract_var_meta(design, treats_name)` and
+appending `name` and `ref_level` fields.
+
+---
+
+## V. Output Contract
+
+### 5.1 S3 Class Hierarchy
+
+```r
+class(result) == c("survey_diffs", "survey_result", "tbl_df", "tbl", "data.frame")
+```
+
+### 5.2 Output Columns
+
+Columns appear in this order. Optional columns are omitted when not requested.
+
+| Column | Type | Presence | Description |
+|---|---|---|---|
+| `{group_cols}` | factor/character | When `group` is active | One column per group variable, in order. Type per `label_values` (Section 3.3). |
+| `{treats_name}` | factor/character | Always | Treatment level. Column named after the `treats` variable. Type per `label_values` (Section 3.3): `factor` when labels are applied, `character` otherwise. |
+| `estimate` | numeric | Always | Treatment effect (difference from reference). Reference row = 0. |
+| `pct_change` | numeric | When `show_pct_change = TRUE`, subject to link-scale suppression (Section 3.2) | `estimate / reference_mean`. Reference row = NA. |
+| `mean` | numeric | When `show_means = TRUE`, subject to link-scale suppression (Section 3.2) | Weighted mean for this treatment level. |
+| `n` | integer | Always | Unweighted in-domain observation count for this treatment level (within group if applicable). When domain filtering is active (`..surveycore_domain..` exists in `@data`), counts only rows where `..surveycore_domain.. == TRUE`. Provided for quality assurance (e.g., small cell detection). Inference is design-based and uses weighted data. |
+| `n_weighted` | numeric | When `n_weighted = TRUE` | Sum of weights for this treatment level (within group if applicable). |
+| `se` | numeric | When `variance` includes `"se"` | Standard error of the estimate. Reference row = NA. |
+| `ci_low` | numeric | When `variance` includes `"ci"` | Lower confidence bound. Reference row = NA. |
+| `ci_high` | numeric | When `variance` includes `"ci"` | Upper confidence bound. Reference row = NA. |
+| `p_value` | numeric | Always | P-value (possibly adjusted). Reference row = NA. |
+| `stars` | character | Always | Significance stars. Reference row = `""`. |
+
+### 5.3 Row Order
+
+1. When `show_means = TRUE`: reference row first, then non-reference levels in
+   factor-level order.
+2. When `show_means = FALSE`: non-reference levels only, in factor-level order.
+3. When `group` is active: rows grouped by group combination, with the above
+   ordering within each group.
+
+### 5.4 Reference Row Contract
+
+When `show_means = TRUE`, the reference level appears as a row with the
+values below. The reference row has `p_value = NA` because no hypothesis test
+exists for the baseline — the difference from itself is zero by definition.
+
+| Column | Value |
+|---|---|
+| `{treats_name}` | `ref_level` |
+| `estimate` | `0` |
+| `pct_change` | `NA_real_` |
+| `mean` | Weighted mean of reference group |
+| `n` | Unweighted in-domain count of reference group |
+| `se` | `NA_real_` |
+| `ci_low` | `NA_real_` |
+| `ci_high` | `NA_real_` |
+| `p_value` | `NA_real_` |
+| `stars` | `""` |
+| `n_weighted` | Sum of weights for reference level (within group if applicable). Only present when `n_weighted = TRUE`. |
+
+### 5.5 Column-Level Labels
+
+Every column in the output has a `label` attribute set via
+`attr(col, "label") <- "..."`. These are automatically picked up by
+`gt::gt()`. Column labels always use variable labels from metadata when
+available, falling back to raw variable names — there is no user-facing
+toggle for this behavior.
+
+| Column | `label` value |
+|---|---|
+| `{treats_name}` | Variable label from metadata, or variable name if no label |
+| `{group_cols}` | Variable label from metadata per group variable, or variable name if no label |
+| `estimate` | `"Difference relative to {ref_level}"` |
+| `pct_change` | `"% Change"` |
+| `mean` | `"Mean"` |
+| `n` | `"N"` |
+| `n_weighted` | `"N (weighted)"` |
+| `se` | `"Std. Error"` |
+| `ci_low` | `"Low CI"` |
+| `ci_high` | `"High CI"` |
+| `p_value` | `"P-Value"` |
+| `stars` | `""` |
+
+---
+
+## VI. Error & Warning Conditions
+
+### 6.1 Errors
+
+| Error class | Trigger | Message template |
+|---|---|---|
+| `surveycore_error_unsupported_class` | `design` is not a `survey_base` subclass | Reuse `.check_unsupported_class(design, "get_diffs")` |
+| `surveycore_error_non_numeric_variable` | `x` column is not numeric | `{.arg x} must be numeric. {.field {x_name}} is {.cls {class}}.` |
+| `surveycore_error_treats_single` | `treats` resolves to != 1 column | `{.arg treats} must select exactly one column.` |
+| `surveycore_error_wrong_variable_count` | `x` resolves to != 1 column | `{.arg x} must select exactly one column.` |
+| `surveycore_error_ref_level_not_found` | `ref_level` not in levels of treats | `{.arg ref_level} {.val {ref_level}} not found in levels of {.field {treats_name}}.` |
+| `surveycore_error_treats_one_level` | `treats` has only 1 unique value after NA removal | `{.arg treats} must have at least 2 levels. {.field {treats_name}} has only 1.` |
+| `surveycore_error_invalid_pval_adj` | `pval_adj` not a valid method | `{.arg pval_adj} must be a valid method for {.fn stats::p.adjust}.` |
+| `surveycore_error_invalid_conf_level` | `conf_level` not in (0, 1) | (reuse existing class from Phase 2) |
+| `surveycore_error_covariates_not_character` | `covariates` is not a character vector | `{.arg covariates} must be a character vector of model terms.` |
+
+| `surveycore_error_reference_row_not_found` | `clean()` output has zero or multiple `(Intercept)` rows | `Reference row not found in model output. Expected exactly one intercept row.` |
+
+Errors from `survey_glm()` propagate unchanged (e.g.,
+`surveycore_error_formula_missing`, `surveycore_error_singular_model_matrix`,
+`surveycore_error_na_in_data`, `surveycore_error_empty_domain`).
+
+### 6.2 Warnings
+
+| Warning class | Trigger | Message template |
+|---|---|---|
+| `surveycore_warning_pct_change_zero_ref` | `show_pct_change = TRUE` and reference mean is 0 | `Reference group mean is 0; percentage change is undefined.` |
+| `surveycore_warning_treats_coerced` | `treats` column is not a factor (coerced) | `{.field {treats_name}} coerced to factor.` |
+| `surveycore_warning_small_cell` | Any treatment level (within group) has fewer than `min_cell_n` unweighted observations | `Treatment level {.val {level}} has only {n} observations (threshold: {min_cell_n}).` |
+
+Warnings from `survey_glm()` propagate unchanged (e.g.,
+`surveycore_warning_glm_convergence`, `surveycore_warning_perfect_separation`).
+
+---
+
+## VII. Execution Flow
+
+### 7.1 Step-by-Step
+
+```
+Step 1:  Validate shared args (.validate_shared_args with
+         valid_variance = c("se", "ci"): variance, conf_level,
+         name_style, decimals, na.rm)
+Step 2:  Validate design class (.check_unsupported_class)
+Step 3:  Resolve x, treats, group via tidy-select
+Step 4:  Validate x is numeric, treats has ≥ 2 levels
+Step 4a: Validate covariates is character or NULL
+         (surveycore_error_covariates_not_character);
+         validate pval_adj is NULL or in stats::p.adjust.methods
+         (surveycore_error_invalid_pval_adj)
+Step 5:  Handle ref_level (default or validate user-supplied)
+Step 6:  Handle na.rm → na.action translation
+Step 7:  Coerce treats to factor, relevel if needed, force treatment
+         contrasts (Section 3.7 Step 5: contr.treatment).
+         NOTE: Steps 7–8 modify design@data in place before the
+         GLM call in Step 9.
+Step 8:  Build formula from treats + group + covariates
+Step 9:  Call survey_glm(design, formula, na.action, ...)
+Step 10: Determine estimation path (clean vs marginaleffects;
+         see Section 7.2)
+Step 11: Extract estimates and means via chosen path
+Step 12: Compute n per treatment level (+ group), domain-aware
+         (see Section 5.2 `n` column)
+Step 13: Apply pval_adj if requested
+Step 14: Apply link-scale suppression (Section 3.2): omit mean
+         and pct_change columns if applicable
+Step 15: Compute pct_change if requested and not suppressed
+Step 16: Assign stars
+Step 17: Assemble output tibble in column order
+Step 17a: Apply label_values via .apply_group_labels() to
+          treats and group columns
+Step 18: Apply decimals rounding if requested
+Step 19: Apply name_style via .apply_name_style(result,
+         name_style, exclude = "mean")
+Step 20: Attach .meta via .make_result_tibble()
+Step 21: Attach column-level labels (inline; Section 5.5)
+Step 22: Set S3 class and return
+```
+
+### 7.2 Estimation Path Decision
+
+```r
+family_name <- fit@family$family
+has_covariates <- !is.null(covariates)
+has_group <- length(group_names) > 0
+scale <- match.arg(scale)
+
+use_marginaleffects <- has_covariates ||
+  has_group ||
+  (family_name != "gaussian" && scale == "ame")
+```
+
+When `scale = "link"`, non-gaussian models use the clean path (Section 3.8,
+coefficients on the link scale) unless covariates or groups are present,
+which still require `avg_slopes()` (Section 3.9). When `scale = "ame"`
+(default), non-gaussian models always use the marginaleffects path to compute
+response-scale AMEs.
+
+---
+
+## VIII. Print Method
+
+`survey_diffs` inherits from `survey_result`, which has a generic
+`print.survey_result()` in `analysis-meta.R` that prints a single header line
+(`# A <survey_diffs> [N × M]`) then delegates to tibble.
+
+`print.survey_diffs()` **overrides** `print.survey_result()` to add 3
+additional context lines before the tibble body. S3 dispatch finds
+`print.survey_diffs` before `print.survey_result` because `survey_diffs` is
+first in the class vector.
+
+**Registration:** `registerS3method("print", "survey_diffs",
+print.survey_diffs)` in `.onLoad()` in `zzz.R`.
+
+**Exact console output:**
+
+```
+# A survey_diffs result
+# Design: Taylor series | Family: gaussian (identity)
+# DV: agree_trope | Treatment: message_arm (ref: Control)
+# Method: coefficient / intercept
+# A tibble: 4 × 8
+  message_arm estimate  mean     n ci_low ci_high p_value stars
+  <fct>          <dbl> <dbl> <int>  <dbl>   <dbl>   <dbl> <chr>
+1 Control        0     0.401   752 NA      NA      NA      ""
+2 Message A      0.082 0.483   748  0.042   0.122   0.001  "**"
+3 Message B      0.103 0.504   751  0.063   0.143   0.000  "***"
+4 Message C      0.045 0.446   749  0.005   0.085   0.028  "*"
+```
+
+The 4 header lines:
+- Line 1: Result class name
+- Line 2: Design type + family + link (from `.meta$design_type`, `.meta$family`, `.meta$link`)
+- Line 3: DV name + treatment variable + reference level (from `.meta$x`, `.meta$treats$name`, `.meta$treats$ref_level`)
+- Line 4: Estimation method (from `.meta$estimate_method` / `.meta$mean_method`)
+
+---
+
+## IX. Testing Requirements
+
+### 9.1 Test Categories
+
+Per `testing-standards.md`: happy path + error paths + edge cases for every
+exported function.
+
+#### Happy Path Tests (`test-analysis-diffs.R`)
+
+| Test | Description |
+|---|---|
+| Bivariate gaussian, no group | Basic `DV ~ treats` with `survey_taylor` design |
+| Bivariate gaussian, with group | `DV ~ treats * group` with `survey_taylor` |
+| With covariates, no group | `DV ~ treats + covariates` |
+| With covariates and group | `DV ~ treats * group + covariates` |
+| Non-gaussian family (quasibinomial) | Binary DV with `family = quasibinomial()` via `...` |
+| `show_means = FALSE` | No reference row, no `mean` column |
+| `show_pct_change = TRUE` | `pct_change` column present and correct |
+| `pval_adj = "BH"` | P-values adjusted, adjustment recorded in `.meta` |
+| `variance = "se"` | SE column present, no CI columns |
+| `variance = c("se", "ci")` | Both SE and CI columns present |
+| `variance = NULL` | No SE or CI columns |
+| `ref_level` specified | Different reference level changes output |
+| `decimals` | Numeric columns rounded correctly |
+| All 4 design classes | One test per design class (taylor, replicate, twophase, nonprob) |
+| Domain estimation | `filter(design, condition) \|> get_diffs(...)` produces in-domain `n` counts and correct estimates. Gated with `skip_if_not_installed("surveytidy")`. |
+| Print snapshot | `expect_snapshot(print(result))` captures all 4 header lines + tibble body. Verifies class, design+family, DV+treatment+ref, and method display. |
+| `label_values = TRUE` | Treats and group columns display value labels from metadata |
+| `label_values = FALSE` | Treats and group columns display raw codes |
+| `name_style = "broom"` | Columns renamed: `se` → `std.error`, `ci_low` → `conf.low`, etc.; `mean` excluded |
+| `n_weighted = TRUE` | `n_weighted` column present with sum of weights per treatment level |
+| `min_cell_n` custom | Custom threshold fires `surveycore_warning_small_cell` at the right count |
+
+#### Error Path Tests (`test-analysis-diffs.R`)
+
+One `test_that()` block per error class in Section VI, using the dual pattern
+from `testing-standards.md`: `expect_error(class = ...)` +
+`expect_snapshot(error = TRUE, ...)`.
+
+#### Edge Case Tests (`test-analysis-diffs.R`)
+
+| Test | Description |
+|---|---|
+| `treats` with 2 levels | Simplest case: 1 reference + 1 treatment row |
+| `treats` with many levels (10+) | Verify all non-reference levels appear |
+| `treats` as character (not factor) | Coerced to factor with warning |
+| Reference mean = 0 with `show_pct_change` | Warning + `pct_change = NA` |
+| Single observation in one treatment level | `surveycore_warning_small_cell` fires |
+| All NA in `x` for one treatment level | Model still fits; that level has `n = 0` |
+| `group` with only 1 unique value | `survey_glm()` throws `surveycore_error_singular_model_matrix` due to collinear interaction terms. Verify error propagation. |
+| `na.rm = FALSE` with NAs present | Error propagated from `survey_glm()` |
+| Gaussian `scale = "ame"` == `scale = "link"` | Both scales produce identical estimates, SEs, and CI bounds (tolerance 1e-10 for point, 1e-8 for SEs). Guards routing logic. |
+| `scale = "link"` + non-gaussian | Link-scale suppression (Section 3.2): `mean` and `pct_change` columns omitted |
+
+#### Numerical Tests (`test-analysis-diffs-numerical.R`)
+
+| Test | Description |
+|---|---|
+| Bivariate OLS vs manual computation | `clean()` coefficient = hand-computed diff of weighted means |
+| Multivariate OLS vs `survey::svyglm` + `marginaleffects` | `avg_slopes()` output matches direct `survey::svyglm` → `marginaleffects::avg_slopes()` pipeline |
+| Logistic AME vs `survey::svyglm` + `marginaleffects` | Binary DV with `quasibinomial()` family: AME and SE match `survey::svyglm(..., family = quasibinomial()) + marginaleffects::avg_slopes()` |
+| Poisson AME vs `survey::svyglm` + `marginaleffects` | Count response with `poisson()` family: same comparison pipeline |
+| SRS full covariance matrix verification | For multivariate tests, verify that off-diagonal elements of `fit@vcov` are non-zero (where expected) and match `survey::svyglm()` within tolerance 1e-8. A diagonal-only implementation would pass point-estimate tests but produce wrong SEs when covariates are correlated. |
+| Replicate design non-integer df | Replicate design with non-integer `degf` produces CI bounds matching manual `qt(0.975, df = degf_value)`. Verify df is numeric (double), not integer. |
+| Replicate domain convergence | Call `get_diffs()` on a replicate design with a tight domain filter causing some replicates to have near-zero in-domain rows. Verify that warnings from `survey_glm()` propagate and that results are finite (no silent NaN propagation). |
+
+**Tolerances:**
+- Bivariate OLS (clean path): `1e-8` for estimates, `1e-6` for SEs and CI bounds.
+- Marginaleffects oracle tests: `1e-10` for point estimates, `1e-8` for SEs, `1e-6` for CI bounds — matching Phase 2 spec Section IX.
+
+#### Marginaleffects Path Tests (`test-analysis-diffs-marginaleffects.R`)
+
+All tests gated with `skip_if_not_installed("marginaleffects")`.
+
+| Test | Description |
+|---|---|
+| `avg_slopes()` produces correct number of rows | One row per non-reference treatment level (× group) |
+| `avg_predictions()` produces correct means | One row per treatment level (× group) |
+| `wts = TRUE` produces weighted averages | Compare against manual weighted computation |
+
+### 9.2 `.meta` Tests
+
+Every happy path test must also verify:
+- `meta(result)$estimate_method` matches expected path
+- `meta(result)$mean_method` matches expected path
+- `meta(result)$treats$ref_level` matches expected reference level
+- `meta(result)$family` matches expected family
+
+### 9.3 Column Label Tests
+
+At least one test verifies that every output column has a `label` attribute set:
+```r
+test_that("get_diffs() sets column-level labels on all columns", {
+  result <- get_diffs(d, dv, treatment)
+  for (col in names(result)) {
+    expect_false(is.null(attr(result[[col]], "label")))
+  }
+})
+```
+
+---
+
+## X. Quality Gates
+
+All gates must pass before `get_diffs()` is merged:
+
+- [ ] `devtools::check()` returns 0 errors, 0 warnings, ≤ 2 pre-approved notes
+- [ ] 98%+ line coverage on `analysis-diffs.R` and `analysis-diffs-helpers.R`
+- [ ] All error classes from Section VI have corresponding tests
+- [ ] All 4 design classes have at least one happy-path test
+- [ ] Numerical tests pass against reference implementation
+- [ ] `.meta` contract fully tested
+- [ ] Column labels tested
+- [ ] `marginaleffects` added to `Imports` in DESCRIPTION
+- [ ] `plans/error-messages.md` updated with new error/warning classes
+
+---
+
+## XI. Usage Examples
+
+### 11.1 Basic Bivariate (SOP Model A)
+
+```r
+d <- as_survey(msg_test_data, ids = resp_id, weights = rake_wt)
+
+# Treatment effect — percentage point difference vs. control
+get_diffs(d, agree_trope, message_arm)
+```
+
+### 11.2 Multivariate with Covariates (SOP Model B)
+
+```r
+get_diffs(d, agree_trope, message_arm,
+          covariates = c("age", "gender", "education", "ideology"))
+```
+
+### 11.3 Subgroup Analysis (SOP Section 5)
+
+```r
+get_diffs(d, agree_trope, message_arm,
+          group = age_group,
+          covariates = c("gender", "education", "ideology"))
+```
+
+### 11.4 Logistic Path (SOP Section 2.2)
+
+```r
+# When ≥90% agree in control, use logistic
+get_diffs(d, agree_trope, message_arm,
+          family = quasibinomial())
+```
+
+### 11.5 With P-Value Adjustment (SOP Section 6.4)
+
+```r
+get_diffs(d, agree_trope, message_arm,
+          pval_adj = "BH")
+```
+
+### 11.6 Full Reporting Table
+
+```r
+library(gt)
+
+get_diffs(d, agree_trope, message_arm,
+          show_pct_change = TRUE,
+          variance = c("se", "ci"),
+          decimals = 3) |>
+  gt::gt()
+# Column headers auto-populated from label attributes
+```

--- a/plans/spec-methods-review-get-diffs.md
+++ b/plans/spec-methods-review-get-diffs.md
@@ -1,0 +1,712 @@
+# Methodology Review: get-diffs
+
+## Pass 1 (2026-03-16)
+
+### New Issues
+
+#### Lens 1 — Estimator Specification
+
+**Issue 1: Contrast function not validated — clean path assumes treatment contrasts**
+Severity: BLOCKING
+Resolution type: UNAMBIGUOUS
+
+The clean path (Section 3.7) extracts the intercept as the reference group mean:
+> "Extract reference row (intercept): the row where `term == "(Intercept)"`.
+> `reference_mean <- tidy_result$estimate` for this row (the intercept IS the
+> reference group mean for a factor-only model)."
+
+This formula holds **only under treatment contrasts** (`contr.treatment()`). Under
+Helmert contrasts the intercept is the grand mean; under sum contrasts it is the
+unweighted mean of level means. The spec coerces `treats` to factor (Section 3.6)
+but does not validate which contrast function is in effect.
+
+`stats::reformulate()` builds the formula, and `survey_glm()` fits the model using
+whatever contrasts are set on the factor. If a user pre-sets non-treatment contrasts
+(via `contrasts<-()` or `options(contrasts = ...)`), the clean path silently produces
+wrong reference means and wrong treatment effects.
+
+Options:
+- **[A]** Add validation in Section 3.6 (after `relevel()`): check that the
+  effective contrast function is `contr.treatment`. If not, either error
+  (`surveycore_error_unsupported_contrasts`) or force treatment contrasts
+  explicitly via `contrasts(data[[treats_name]]) <- contr.treatment`. Add the
+  error class to `error-messages.md`. — Effort: low, Risk: low, Impact: prevents
+  silent wrong results, Maintenance: none
+- **[B]** Route all configurations through the marginaleffects path (which
+  computes AMEs without depending on contrast interpretation). — Effort: medium,
+  Risk: low, Impact: removes the clean path entirely, Maintenance: adds
+  marginaleffects as a hard dependency for all calls
+- **[C] Do nothing** — Rely on R's default `contr.treatment`. Wrong results if
+  the user has changed contrasts.
+
+**Recommendation: [A]** — Validate and/or force treatment contrasts. Low cost,
+eliminates a class of silent errors.
+
+Source: R documentation for `stats::contr.treatment()`; Phase 2 spec Section 6.3
+(reference level detection assumes treatment contrasts).
+
+---
+
+**Issue 2: Interaction model and group-specific slopes not explained**
+Severity: REQUIRED
+Resolution type: UNAMBIGUOUS
+
+Section 3.5 builds `x ~ treats * group + covariates` when `group` is provided, and
+Section 3.8.1 calls `avg_slopes(fit, variables = treats_name, by = group_names)`.
+The spec does not explain how the interaction term creates group-specific treatment
+effects:
+
+```
+x ~ treats + group + treats:group + covariates
+dY/d(treats) = beta_treats + beta_interact * I(group = g)
+```
+
+A reader might assume the model is additive (no interaction). The spec should
+document that the `treats:group` interaction allows the treatment effect to differ
+by subgroup, and that `avg_slopes(by = group)` correctly incorporates this.
+
+Options:
+- **[A]** Add explanatory paragraph to Section 3.5 describing the interaction
+  expansion and its effect on slope computation. Note that hypothesis testing on
+  the interaction coefficient itself requires `summary(fit)`. — Effort: low,
+  Risk: low, Impact: clarity, Maintenance: none
+- **[C] Do nothing** — Readers must infer from the formula notation.
+
+**Recommendation: [A]** — One paragraph of documentation clarifies a non-obvious
+statistical dependency.
+
+Source: Standard GLM interaction theory; marginaleffects documentation for `by`
+argument.
+
+---
+
+**Issue 3: SRS full covariance matrix verification needed in tests**
+Severity: REQUIRED
+Resolution type: UNAMBIGUOUS
+
+Phase 2 spec Section 8.4 explicitly warns:
+> "Using only the diagonal (column-wise variances) is incorrect when bread is
+> non-diagonal, which is almost always the case with multiple predictors."
+
+The `get_diffs()` test plan (Section 9.1) specifies a multivariate oracle test but
+does not explicitly verify that off-diagonal elements of the design-based vcov match
+`survey::svyglm()`. A diagonal-only implementation would pass point-estimate tests
+but produce wrong SEs for treatment effects when covariates are correlated.
+
+Options:
+- **[A]** Add to Section 9.1 (Numerical Tests): for multivariate tests, verify
+  that off-diagonal elements of `fit@vcov` are non-zero (where expected) and
+  match `survey::svyglm()` within tolerance 1e-8. — Effort: low, Risk: low,
+  Impact: catches a common variance implementation bug, Maintenance: one test
+- **[C] Do nothing** — Rely on SE matching to implicitly catch this.
+
+**Recommendation: [A]** — Explicit off-diagonal verification is a stronger test.
+
+Source: Phase 2 spec Section 8.4 (SRS variance formula with full meat matrix).
+
+---
+
+**Issue 4: Reference row extraction needs defensive validation**
+Severity: ADVISORY
+Resolution type: UNAMBIGUOUS
+
+Section 3.7 Step 3 extracts the reference row via `term == "(Intercept)"` from
+`clean()` output. If `clean()` output format changes or the GLM fit is degenerate,
+this extraction could silently fail.
+
+Options:
+- **[A]** Add validation: if zero or multiple rows match `term == "(Intercept)"`,
+  error with `surveycore_error_reference_row_not_found`. — Effort: low, Risk:
+  low, Impact: defensive, Maintenance: none
+- **[C] Do nothing** — `clean()` contract guarantees exactly one intercept row.
+
+**Recommendation: [A]** — Low-cost defensive check.
+
+---
+
+#### Lens 2 — Variance Estimation
+
+**Issue 5: Clean path variance not documented as design-class-aware**
+Severity: REQUIRED
+Resolution type: UNAMBIGUOUS
+
+Section 3.7 extracts `se`, `ci_low`, `ci_high` from `clean()` output without
+stating that these are computed via the design-class-specific Binder sandwich
+variance from `survey_glm()@vcov`. Readers must cross-reference Phase 2 spec
+Section VIII to confirm variance correctness for Taylor, replicate, two-phase, SRS,
+and nonprob designs.
+
+Options:
+- **[A]** Add one sentence to Section 3.7 after Step 2: "The `clean()` function
+  returns `std_error` and CI bounds computed from `fit@vcov`, which is the
+  design-based Binder sandwich variance (per Phase 2 spec Section VIII). Variance
+  computation is design-class-specific." — Effort: low, Risk: low, Impact:
+  clarity, Maintenance: none
+- **[C] Do nothing** — Cross-reference to Phase 2 is implicit.
+
+**Recommendation: [A]** — One sentence makes the spec self-contained.
+
+---
+
+**Issue 6: Delta method chain for marginaleffects path not documented**
+Severity: REQUIRED
+Resolution type: UNAMBIGUOUS
+
+*Cross-lens: also flagged by Lens 1 (delta method) and Lens 5 (AME convention).*
+
+Section 3.8.1 shows the `avg_slopes()` call and states that it returns `estimate`
+and `std.error`, but does not document that:
+
+1. The SE is computed via the delta method using `vcov()` from `survey_glm_fit`
+2. The Phase 2 marginaleffects extension registers `get_vcov()` returning the
+   Binder sandwich variance
+3. For non-gaussian families, the numerical Jacobian of the inverse link converts
+   from linear predictor to response scale
+
+Without this, readers cannot verify the correctness of the SE chain.
+
+Options:
+- **[A]** Add a "Methodological Note" paragraph in Section 3.8 explaining: (a)
+  marginaleffects uses the delta method on `vcov()`, (b) `get_vcov()` returns the
+  design-based sandwich, (c) the Jacobian is model-based (numerical derivatives),
+  (d) this hybrid (design-based variance + model-based Jacobian) is standard. —
+  Effort: low, Risk: low, Impact: critical for reviewers, Maintenance: none
+- **[C] Do nothing** — Assume readers know marginaleffects internals.
+
+**Recommendation: [A]** — This is the most important variance chain in the spec;
+document it.
+
+Source: Phase 2 spec Section VII (marginaleffects extension interface); Binder
+(1983), JASA 78(382):626-631.
+
+---
+
+**Issue 7: Non-gaussian oracle tests missing from test plan**
+Severity: REQUIRED
+Resolution type: UNAMBIGUOUS
+
+Section 9.1 (Numerical Tests) specifies oracle tests for bivariate OLS but does not
+require oracle tests comparing non-gaussian AMEs against a reference pipeline
+(`survey::svyglm()` + `marginaleffects::avg_slopes()`).
+
+For logistic regression, the score includes family-specific working residuals. A
+Gaussian-specific formula (using response residuals instead of working residuals)
+produces no error — just wrong SEs. Without oracle testing, this bug is invisible.
+
+Options:
+- **[A]** Add to Section 9.1:
+  - Logistic regression: binary DV, compare AME and SE against
+    `survey::svyglm(..., family = quasibinomial()) + marginaleffects::avg_slopes()`.
+    Tolerance: 1e-6 for AME, 1e-6 for SE.
+  - Poisson regression: count response, same comparison.
+  — Effort: medium, Risk: low, Impact: catches sandwich bugs for non-gaussian,
+  Maintenance: two test blocks
+- **[C] Do nothing** — Phase 2 spec already has these tests; assume they catch
+  bugs before `get_diffs()` uses them.
+
+**Recommendation: [A]** — End-to-end oracle tests at the `get_diffs()` level catch
+integration bugs that unit-level Phase 2 tests may miss.
+
+---
+
+**Issue 8: Marginaleffects oracle test tolerances not specified**
+Severity: REQUIRED
+Resolution type: UNAMBIGUOUS
+
+Section 9.1 specifies tolerances only for "Bivariate OLS" tests (1e-8 for
+estimates, 1e-6 for SEs). The marginaleffects path has no stated tolerances.
+
+Options:
+- **[A]** Add to Section 9.1: "Marginaleffects oracle tests use: 1e-10 for point
+  estimates, 1e-8 for SEs, 1e-6 for CI bounds — matching Phase 2 spec Section
+  IX." — Effort: low, Risk: low, Impact: implementers have a clear target,
+  Maintenance: none
+- **[C] Do nothing** — Implementers guess.
+
+**Recommendation: [A]** — State the tolerances explicitly.
+
+---
+
+#### Lens 3 — Degrees of Freedom and Inference
+
+**Issue 9: P-value distribution inconsistent across estimation paths (t vs Z)**
+Severity: BLOCKING
+Resolution type: JUDGMENT CALL
+
+The clean path produces p-values from `clean()`, which uses the t-distribution with
+design-based df = `degf(design) - (p - 1)` (Phase 2 spec Section 6.3):
+> "`p_value` — Two-sided p-value from t-distribution with `degf - (p - 1)` df."
+
+The marginaleffects path produces p-values from `avg_slopes()`, which by default
+uses the **normal (Z) distribution** — i.e., infinite df. This creates a
+discontinuity: the same treatment effect can produce different p-values and narrower
+CIs depending on whether the user adds one covariate (forcing the marginaleffects
+path).
+
+No warning alerts the user to this regime change, and the output labels p-values
+identically regardless of path.
+
+Options:
+- **[A]** Document the inconsistency explicitly. Add `.meta$pvalue_distribution`
+  key recording `"t"` or `"z"` per path. Consider emitting
+  `surveycore_warning_inference_method_change` when the marginaleffects path is
+  used. — Effort: medium, Risk: low, Impact: transparency without changing
+  inference, Maintenance: low
+- **[B]** Force design-based df on the marginaleffects path. Pass `df` to
+  `marginaleffects::avg_slopes()` via the `vcov` or `df` argument (if supported)
+  to force t-distribution inference. — Effort: high, Risk: medium
+  (marginaleffects API compatibility), Impact: full consistency across paths,
+  Maintenance: tied to marginaleffects API evolution
+- **[C] Do nothing** — Silent inconsistency between paths.
+
+**Recommendation: [B] if feasible, else [A]** — Full consistency is ideal. If
+marginaleffects supports a `df` argument (check API), use it. Otherwise, document
+the inconsistency so users can make informed decisions.
+
+Source: Phase 2 spec Section 6.3 (t-distribution with design df); marginaleffects
+documentation (default Wald Z); [verify] marginaleffects source for df parameter
+support.
+
+---
+
+**Issue 10: DF formula for p-values not explicitly specified in get_diffs()**
+Severity: REQUIRED
+Resolution type: UNAMBIGUOUS
+
+The spec does not state the degrees of freedom formula used for computing p-values
+in either path. Phase 2 spec Section 8.5 defines `df_residual = degf(design) -
+(p - 1)`, but `get_diffs()` does not cross-reference this.
+
+Options:
+- **[A]** Add to Section 3.8.3 (Assembly): "P-values are computed using
+  design-based residual df: `df = degf(design) - (p - 1)`, where `p` is the total
+  number of GLM coefficients (including intercept). This follows Phase 2 spec
+  Section 8.5." — Effort: low, Risk: low, Impact: clarity, Maintenance: none
+- **[C] Do nothing** — Readers cross-reference Phase 2.
+
+**Recommendation: [A]** — Cross-reference explicitly.
+
+---
+
+**Issue 11: P-value and CI labels should differentiate by estimation path for
+non-gaussian families**
+Severity: REQUIRED
+Resolution type: JUDGMENT CALL
+
+When `marginaleffects::avg_slopes()` is used for non-gaussian families, `estimate`
+is the AME on the response scale (e.g., probability for logistic), and `p_value`
+tests whether the AME differs from zero. The clean path's `estimate` is the
+coefficient. The spec labels both identically (Section 5.5):
+> `estimate` label: `"Difference relative to {ref_level}"`
+> `p_value` label: `"P-Value"`
+
+A user seeing `p_value = 0.03` cannot tell from the label whether this tests a
+coefficient or an AME.
+
+Options:
+- **[A]** Dynamically set column labels based on path:
+  - Clean path: `"Difference relative to {ref_level}"` (coefficient)
+  - Marginaleffects path (non-gaussian): `"Avg. Marginal Effect vs {ref_level}"`
+  — Effort: low, Risk: low, Impact: users see the scale in the output,
+  Maintenance: label logic in `.attach_col_labels()`
+- **[B]** Add `.meta$estimate_scale` key recording `"coefficient"` or `"ame"`.
+  Leave column labels generic. — Effort: low, Risk: low, Impact: transparent in
+  metadata but not visible in print, Maintenance: none
+- **[C] Do nothing** — Assume users understand the scale from the family.
+
+**Recommendation: [A]** — Dynamic labels are low-cost and solve the problem at the
+point of use.
+
+Source: Lens 3 output-labeling check: "Does every displayed quantity match its
+label?"
+
+---
+
+**Issue 12: Non-integer df must be preserved (not truncated)**
+Severity: REQUIRED
+Resolution type: UNAMBIGUOUS
+
+For replicate designs, `degf()` returns non-integer values (e.g., 99.0 for 100 BRR
+replicates). The spec does not explicitly forbid integer coercion of df values. If
+downstream code truncates df to integer, t-distribution quantiles become
+inconsistent.
+
+Options:
+- **[A]** Add to spec: "All df values are numeric (double), never integer.
+  Preserve decimal places through t-distribution quantile lookup." Add test:
+  replicate design with non-integer degf produces CI bounds matching manual
+  `qt(0.975, df = degf_value)`. — Effort: low, Risk: low, Impact: prevents
+  subtle rounding, Maintenance: none
+- **[C] Do nothing** — Phase 2 already specifies numeric df.
+
+**Recommendation: [A]** — Explicit guidance + one test.
+
+Source: Phase 2 spec Section 2.2 (df computation preserves numeric type).
+
+---
+
+**Issue 13: Reference row p_value = NA semantics not explained**
+Severity: ADVISORY
+Resolution type: UNAMBIGUOUS
+
+Section 5.4 specifies `p_value = NA_real_` for the reference row but does not
+explain why. Users may interpret `NA` as a computation failure rather than an
+intentional absence.
+
+Options:
+- **[A]** Add one sentence to Section 5.4: "The reference row has `p_value = NA`
+  because no hypothesis test exists for the baseline (the difference from itself
+  is zero by definition)." — Effort: negligible, Risk: none, Impact: clarity,
+  Maintenance: none
+- **[C] Do nothing** — Users infer from context.
+
+**Recommendation: [A]** — One sentence.
+
+---
+
+#### Lens 4 — Domain Estimation
+
+**Issue 14: Replicate domain convergence with marginaleffects unspecified**
+Severity: BLOCKING
+Resolution type: UNAMBIGUOUS
+
+Phase 2 spec Section 4.5 specifies: "If a replicate refit on in-domain rows fails
+to converge, warn with `surveycore_warning_glm_convergence` and use beta_r = beta
+(zero deviation)." This handles the `survey_glm()` layer.
+
+However, `get_diffs()` uses `marginaleffects::avg_slopes()` on the fitted model. If
+a domain filter leaves very few in-domain rows and some replicate subsets are
+degenerate, the marginaleffects delta method computation may fail or produce `NaN`
+SEs. The spec does not specify behavior when `avg_slopes()` encounters degenerate
+replicate subsets.
+
+Options:
+- **[A]** Add test in Section 9.1 (`test-diffs-numerical.R`): call `get_diffs()`
+  on a replicate design with a tight domain filter causing some replicates to have
+  near-zero in-domain rows. Verify that `avg_slopes()` handles gracefully (with
+  warning) or errors with a typed message. Document the expected behavior. —
+  Effort: medium, Risk: low, Impact: prevents silent NaN propagation, Maintenance:
+  one test
+- **[C] Do nothing** — Assume Phase 2 catches this before marginaleffects sees it.
+
+**Recommendation: [A]** — Integration test at the `get_diffs()` level catches
+problems that unit-level Phase 2 tests may miss.
+
+Source: Phase 2 spec Section 4.5 (domain estimation contract).
+
+---
+
+**Issue 15: Empty domain error not in get_diffs() error table**
+Severity: REQUIRED
+Resolution type: UNAMBIGUOUS
+
+Section 3.13 states `survey_glm()` respects the domain mask from `filter()`, but
+Section VI (Error & Warning Conditions) does not list
+`surveycore_error_empty_domain` as a propagated error. If a user calls
+`filter(impossible_condition) |> get_diffs(...)`, the error comes from
+`survey_glm()` but is not documented in the `get_diffs()` error table.
+
+Options:
+- **[A]** Add `surveycore_error_empty_domain` to Section 6.1 with note: "from
+  `survey_glm()`, propagates unchanged." — Effort: negligible, Risk: none,
+  Impact: complete error documentation, Maintenance: none
+- **[C] Do nothing** — Users discover it at runtime.
+
+**Recommendation: [A]** — Add to error table.
+
+---
+
+**Issue 16: `n` column calculation ambiguous with domain filtering**
+Severity: REQUIRED
+Resolution type: JUDGMENT CALL
+
+Section 3.8.3 says: "Compute `n` per treatment level (+ group) from `design@data`
+directly (unweighted count)."
+
+With domain filtering, `design@data` contains both in-domain and out-of-domain rows
+(domain mask is in `..surveycore_domain..`). The spec does not specify whether `n`
+counts all rows or only in-domain rows.
+
+Options:
+- **[A]** Report in-domain counts only: "Compute `n` per treatment level by
+  counting rows where `design@data[[..surveycore_domain..]] == TRUE`." This
+  matches the sample size used for variance estimation. — Effort: low, Risk: low,
+  Impact: internal consistency, Maintenance: none
+- **[B]** Report total counts with a separate `.meta$n_domain` tracking in-domain
+  count. — Effort: medium, Risk: low, Impact: full transparency, Maintenance:
+  document new `.meta` key
+- **[C] Do nothing** — Ambiguous; implementer decides.
+
+**Recommendation: [A]** — `n` should reflect the observations used for inference.
+
+---
+
+**Issue 17: `.meta$n_respondents` definition ambiguous with domain filtering**
+Severity: REQUIRED
+Resolution type: UNAMBIGUOUS
+
+Section IV defines `n_respondents` as "Total rows in design (regardless of
+groups/domain)." This is ambiguous: does "design" mean the original design or the
+design after `filter()`?
+
+Phase 2 `clean()` provides `n_observations` = "Unweighted row count after domain
+filtering and na.action" (Section 6.3), which is post-filtering. Using a different
+definition in `get_diffs()` creates confusion.
+
+Options:
+- **[A]** Clarify: `n_respondents` = `nrow(design@data)` — total rows in the
+  design object as passed to `get_diffs()`, before `na.action`. This includes
+  out-of-domain rows (they are still in `@data`). Document this explicitly. —
+  Effort: low, Risk: low, Impact: unambiguous, Maintenance: none
+- **[C] Do nothing** — Readers guess.
+
+**Recommendation: [A]** — State the definition precisely.
+
+---
+
+**Issue 18: Domain + @groups interaction not clarified**
+Severity: ADVISORY
+Resolution type: JUDGMENT CALL
+
+Section 3.14 says groups are "combined with the `group` argument" but does not
+specify how domain filtering interacts with grouping. When both are present, the
+spec should clarify that the domain filter is applied uniformly across all group
+strata.
+
+Options:
+- **[A]** Add to Section 3.14: "When both domain filtering and `@groups` are
+  active, the domain filter is applied uniformly to all group strata. The GLM is
+  fit on rows matching both domain and non-missing group values." — Effort: low,
+  Risk: low, Impact: clarity, Maintenance: none
+- **[C] Do nothing** — Behavior is implicit in `survey_glm()`.
+
+**Recommendation: [A]** — One clarifying sentence.
+
+---
+
+#### Lens 5 — Established Practice and Literature
+
+**Issue 19: AME choice for non-gaussian families not documented as intentional
+deviation from survey package**
+Severity: REQUIRED
+Resolution type: JUDGMENT CALL
+
+The spec uses `marginaleffects::avg_slopes()` for non-gaussian families (Section
+3.8.1), returning average marginal effects on the response scale (e.g., probability
+differences for logistic). The `survey` package reports coefficients on the **link
+scale** (log-odds for logistic). This is a deliberate design choice but the spec
+does not document it as a deviation or explain the rationale.
+
+Options:
+- **[A]** Add to Section 3.8 or roxygen `@details`: "For non-gaussian families,
+  `get_diffs()` reports average marginal effects (AMEs) on the response scale, not
+  coefficients on the link scale. This departs from `survey::svyglm()` convention
+  and is intentional: AMEs are more interpretable for treatment effect reporting
+  (see Gomila 2021)." — Effort: low, Risk: low, Impact: users understand the
+  design choice, Maintenance: none
+- **[B]** Add `scale` argument (`"ame"` or `"link"`) for user control. — Effort:
+  medium, Risk: medium, Impact: flexibility, Maintenance: ongoing
+- **[C] Do nothing** — SOP documents the choice separately.
+
+**Recommendation: [A]** — Document the deviation in the spec itself.
+
+Source: Gomila, R. (2021). *Journal of Experimental Psychology: General*,
+150(3):700-709 [verify]; SOP Section 7.3.
+
+---
+
+**Issue 20: P-value adjustment scope with groups undefined**
+Severity: REQUIRED
+Resolution type: JUDGMENT CALL
+
+Section 3.9 says: "Apply `stats::p.adjust(p_values, method = pval_adj)` to
+comparison rows only." When `group` is active, the output has multiple comparison
+rows per group. The spec does not define whether p-adjustment is:
+
+1. Applied separately within each group (each group's comparisons adjusted
+   independently)
+2. Applied globally across all comparison rows (pooled across groups)
+
+These produce different adjusted p-values. The SOP (Section 6.4) recommends BH
+adjustment for "multiple DVs and multiple subgroups" — suggesting group-stratified
+adjustment.
+
+Options:
+- **[A]** Apply adjustment separately within each group. Document: "When `group` is
+  active, `p.adjust()` is applied independently within each group stratum. The
+  multiple testing correction applies to comparisons against the reference within a
+  group, not across groups." — Effort: low, Risk: low, Impact: correctness,
+  Maintenance: none
+- **[B]** Apply adjustment globally across all comparison rows. — Effort: low,
+  Risk: low, Impact: more conservative, Maintenance: none
+- **[C] Do nothing** — Implementer decides.
+
+**Recommendation: [A]** — Group-stratified adjustment is the standard for subgroup
+analysis and aligns with the SOP.
+
+Source: Benjamini & Hochberg (1995), JRSS-B 57(1):289-300 [verify]; SOP Section
+6.4.
+
+---
+
+**Issue 21: Percentage change — no variance, small-ref caveat, not standard
+estimand**
+Severity: REQUIRED
+Resolution type: UNAMBIGUOUS
+
+*Cross-lens: flagged by Lens 1 (small reference mean), Lens 2 (no variance), and
+Lens 5 (not a standard survey estimand).*
+
+Section 3.10 computes `pct_change = estimate / reference_mean` as a point estimate.
+Three concerns:
+
+1. **No variance:** The `se`, `ci_low`, `ci_high` columns apply to `estimate`, not
+   `pct_change`. The spec does not state that `pct_change` has no uncertainty
+   quantification.
+2. **Small reference mean:** When `reference_mean` is very small (but nonzero),
+   `pct_change` becomes very large and potentially misleading. The spec only
+   handles the exact-zero case.
+3. **Not a standard survey estimand:** The survey literature does not define
+   `estimate / reference_mean` as a formal estimand with known statistical
+   properties.
+
+Options:
+- **[A]** Add documentation to Section 3.10:
+  - "Only the point estimate `pct_change` is reported. SE and CI are not computed
+    for `pct_change`; users requiring confidence intervals should apply the delta
+    method to `estimate` and `reference_mean`."
+  - "Percentage change is substantively interpretable only when `reference_mean` is
+    a meaningful nonzero baseline. For outcomes with baseline near zero, consider
+    reporting the absolute difference (`estimate`) instead."
+  — Effort: low, Risk: low, Impact: clarity and statistical integrity, Maintenance:
+  none
+- **[B]** Compute delta-method SE/CI for `pct_change`. — Effort: high, Risk:
+  medium, Impact: completeness, Maintenance: substantial
+- **[C] Do nothing** — Users figure it out.
+
+**Recommendation: [A]** — Document the limitations. Computing variance for the
+ratio adds substantial complexity for an optional display feature.
+
+Source: Korn & Graubard (1999), *Analysis of Health Surveys* (delta method for
+ratios) [verify].
+
+---
+
+**Issue 22: Clean path coefficient = AME equivalence assumption not documented**
+Severity: REQUIRED
+Resolution type: UNAMBIGUOUS
+
+The spec uses two different estimation methods that produce identical results only
+under specific conditions. The clean path (Section 3.7) extracts OLS coefficients;
+the marginaleffects path (Section 3.8) computes AMEs. These are mathematically
+identical **only when**: (a) family is Gaussian with identity link, (b) the model
+has a single factor predictor (no covariates), (c) no interactions.
+
+The routing logic (Section 7.2) enforces these conditions, but the spec does not
+explicitly state this equivalence or explain why it holds.
+
+Options:
+- **[A]** Add to Section 3.7: "This equivalence (coefficient = AME) holds only for
+  Gaussian/identity + factor-only models. The routing logic (Section 7.2)
+  guarantees these conditions. If the routing conditions change, the clean path
+  must be re-validated." — Effort: low, Risk: low, Impact: clarity, Maintenance:
+  none
+- **[C] Do nothing** — Readers reverse-engineer the routing logic.
+
+**Recommendation: [A]** — Make the assumption explicit.
+
+Source: Angrist & Pischke (2009), *Mostly Harmless Econometrics* [verify].
+
+---
+
+**Issue 23: CI bounds unaffected by pval_adj not documented for users**
+Severity: ADVISORY
+Resolution type: UNAMBIGUOUS
+
+Section 3.9 correctly states CIs are not recalculated after p-value adjustment, but
+this should be surfaced in roxygen documentation so users don't assume CIs reflect
+the adjusted significance level.
+
+Options:
+- **[A]** Add to roxygen `@details`: "Confidence intervals reflect the specified
+  `conf_level` and are not affected by p-value adjustment." — Effort: low, Risk:
+  none, Impact: prevents confusion, Maintenance: none
+- **[C] Do nothing** — Spec is clear; roxygen inherits from spec.
+
+**Recommendation: [A]** — One sentence.
+
+---
+
+**Issue 24: Unweighted `n` vs effective sample size distinction**
+Severity: ADVISORY
+Resolution type: JUDGMENT CALL
+
+Section 5.2 includes an `n` column: unweighted observation count. The `survey`
+package does not report unweighted N in estimation output. For design-based
+inference, the "effective sample size" (`n_eff = (sum(w))^2 / sum(w^2)`) is more
+relevant than the raw count.
+
+The unweighted `n` is useful for quality assurance (small cell detection, per the
+`surveycore_warning_small_cell` at n < 30), but users might misinterpret it as a
+design-effective sample size.
+
+Options:
+- **[A]** Document: "`n` reports unweighted counts and is provided primarily for
+  quality assurance. Inference (estimates, SEs, p-values) is design-based and uses
+  weighted data." — Effort: low, Risk: low, Impact: clarity, Maintenance: none
+- **[B]** Add `n_eff` column alongside `n`. — Effort: medium, Risk: low, Impact:
+  completeness, Maintenance: ongoing
+- **[C] Do nothing** — Users understand from context.
+
+**Recommendation: [A]** — Document the distinction.
+
+Source: Korn & Graubard (1999) (effective sample size definition) [verify].
+
+---
+
+## Summary (Pass 1)
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 3 |
+| REQUIRED | 15 |
+| ADVISORY | 6 |
+
+**Total issues:** 24
+
+| # | Title | Lens | Severity | Resolution |
+|---|---|---|---|---|
+| 1 | Contrast function not validated | 1, 5 | BLOCKING | UNAMBIGUOUS |
+| 2 | Interaction model not explained | 1 | REQUIRED | UNAMBIGUOUS |
+| 3 | SRS covariance matrix verification | 1 | REQUIRED | UNAMBIGUOUS |
+| 4 | Reference row defensive validation | 1 | ADVISORY | UNAMBIGUOUS |
+| 5 | Clean path variance not documented | 2 | REQUIRED | UNAMBIGUOUS |
+| 6 | Delta method chain not documented | 1, 2 | REQUIRED | UNAMBIGUOUS |
+| 7 | Non-gaussian oracle tests missing | 2 | REQUIRED | UNAMBIGUOUS |
+| 8 | Marginaleffects test tolerances | 2 | REQUIRED | UNAMBIGUOUS |
+| 9 | P-value distribution t vs Z | 3 | BLOCKING | JUDGMENT CALL |
+| 10 | DF formula not specified | 1, 3 | REQUIRED | UNAMBIGUOUS |
+| 11 | Labels by estimation path | 3 | REQUIRED | JUDGMENT CALL |
+| 12 | Non-integer df preservation | 3 | REQUIRED | UNAMBIGUOUS |
+| 13 | Reference row NA semantics | 3 | ADVISORY | UNAMBIGUOUS |
+| 14 | Replicate domain convergence | 4 | BLOCKING | UNAMBIGUOUS |
+| 15 | Empty domain error undocumented | 4 | REQUIRED | UNAMBIGUOUS |
+| 16 | n column with domain filtering | 4 | REQUIRED | JUDGMENT CALL |
+| 17 | n_respondents ambiguous | 4 | REQUIRED | UNAMBIGUOUS |
+| 18 | Domain + groups interaction | 4 | ADVISORY | JUDGMENT CALL |
+| 19 | AME deviation not documented | 5 | REQUIRED | JUDGMENT CALL |
+| 20 | P-value adjustment scope | 5 | REQUIRED | JUDGMENT CALL |
+| 21 | Percentage change limitations | 1, 2, 5 | REQUIRED | UNAMBIGUOUS |
+| 22 | Coefficient = AME equivalence | 1, 5 | REQUIRED | UNAMBIGUOUS |
+| 23 | CI unaffected by pval_adj | 5 | ADVISORY | UNAMBIGUOUS |
+| 24 | Unweighted n vs n_eff | 5 | ADVISORY | JUDGMENT CALL |
+
+**Assessment:** The estimation architecture is sound — `get_diffs()` correctly
+delegates to `survey_glm()` for variance and `marginaleffects` for AMEs. The three
+blocking issues are: (1) missing contrast validation in the clean path, which would
+silently produce wrong reference means under non-treatment contrasts; (2)
+inconsistent p-value distributions between the t-based clean path and Z-based
+marginaleffects path; and (3) unspecified behavior when replicate domain subsets are
+degenerate in the marginaleffects path. The remaining 15 required issues are
+documentation gaps, missing oracle tests, and underspecified edge cases — all
+addressable without architectural changes.

--- a/plans/spec-nonprob-zero-weights.md
+++ b/plans/spec-nonprob-zero-weights.md
@@ -1,0 +1,502 @@
+# Spec: Allow Zero Weights in `survey_nonprob`
+
+**Version:** 0.3
+**Date:** 2026-03-18
+**Status:** Approved
+**Branch identifier:** `nonprob-zero-weights`
+**Related files:** `plans/spec-review-nonprob-zero-weights.md` (after review),
+`plans/decisions-nonprob-zero-weights.md` (after resolve)
+
+---
+
+## Document Purpose
+
+This document is the single source of truth for relaxing the `survey_nonprob`
+S7 validator to allow zero weights. This is a prerequisite for surveywts
+Change 2 (`adjust_nonresponse()` zero-weight nonrespondents). The surveywts
+spec lives at `../surveywts/plans/spec-phase-0-fixes.md` §III.
+
+This spec does NOT repeat rules defined in:
+- `code-style.md` — formatting, pipe, error structure, S7 patterns
+- `testing-standards.md` — `test_that()` scope, coverage targets, assertion patterns
+- `testing-surveycore.md` — `test_invariants()`, layer 1 error testing
+
+Those rules apply by reference.
+
+---
+
+## I. Scope
+
+### Deliverables
+
+| # | Change | Severity |
+|---|--------|----------|
+| 1 | Relax `survey_nonprob` validator condition 4: allow zero weights | High |
+| 2 | Update `test_invariants()` for zero-weight `survey_nonprob` objects | Medium |
+| 3 | Add new error class `surveycore_error_weights_negative` | Medium |
+
+### Non-Deliverables
+
+| Item | Reason |
+|------|--------|
+| `survey_taylor` validator changes | `survey_taylor` retains strict positivity (> 0) — zero weights are not meaningful for probability designs |
+| `survey_replicate` validator changes | Same — replicate designs require positive weights |
+| `as_survey_nonprob()` constructor changes | Constructor still requires positive weights at creation time; zeros only arise from post-construction operations (e.g., nonresponse adjustment) |
+| Zero-weight filtering in analysis functions | Analysis functions already handle zero weights via the survey package delegation; no surveycore changes needed |
+
+### Why This Change
+
+S7 re-triggers the class validator on every property assignment via `@<-`.
+When surveywts's `adjust_nonresponse()` sets nonrespondent weights to 0 on a
+`survey_nonprob` object (`design@data[[wt_col]] <- new_weights`), the current
+validator rejects the update because it enforces strict positivity. Relaxing
+this validator is the minimal change that unblocks the surveywts workflow.
+
+---
+
+## II. Architecture
+
+### Files Modified
+
+| File | Change |
+|------|--------|
+| `R/core-classes.R` | Split `survey_nonprob` validator condition 4 into two checks |
+| `tests/testthat/helper-test-data.R` | Update `test_invariants()` weight check for `survey_nonprob` |
+| `tests/testthat/test-s7-classes.R` | Update/add validator tests for `survey_nonprob` |
+| `plans/error-messages.md` | Add `surveycore_error_weights_negative` |
+
+No new files. No deleted files.
+
+---
+
+## III. Change 1 — Relax `survey_nonprob` Validator Condition 4
+
+### Current Behavior (`R/core-classes.R` lines 700–710)
+
+Condition 4 rejects all non-NA weights that are zero **or** negative:
+
+```r
+n_bad <- sum(non_na <= 0)
+if (n_bad > 0L) {
+  cli::cli_abort(
+    c(
+      "x" = "Weight column {.field {weights_var}} has {n_bad} non-positive value(s).",
+      "i" = "All non-NA weights must be strictly greater than 0.",
+      "v" = "Remove or replace rows where {.field {weights_var}} is 0 or negative."
+    ),
+    class = "surveycore_error_weights_nonpositive"
+  )
+}
+```
+
+### New Behavior
+
+Split condition 4 into two checks — 4a and 4b:
+
+**Condition 4a — No negative weights:**
+
+```r
+n_neg <- sum(non_na < 0)
+if (n_neg > 0L) {
+  cli::cli_abort(
+    c(
+      "x" = "Weight column {.field {weights_var}} has {n_neg} negative value(s).",
+      "i" = "All non-NA weights must be non-negative (>= 0).",
+      "v" = "Remove or replace rows where {.field {weights_var}} is negative."
+    ),
+    class = "surveycore_error_weights_negative"
+  )
+}
+```
+
+**Condition 4b — At least one positive weight:**
+
+```r
+if (!any(non_na > 0)) {
+  cli::cli_abort(
+    c(
+      "x" = "Weight column {.field {weights_var}} has no positive values.",
+      "i" = "At least one non-NA weight must be greater than 0.",
+      "v" = "Check that {.field {weights_var}} contains valid survey weights."
+    ),
+    class = "surveycore_error_weights_all_zero"
+  )
+}
+```
+
+### Rationale for Two Separate Checks
+
+- **4a (negative)** uses a new class `surveycore_error_weights_negative` because
+  the existing `surveycore_error_weights_nonpositive` name implies zero is also
+  rejected. A distinct class name makes the relaxed semantics explicit and
+  avoids confusion with `survey_taylor`'s validator, which retains the original
+  `surveycore_error_weights_nonpositive` behavior.
+
+- **4b (all zero)** reuses the existing `surveycore_error_weights_all_zero` class.
+  Condition 3 handles the "all NA" case and uses the same class — but conditions
+  3 and 4b are mutually exclusive (if condition 3 fires, condition 4b is never
+  reached), so the shared class is unambiguous. **Note:** the message text
+  intentionally differs between the three call sites that use this class:
+  condition 3 says `"has no non-NA values"`, condition 4b says `"has no positive
+  values"`, and `.validate_weights()` says `"are zero or missing"`. The class
+  semantics are identical for programmatic `tryCatch(class=)` usage; only the
+  human-readable text varies by context.
+
+### What Does NOT Change
+
+- **`survey_taylor` validator** (`R/core-classes.R` lines ~420–470): retains
+  `surveycore_error_weights_nonpositive` with the `<= 0` check. Zero weights
+  are not meaningful for probability survey designs.
+
+- **`survey_replicate` validator**: retains strict positivity.
+
+- **`as_survey_nonprob()` constructor** (`R/core-constructors.R`): the constructor
+  calls `.validate_weights()` (`R/core-validators.R`, line ~135, `<= 0` check)
+  which enforces strict positivity. **Do not modify `.validate_weights()`** —
+  it is correct as-is. You should not create a `survey_nonprob` with zero
+  weights. Zeros only arise from post-construction operations like nonresponse
+  adjustment, which bypass the constructor and trigger only the S7 validator.
+
+- **Conditions 1–3** of the `survey_nonprob` validator: unchanged.
+
+---
+
+## IV. Change 2 — Update `test_invariants()`
+
+**Scope:** Update only the `survey_nonprob` branch of `test_invariants()`
+(~line 287 in `helper-test-data.R`). The main branch (~line 359, used by
+`survey_taylor`, `survey_replicate`, `survey_twophase`) retains strict `> 0`.
+The two branches are separated by an early `return(invisible(design))` on
+~line 301.
+
+### Current Behavior (`tests/testthat/helper-test-data.R` line ~287, `survey_nonprob` branch only)
+
+```r
+testthat::expect_true(
+  all(wt_col[!is.na(wt_col)] > 0),
+  label = "weight column has all positive non-NA values"
+)
+```
+
+### New Behavior
+
+```r
+testthat::expect_true(
+  all(wt_col[!is.na(wt_col)] >= 0),
+  label = "weight column has all non-negative non-NA values"
+)
+testthat::expect_true(
+  any(wt_col[!is.na(wt_col)] > 0),
+  label = "weight column has at least one positive non-NA value"
+)
+```
+
+This mirrors the relaxed validator: non-negative (>= 0) with at least one
+positive. Post-nonresponse test blocks will now pass the invariant check
+while still catching invalid states (all-zero, negative).
+
+---
+
+## V. Error Table Changes
+
+### New Error Class
+
+| Class | Thrown by | Condition | Message Template |
+|-------|-----------|-----------|------------------|
+| `surveycore_error_weights_negative` | `survey_nonprob` validator (condition 4a) | Any non-NA weight is negative (< 0) | `"x" = "Weight column {.field {weights_var}} has {n_neg} negative value(s)."`, `"i" = "All non-NA weights must be non-negative (>= 0)."`, `"v" = "Remove or replace rows where {.field {weights_var}} is negative."` |
+
+### Existing Class Reused
+
+| Class | New usage |
+|-------|-----------|
+| `surveycore_error_weights_all_zero` | `survey_nonprob` validator condition 4b — all non-NA weights are zero (no positive values). Already used by condition 3 (all NA); conditions are mutually exclusive. |
+
+### Existing Class Narrowed
+
+| Class | Change |
+|-------|--------|
+| `surveycore_error_weights_nonpositive` | No longer thrown by `survey_nonprob` validator. Still thrown by `survey_taylor` and `survey_replicate` validators (unchanged). |
+
+### Exact `plans/error-messages.md` Edits
+
+1. **Row 33** (`surveycore_error_weights_nonpositive`): Update Function column from
+   `S7 validator (survey_taylor)` to `S7 validator (survey_taylor, survey_replicate)`.
+   Add note: "No longer thrown by `survey_nonprob` validator (see row 101,
+   `surveycore_error_weights_negative`)."
+
+2. **Row 10** (`surveycore_error_weights_all_zero`): Add note that this class is also
+   thrown by the `survey_nonprob` validator condition 4b (all non-NA weights are zero,
+   no positive values).
+
+3. **Row 101** (new): Add `surveycore_error_weights_negative` — thrown by
+   `survey_nonprob` validator (condition 4a), condition: any non-NA weight is negative
+   (< 0), with full message template from §V above.
+
+---
+
+## VI. Testing
+
+### Workflow path — post-construction weight assignment (in `test-s7-classes.R`)
+
+This is the primary use case: `as_survey_nonprob()` creates a valid object with
+positive weights, then `@data<-` assignment introduces zeros (simulating
+surveywts `adjust_nonresponse()`). S7 re-triggers the validator on `@data<-`.
+
+```r
+test_that("survey_nonprob allows zero weights after post-construction assignment", {
+  df <- data.frame(x = 1:5, w = c(1, 2, 3, 4, 5))
+  obj <- as_survey_nonprob(df, weights = w)
+
+  # Simulate surveywts adjust_nonresponse() setting zeros
+  new_data <- obj@data
+  new_data$w <- c(1, 0, 0, 4, 0)
+  obj@data <- new_data  # This triggers S7 re-validation
+
+  test_invariants(obj)
+  expect_equal(sum(obj@data$w == 0), 3L)
+})
+```
+
+### Validator tests — Layer 1 (raw constructor, in `test-s7-classes.R`)
+
+These test the S7 validator directly. Use the raw `survey_nonprob()` constructor
+with the **full `variables` list** (all keys present, per `code-style.md §2`).
+Layer 1 tests use `class=` only — no snapshot (per `testing-surveycore.md`).
+
+**Happy path — zero weights accepted:**
+
+```r
+test_that("survey_nonprob validator accepts zero weights with at least one positive", {
+  df <- data.frame(x = 1:5, w = c(1, 0, 0, 2, 0))
+  obj <- survey_nonprob(
+    data = df,
+    variables = list(
+      weights        = "w",
+      probs_provided = FALSE,
+      ids            = NULL,
+      strata         = NULL,
+      fpc            = NULL,
+      nest           = FALSE,
+      visible_vars   = NULL
+    )
+  )
+  test_invariants(obj)
+  expect_s3_class(obj@data, "data.frame")
+  expect_equal(sum(obj@data$w == 0), 3L)
+})
+```
+
+**Error path — negative weights rejected (condition 4a):**
+
+```r
+test_that("survey_nonprob validator rejects negative weights", {
+  df <- data.frame(x = 1:3, w = c(1, -0.5, 2))
+  expect_error(
+    survey_nonprob(
+      data = df,
+      variables = list(
+        weights        = "w",
+        probs_provided = FALSE,
+        ids            = NULL,
+        strata         = NULL,
+        fpc            = NULL,
+        nest           = FALSE,
+        visible_vars   = NULL
+      )
+    ),
+    class = "surveycore_error_weights_negative"
+  )
+})
+```
+
+**Error path — all-zero weights rejected (condition 4b):**
+
+```r
+test_that("survey_nonprob validator rejects all-zero weights", {
+  df <- data.frame(x = 1:3, w = c(0, 0, 0))
+  expect_error(
+    survey_nonprob(
+      data = df,
+      variables = list(
+        weights        = "w",
+        probs_provided = FALSE,
+        ids            = NULL,
+        strata         = NULL,
+        fpc            = NULL,
+        nest           = FALSE,
+        visible_vars   = NULL
+      )
+    ),
+    class = "surveycore_error_weights_all_zero"
+  )
+})
+```
+
+**Edge cases:**
+
+```r
+test_that("survey_nonprob validator accepts single positive weight among zeros", {
+  df <- data.frame(x = 1:5, w = c(0, 0, 0, 0, 0.001))
+  obj <- survey_nonprob(
+    data = df,
+    variables = list(
+      weights        = "w",
+      probs_provided = FALSE,
+      ids            = NULL,
+      strata         = NULL,
+      fpc            = NULL,
+      nest           = FALSE,
+      visible_vars   = NULL
+    )
+  )
+  test_invariants(obj)
+})
+
+test_that("survey_nonprob validator accepts mix of zeros and NAs with one positive", {
+  df <- data.frame(x = 1:4, w = c(0, NA, 1, 0))
+  obj <- survey_nonprob(
+    data = df,
+    variables = list(
+      weights        = "w",
+      probs_provided = FALSE,
+      ids            = NULL,
+      strata         = NULL,
+      fpc            = NULL,
+      nest           = FALSE,
+      visible_vars   = NULL
+    )
+  )
+  test_invariants(obj)
+})
+
+test_that("survey_nonprob validator rejects mix of zeros and negatives", {
+  df <- data.frame(x = 1:3, w = c(0, -1, 0))
+  expect_error(
+    survey_nonprob(
+      data = df,
+      variables = list(
+        weights        = "w",
+        probs_provided = FALSE,
+        ids            = NULL,
+        strata         = NULL,
+        fpc            = NULL,
+        nest           = FALSE,
+        visible_vars   = NULL
+      )
+    ),
+    class = "surveycore_error_weights_negative"
+  )
+})
+
+test_that("survey_nonprob validator rejects all-zero weights with NAs", {
+  df <- data.frame(x = 1:3, w = c(0, NA, 0))
+  expect_error(
+    survey_nonprob(
+      data = df,
+      variables = list(
+        weights        = "w",
+        probs_provided = FALSE,
+        ids            = NULL,
+        strata         = NULL,
+        fpc            = NULL,
+        nest           = FALSE,
+        visible_vars   = NULL
+      )
+    ),
+    class = "surveycore_error_weights_all_zero"
+  )
+})
+```
+
+### Existing Tests — Action Table
+
+The following table lists all existing `survey_nonprob` weight validation tests
+and the required action for each. Layer 1 = S7 validator (raw `survey_nonprob()`),
+Layer 3 = constructor (`as_survey_nonprob()`).
+
+| Line | File | Test Name | Layer | Current Class | Action |
+|------|------|-----------|-------|---------------|--------|
+| 748 | `test-s7-classes.R` | `survey_nonprob validator rejects non-numeric weight column` | 1 | `weights_not_numeric` | **Unchanged** |
+| 1797 | `test-constructors.R` | `survey_nonprob validator rejects non-numeric weight column` | 1 | `weights_not_numeric` | **Delete** (duplicate of line 748) |
+| 1816 | `test-constructors.R` | `survey_nonprob validator rejects all-NA weight column` | 1 | `weights_all_zero` | **Unchanged** |
+| 1835 | `test-constructors.R` | `survey_nonprob validator rejects non-positive weight column` | 1 | `weights_nonpositive` | **Change class to `weights_negative`; rename test to `"survey_nonprob validator rejects negative weights"`** (input has negatives, not zeros; "non-positive" is no longer accurate) |
+| 1672 | `test-constructors.R` | `as_survey_nonprob() rejects non-positive weights` | 3 | `weights_nonpositive` | **Unchanged** (`.validate_weights()` still rejects zeros; dual pattern retained) |
+| 1936 | `test-constructors.R` | `as_survey_nonprob() rejects non-numeric weight column` | 3 | `weights_not_numeric` | **Unchanged** |
+
+Key points:
+- `survey_taylor` tests with `surveycore_error_weights_nonpositive` are **unchanged**
+- Layer 3 constructor tests are **unchanged** — the constructor still rejects zeros
+- Only one existing test changes class; one is deleted as a duplicate
+
+### Snapshot Updates
+
+No existing snapshots are affected by this change. The S7 validator tests
+(Layer 1) use `class=` only — no snapshot. The Layer 3 constructor test at
+line 1672 is unchanged (`.validate_weights()` still rejects zeros with the
+same message). New validator tests also use `class=` only per Layer 1
+convention.
+
+### `test_invariants()` Verification
+
+Add a test that `test_invariants()` itself works correctly with zero-weight
+`survey_nonprob` objects. Uses the workflow path (create via constructor, then
+mutate weights):
+
+```r
+test_that("test_invariants() passes for survey_nonprob with zero weights", {
+  df <- data.frame(x = 1:5, w = c(1, 2, 3, 4, 5))
+  obj <- as_survey_nonprob(df, weights = w)
+
+  # Introduce zeros via @data<- (triggers S7 re-validation)
+  new_data <- obj@data
+  new_data$w <- c(1, 0, 0, 2, 0)
+  obj@data <- new_data
+
+  expect_no_error(test_invariants(obj))
+})
+```
+
+---
+
+## VII. Quality Gates
+
+All of the following must be true before this spec is considered complete:
+
+- [ ] `survey_nonprob` validator condition 4 split into 4a (negative) and 4b (all-zero)
+- [ ] Zero weights accepted by `survey_nonprob` validator when at least one positive weight exists
+- [ ] Negative weights rejected with `surveycore_error_weights_negative`
+- [ ] All-zero weights (no positive) rejected with `surveycore_error_weights_all_zero`
+- [ ] `survey_taylor` and `survey_replicate` validators unchanged (strict > 0)
+- [ ] `test_invariants()` updated: `>= 0` with `any > 0` for `survey_nonprob` path
+- [ ] `plans/error-messages.md` updated with `surveycore_error_weights_negative`
+- [ ] All existing `survey_nonprob` weight tests updated for new error classes
+- [ ] New happy-path and edge-case tests for zero-weight `survey_nonprob` objects
+- [ ] `R CMD check`: 0 errors, 0 warnings, <=2 notes
+- [ ] 98%+ line coverage maintained
+- [ ] All snapshot files reviewed and approved
+
+---
+
+## VIII. Integration: surveycore <-> surveywts
+
+### Dependency
+
+surveywts `adjust_nonresponse()` (Change 2 in `../surveywts/plans/spec-phase-0-fixes.md`)
+depends on this change. Specifically:
+
+1. `adjust_nonresponse()` sets nonrespondent weights to 0 on `survey_nonprob` objects
+2. S7 re-triggers the `survey_nonprob` validator on `@data<-` assignment
+3. Without this relaxation, the validator rejects the zero weights
+
+### Release Order
+
+1. This surveycore change must land on `develop` first
+2. surveywts pins `surveycore (>= current_version)` in DESCRIPTION
+3. During development, surveywts uses `Remotes:` to point to surveycore's dev branch
+
+### No Impact on Other surveycore Consumers
+
+- `survey_taylor` and `survey_replicate` validators are untouched
+- `as_survey_nonprob()` constructor still requires positive weights at creation time
+- Analysis functions (`get_means()`, etc.) are unaffected — they delegate to
+  the survey package which handles zero weights correctly

--- a/plans/spec-review-get-diffs.md
+++ b/plans/spec-review-get-diffs.md
@@ -1,0 +1,1157 @@
+# Spec Review: get-diffs
+
+## Pass 1 (2026-03-16)
+
+### New Issues
+
+#### Section: I. Scope
+
+No new issues found.
+
+---
+
+#### Section: II. Architecture
+
+**Issue 1: Test file naming convention inconsistent with Phase 1**
+Severity: SUGGESTION
+Violates Phase 1 naming convention in `testing-surveycore.md`
+
+The spec defines test files as:
+```
+test-diffs.R
+test-diffs-numerical.R
+test-diffs-marginaleffects.R
+```
+
+Phase 1 analysis test files follow the `test-analysis-{function}.R` convention (e.g.,
+`test-analysis-means.R`, `test-analysis-freqs.R`). This inconsistency could confuse
+contributors navigating the test directory.
+
+Options:
+- **[A]** Rename to `test-analysis-diffs.R`, `test-analysis-diffs-numerical.R`,
+  `test-analysis-diffs-marginaleffects.R` — Effort: low, Risk: low, Impact: consistency,
+  Maintenance: none
+- **[C] Do nothing** — Files work regardless of naming.
+
+**Recommendation: [A]** — Consistency costs nothing and helps discoverability.
+
+---
+
+**Issue 2: `.build_diffs_meta()` should delegate to `.build_meta()` for common fields**
+Severity: REQUIRED
+Violates `engineering-preferences.md` §1 (DRY)
+
+Section 2.2 defines `.build_diffs_meta()` as constructing the full `.meta` list. But
+`.build_meta()` in `analysis-helpers.R` already derives `design_type` and `n_respondents`
+from the design object and merges with function-specific `meta_args`. The spec does not
+reference `.build_meta()` or explain why a separate helper is needed.
+
+If `.build_diffs_meta()` duplicates the design-type derivation logic
+(`S7::S7_inherits(design, survey_taylor)` → `"taylor"`, etc.), any future change to
+design type mapping must be updated in two places.
+
+Options:
+- **[A]** Specify that `.build_diffs_meta()` calls `.build_meta(design, meta_args)`
+  internally, passing diffs-specific fields via `meta_args`. The helper's role is
+  assembling the `meta_args` list, not deriving `design_type`. — Effort: low, Risk: low,
+  Impact: DRY, Maintenance: none
+- **[B]** Remove `.build_diffs_meta()` entirely; build `meta_args` inline in
+  `get_diffs()` and pass to `.build_meta()` directly (matching the Phase 1 pattern in
+  `get_means()`). — Effort: low, Risk: low, Impact: simpler, Maintenance: none
+- **[C] Do nothing** — Duplicate logic.
+
+**Recommendation: [B]** — Phase 1 functions build `meta_args` inline and pass to
+`.build_meta()`. A separate helper is unnecessary abstraction for a single call site.
+
+---
+
+**Issue 3: `DIFFS_META_KEYS` constant not defined**
+Severity: REQUIRED
+Violates Phase 1 pattern in `analysis-helpers.R`
+
+Phase 1 defines `*_META_KEYS` constants for each `get_*()` function (e.g.,
+`MEANS_META_KEYS`, `FREQS_META_KEYS`). These are the single source of truth for each
+function's meta contract and are passed to `.make_result_tibble()` for validation. The
+spec does not define a `DIFFS_META_KEYS` constant or discuss how it integrates with
+`.make_result_tibble()`.
+
+The `get_diffs()` `.meta` contract (Section IV) has keys: `group`, `x`, `treats`,
+`covariates`, `family`, `link`, `pval_adj`, `estimate_method`, `mean_method`,
+`estimate_scale`. The constant should include all function-specific keys.
+
+Options:
+- **[A]** Add to Section 2.2 or IV: define `DIFFS_META_KEYS` as
+  `c("group", "x", "treats", "covariates", "family", "link", "pval_adj",
+  "estimate_method", "mean_method", "estimate_scale")` in `analysis-helpers.R`. —
+  Effort: low, Risk: low, Impact: consistency with Phase 1 pattern, Maintenance: none
+- **[C] Do nothing** — Miss the validation.
+
+**Recommendation: [A]** — Follow the established pattern.
+
+---
+
+#### Section: III. Function Specification
+
+**Issue 4: Error class names diverge from existing codebase conventions**
+Severity: REQUIRED
+Violates `engineering-preferences.md` §1 (DRY) and `error-messages.md` as single source
+of truth
+
+The spec introduces error classes that duplicate the function of existing classes:
+
+| Spec error class | Existing codebase class | Used in |
+|---|---|---|
+| `surveycore_error_not_survey_object` | `surveycore_error_unsupported_class` | `.check_unsupported_class()` (row 64) |
+| `surveycore_error_x_not_numeric` | `surveycore_error_non_numeric_variable` | `get_means()`, `get_totals()` etc. (row 43) |
+| `surveycore_error_x_single` | `surveycore_error_wrong_variable_count` | `get_means()` validation |
+
+Creating different class names for identical checks means:
+1. Users catching errors by class must know two names for the same condition
+2. Tests are harder to grep/audit
+3. `plans/error-messages.md` grows with synonyms
+
+Options:
+- **[A]** Reuse existing class names. Replace `surveycore_error_not_survey_object` with
+  `surveycore_error_unsupported_class` (and reuse `.check_unsupported_class()`). Replace
+  `surveycore_error_x_not_numeric` with `surveycore_error_non_numeric_variable`. Replace
+  `surveycore_error_x_single` with `surveycore_error_wrong_variable_count`. Keep
+  `surveycore_error_treats_single` as new (no existing equivalent). — Effort: low,
+  Risk: low, Impact: consistency, Maintenance: none
+- **[C] Do nothing** — New synonyms accumulate.
+
+**Recommendation: [A]** — Reuse the existing classes. Only add genuinely new classes to
+`error-messages.md`.
+
+---
+
+**Issue 5: Missing `name_style` argument breaks API uniformity with Phase 1**
+Severity: REQUIRED
+Violates `engineering-preferences.md` §5 (explicit over clever) and API coherence lens
+
+Every Phase 1 `get_*()` function accepts `name_style = "surveycore"` (default) or
+`"broom"`. The `get_diffs()` spec omits this argument entirely. Users who build pipelines
+like `get_means(d, x, name_style = "broom") |> bind_rows(get_diffs(d, x, treats))` would
+find inconsistent column naming.
+
+The `get_diffs()` output has columns that map directly to broom conventions: `estimate`
+(already broom-named), `se` → `std.error`, `ci_low` → `conf.low`, `ci_high` →
+`conf.high`, `p_value` → `p.value`. The existing `.apply_name_style()` handles this
+mapping.
+
+Options:
+- **[A]** Add `name_style = "surveycore"` to the signature (between `na.rm` and `...`).
+  Apply `.apply_name_style()` as the last step before return. Also enables reuse of
+  `.validate_shared_args()` for `conf_level`, `decimals`, `na.rm`, and `name_style`
+  validation. — Effort: low, Risk: low, Impact: API consistency, Maintenance: none
+- **[C] Do nothing** — API inconsistency.
+
+**Recommendation: [A]** — Add the argument and reuse the shared validator.
+
+---
+
+**Issue 6: `na.rm` validation not specified**
+Severity: REQUIRED
+Violates Phase 1 validation contract
+
+Section 3.12 translates `na.rm` to `na.action` for `survey_glm()`, but does not specify
+validation when `na.rm` is not `TRUE` or `FALSE` (e.g., `na.rm = NA`, `na.rm = "yes"`,
+`na.rm = 42`). In Phase 1, `.validate_shared_args()` validates `na.rm` with
+`surveycore_error_na_rm_not_logical` (error-messages.md row 81).
+
+If `get_diffs()` passes an invalid `na.rm` value to `survey_glm()` without validation,
+the `na.action` translation (`ifelse(na.rm, na.omit, na.fail)`) produces unexpected
+results.
+
+Options:
+- **[A]** Add `na.rm` to the validation step. If `name_style` is added (Issue 5), reuse
+  `.validate_shared_args()` which already validates `na.rm`. Otherwise, add inline
+  validation with `surveycore_error_na_rm_not_logical`. — Effort: low, Risk: low,
+  Impact: defensive, Maintenance: none
+- **[C] Do nothing** — Invalid `na.rm` produces cryptic downstream errors.
+
+**Recommendation: [A]** — Validate before use.
+
+---
+
+**Issue 7: `res_df` should use `fit@degf` instead of `.degf(design)`**
+Severity: REQUIRED
+Violates correctness
+
+Section 3.8.1 computes residual df as:
+```r
+res_df <- degf(design) - (length(coef(fit)) - 1L)
+```
+
+Two problems:
+
+1. **Function name:** The internal function is `.degf(design)` (dot-prefixed), but the
+   spec writes `degf(design)` (no dot). The implementer must know to call `.degf()`.
+
+2. **Source of truth:** The fitted `survey_glm_fit` object already stores `@degf` (raw
+   design df, computed at fit time, clamped ≥ 1). Using `.degf(design)` recomputes from
+   the design object, which may differ from `fit@degf` in edge cases (e.g., when
+   `na.action` drops rows that eliminate entire PSUs or strata).
+
+3. **Missing clamping:** The spec's formula doesn't clamp the result. If
+   `.degf(design) - (p - 1) ≤ 0`, `qt()` receives a non-positive df and returns `NaN`.
+   The `survey_glm()` constructor already warns when df ≤ 0 (row 77) and clamps
+   `@df_residual` to 1. But `@df_residual` is classical (n - p), not design-based.
+
+Options:
+- **[A]** Replace `degf(design) - (length(coef(fit)) - 1L)` with
+  `max(1, fit@degf - (length(coef(fit)) - 1L))`. Use `fit@degf` as the authoritative
+  source and add the same clamping that `survey_glm()` uses. — Effort: low, Risk: low,
+  Impact: correctness, Maintenance: none
+- **[B]** Create a helper `.residual_df(fit)` that returns
+  `max(1, fit@degf - (length(fit@coefficients) - 1L))` to avoid repeating the formula.
+  — Effort: low, Risk: low, Impact: DRY, Maintenance: none
+- **[C] Do nothing** — Potential NaN from qt() in edge cases.
+
+**Recommendation: [A]** — Use `fit@degf` and add clamping.
+
+---
+
+**Issue 8: `scale = "link"` with non-gaussian family via clean path — `mean` column semantics unclear**
+Severity: REQUIRED
+Violates API coherence lens (Lens 6)
+
+Section 7.2 routing logic:
+```r
+use_marginaleffects <- has_covariates ||
+  has_group ||
+  (family_name != "gaussian" && scale == "ame")
+```
+
+When `scale = "link"` + non-gaussian family + no covariates + no group, the clean path
+is used. The clean path computes `mean = reference_mean + estimate` where
+`reference_mean` is the intercept and `estimate` is the coefficient — both on the link
+scale.
+
+For logistic regression, this means:
+- `mean` = log-odds (not probability)
+- `pct_change = estimate / reference_mean` = change in log-odds / baseline log-odds
+
+A user seeing `mean = -0.847` would not understand this is log-odds without explicit
+documentation. The column label says `"Mean"` (Section 5.5), which implies the response
+scale.
+
+Options:
+- **[A]** Document in the `mean` column description (Section 5.2): "When `scale =
+  'link'`, `mean` is on the link scale (e.g., log-odds for logistic)." Also update the
+  column label to `"Mean (link scale)"` when `scale = "link"` and family is
+  non-gaussian. Suppress `pct_change` (or make it NA) when `scale = "link"` because the
+  ratio of link-scale values is not meaningful. — Effort: low, Risk: low, Impact:
+  prevents misinterpretation, Maintenance: none
+- **[B]** Force the marginaleffects path for all non-gaussian models regardless of
+  `scale`, then extract coefficients from `clean()` only when the user explicitly wants
+  `scale = "link"`. — Effort: medium, Risk: low, Impact: cleaner, Maintenance: none
+- **[C] Do nothing** — Users misinterpret link-scale means.
+
+**Recommendation: [A]** — Document and adjust labels. The clean path is correct for
+link-scale coefficients; the issue is labeling.
+
+---
+
+**Issue 9: `pct_change` rounding incompatible with `.apply_decimals()`**
+Severity: SUGGESTION
+Deviates from Phase 1 shared helper
+
+Section 3.11 specifies `pct_change` rounds to `decimals + 2`, while all other numeric
+columns round to `decimals`. The existing `.apply_decimals()` rounds all double columns
+to the same number of decimals.
+
+Options:
+- **[A]** Round `pct_change` separately before calling `.apply_decimals()`, or round
+  all columns manually without `.apply_decimals()`. Document the deviation. — Effort:
+  low, Risk: low, Impact: correct rounding, Maintenance: none
+- **[B]** Round `pct_change` to `decimals` like everything else (simpler, still uses
+  `.apply_decimals()`). — Effort: low, Risk: low, Impact: API simplicity, Maintenance:
+  none
+- **[C] Do nothing** — Implementer figures it out.
+
+**Recommendation: [A]** — The spec's differential rounding is intentional; document the
+implementation approach.
+
+---
+
+#### Section: IV. `.meta` Contract
+
+No new issues beyond Issue 3 (DIFFS_META_KEYS).
+
+---
+
+#### Section: V. Output Contract
+
+**Issue 10: Missing `label_values`/`label_vars`/`min_cell_n`/`n_weighted` arguments**
+Severity: SUGGESTION
+API coherence (Lens 6)
+
+Phase 1 `get_*()` functions all accept:
+- `label_values` — accepted for API uniformity (no-op in `get_means()`)
+- `label_vars` — accepted for API uniformity
+- `min_cell_n = 30L` — configurable small-cell threshold
+- `n_weighted` — optional weighted count column
+
+`get_diffs()` omits all four. The `min_cell_n` is hardcoded to 30 in
+`surveycore_warning_small_cell` (Section 6.2). A user who customizes `min_cell_n` in
+`get_means()` would expect the same control in `get_diffs()`.
+
+Options:
+- **[A]** Add `min_cell_n = 30L` and keep `label_values`/`label_vars`/`n_weighted`
+  omitted (they don't map to `get_diffs()` semantics). — Effort: low, Risk: low,
+  Impact: partial consistency, Maintenance: none
+- **[B]** Add all four for full API uniformity. `label_values` and `label_vars` are
+  no-ops; `n_weighted` adds a weighted count column. — Effort: medium, Risk: low,
+  Impact: full consistency, Maintenance: low
+- **[C] Do nothing** — Acceptable deviation.
+
+**Recommendation: [A]** — `min_cell_n` is the most impactful. The others are less
+critical for treatment effect tables.
+
+---
+
+#### Section: VI. Error & Warning Conditions
+
+Covered by Issue 4 (error class naming) and Issue 6 (`na.rm` validation).
+
+---
+
+#### Section: VII. Execution Flow
+
+No new issues.
+
+---
+
+#### Section: VIII. Print Method
+
+**Issue 11: Print method test not specified in test plan**
+Severity: REQUIRED
+Violates `testing-standards.md` Test Completeness category 13 (print snapshot)
+
+Section VIII defines a custom `print.survey_diffs()` method with 4 header lines and
+exact console output. Section IX does not include a print snapshot test.
+
+Phase 1 result classes use the shared `print.survey_result()` method and have snapshot
+tests verifying the header format.
+
+Options:
+- **[A]** Add to Section 9.1 (Happy Path Tests): a snapshot test verifying the full
+  print output matches the Section VIII example, including all 4 header lines. —
+  Effort: low, Risk: low, Impact: catches regressions, Maintenance: one snapshot
+- **[C] Do nothing** — Print format untested.
+
+**Recommendation: [A]** — Snapshot tests are the standard for print methods.
+
+---
+
+#### Section: IX. Testing Requirements
+
+**Issue 12: Domain estimation test missing from test plan**
+Severity: REQUIRED
+Violates Test Completeness category 4 (domain estimation)
+
+Section 9.1 has no test for:
+```r
+d |> filter(condition) |> get_diffs(x, treats)
+```
+
+Domain estimation changes the effective sample and affects `n` counts (Issue 16 from
+methodology review, resolved as "in-domain counts only"). Without a test, the domain
+count logic is unverified.
+
+Options:
+- **[A]** Add to Section 9.1 (Happy Path Tests): "Domain estimation — `filter(design,
+  condition) |> get_diffs(...)` produces in-domain `n` counts and correct estimates."
+  — Effort: low, Risk: low, Impact: covers a critical path, Maintenance: one test
+- **[C] Do nothing** — Domain logic untested at the `get_diffs()` level.
+
+**Recommendation: [A]** — Domain estimation is a first-class feature of surveycore.
+
+---
+
+**Issue 13: `clean()` output filtering not specified precisely**
+Severity: REQUIRED
+Missing implementation detail in Section 3.7
+
+Section 3.7 Step 3 says: "Extract reference row (intercept): the row where
+`term == '(Intercept)'`." Step 4 says: "Extract treatment rows: all non-intercept,
+non-reference rows."
+
+With `clean(fit, include_reference = TRUE)`, the output contains:
+1. `(Intercept)` row (term = "(Intercept)", reference_row = FALSE)
+2. Reference level row (e.g., term = "treatsControl", reference_row = TRUE, estimate = NA)
+3. Treatment rows (reference_row = FALSE, term != "(Intercept)")
+
+The spec must explicitly filter out the `reference_row == TRUE` row from clean() output
+(it has `estimate = NA` and is not used). The phrase "non-reference rows" is ambiguous —
+it could mean "not the reference level" or "reference_row == FALSE".
+
+Options:
+- **[A]** Replace Step 4 with: "Extract treatment rows: all rows where
+  `reference_row == FALSE` and `term != '(Intercept)'`." — Effort: low, Risk: low,
+  Impact: unambiguous, Maintenance: none
+- **[C] Do nothing** — Implementer infers from clean() contract.
+
+**Recommendation: [A]** — Precision prevents implementation bugs.
+
+---
+
+**Issue 14: `scale = "ame"` vs `"link"` identity for Gaussian not tested**
+Severity: SUGGESTION
+Missing edge case coverage
+
+For Gaussian/identity models, `scale = "ame"` and `scale = "link"` should produce
+identical output (both are on the response scale). The routing logic (Section 7.2)
+correctly sends both to the clean path when no covariates/groups are present. But when
+covariates ARE present, `scale = "ame"` goes through marginaleffects while
+`scale = "link"` would use... the clean path with covariates? No — Section 7.2 shows
+`has_covariates` forces marginaleffects regardless of scale.
+
+Actually, for Gaussian + covariates: both scales go through marginaleffects. The AME of
+a linear model = the coefficient. So results should be identical.
+
+A test verifying `scale = "ame"` == `scale = "link"` for Gaussian family would
+guard the routing logic against regressions.
+
+Options:
+- **[A]** Add edge case test: Gaussian model with both `scale = "ame"` and
+  `scale = "link"` produces identical estimates. — Effort: low, Risk: low, Impact:
+  guards routing, Maintenance: one test
+- **[C] Do nothing** — Implicit in other tests.
+
+**Recommendation: [A]** — Explicit is better.
+
+---
+
+#### Section: Cross-Cutting (Lens 2 — Test Completeness Matrix)
+
+For completeness, here is the 13-category assessment:
+
+| # | Category | Status | Notes |
+|---|---|---|---|
+| 1 | Happy path | ✅ Covered | Section 9.1 has extensive happy path list |
+| 2 | Numerical oracle | ✅ Covered | Added in methodology review; tolerances specified |
+| 3 | Grouped analysis | ✅ Covered | `DV ~ treats * group` with taylor design |
+| 4 | Domain estimation | ❌ **Missing** | See Issue 12 |
+| 5 | Variance argument | ✅ Covered | `"se"`, `c("se", "ci")`, `NULL` tested |
+| 6 | label_values | N/A | `get_diffs()` uses column-level labels instead |
+| 7 | label_vars | N/A | Same as above |
+| 8 | meta() contract | ✅ Covered | Section 9.2 requires meta verification |
+| 9 | name_style = "broom" | ❌ **Missing** | See Issue 5 — argument not in spec |
+| 10 | Error paths | ✅ Covered | Dual pattern specified |
+| 11 | Edge cases | ✅ Covered | Section 9.1 has 8 edge cases |
+| 12 | Multi-variable | N/A | Single DV by design |
+| 13 | Print snapshot | ❌ **Missing** | See Issue 11 |
+
+Mechanical rules:
+- `test_invariants()` — N/A (analysis function, not constructor). ✓
+- Dual pattern (class= + snapshot) for Layer 3 errors — specified. ✓
+- `class=` on every error and warning — all present in Sections 6.1 and 6.2. ✓
+
+---
+
+## Summary (Pass 1)
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 0 |
+| REQUIRED | 9 |
+| SUGGESTION | 5 |
+
+**Total issues:** 14
+
+| # | Title | Lens | Severity |
+|---|---|---|---|
+| 1 | Test file naming convention | 2 | SUGGESTION |
+| 2 | `.build_diffs_meta()` should delegate to `.build_meta()` | 1 | REQUIRED |
+| 3 | `DIFFS_META_KEYS` constant not defined | 3 | REQUIRED |
+| 4 | Error class names diverge from existing codebase | 1 | REQUIRED |
+| 5 | Missing `name_style` argument | 6 | REQUIRED |
+| 6 | `na.rm` validation not specified | 3 | REQUIRED |
+| 7 | `res_df` should use `fit@degf` | 3 | REQUIRED |
+| 8 | `scale = "link"` mean column semantics | 6 | REQUIRED |
+| 9 | `pct_change` rounding incompatible with `.apply_decimals()` | 5 | SUGGESTION |
+| 10 | Missing `min_cell_n`/`label_values` etc. arguments | 6 | SUGGESTION |
+| 11 | Print method test not specified | 2 | REQUIRED |
+| 12 | Domain estimation test missing | 2 | REQUIRED |
+| 13 | `clean()` output filtering not precise | 3 | REQUIRED |
+| 14 | `scale = "ame"` = `"link"` for Gaussian test | 4 | SUGGESTION |
+
+**Overall assessment:** The spec is well-structured and methodology-locked with all 24
+methodology review issues resolved. No blocking issues remain. The 9 required issues are:
+DRY violations in error class naming and meta construction (easily fixed by reusing
+existing infrastructure), missing API consistency with Phase 1 (`name_style`, validation),
+a correctness issue with df computation (use `fit@degf` instead of recomputing), and
+gaps in the test plan (domain estimation, print snapshot). All are addressable without
+architectural changes. The spec is near-implementable after this pass.
+
+---
+
+## Pass 2 (2026-03-17)
+
+### Prior Issues (Pass 1)
+
+| # | Title | Status |
+|---|---|---|
+| 1 | Test file naming convention | ✅ Resolved — Section 2.1 now uses `test-analysis-diffs.R` naming |
+| 2 | `.build_diffs_meta()` should delegate to `.build_meta()` | ✅ Resolved — Section 2.2 specifies inline `meta_args` + `.build_meta()` (no separate helper) |
+| 3 | `DIFFS_META_KEYS` constant not defined | ✅ Resolved — Section 2.2 defines `DIFFS_META_KEYS` with all 10 keys |
+| 4 | Error class names diverge from codebase | ✅ Resolved — Section 6.1 reuses `surveycore_error_unsupported_class`, `surveycore_error_non_numeric_variable`, `surveycore_error_wrong_variable_count` |
+| 5 | Missing `name_style` argument | ✅ Resolved — Added to signature (Section 3.1) with `.apply_name_style()` in execution flow |
+| 6 | `na.rm` validation not specified | ✅ Resolved — Section 3.12 specifies `.validate_shared_args()` as first step |
+| 7 | `res_df` should use `fit@degf` | ✅ Resolved — Section 3.8.1 now uses `max(1, fit@degf - (length(coef(fit)) - 1L))` |
+| 8 | `scale = "link"` mean column semantics | ✅ Resolved — Decided option [D]: suppress `mean` and `pct_change` when link + non-gaussian |
+| 9 | `pct_change` rounding incompatible with `.apply_decimals()` | ✅ Resolved — Section 3.11 documents separate rounding after `.apply_decimals()` |
+| 10 | Missing `min_cell_n`/`label_values` etc. arguments | ✅ Resolved — All four added to signature |
+| 11 | Print method test not specified | ✅ Resolved — Print snapshot test added to Section 9.1 |
+| 12 | Domain estimation test missing | ✅ Resolved — Domain estimation test added to Section 9.1 |
+| 13 | `clean()` output filtering not precise | ✅ Resolved — Section 3.7 Step 4 now says `reference_row == FALSE` and `term != "(Intercept)"` |
+| 14 | `scale = "ame"` = `"link"` for Gaussian test | ✅ Resolved — Edge case test added to Section 9.1 |
+
+All 14 Pass 1 issues resolved.
+
+### New Issues
+
+#### Section: I. Scope
+
+**Issue 15: `survey_srs` listed as supported but removed from codebase**
+Severity: BLOCKING
+Violates contract completeness — spec references a class that no longer exists
+
+Section I lists `survey_srs` as a supported design class:
+```
+| survey_srs | Yes |
+```
+
+The `refactor/remove-survey-srs` branch removes the `survey_srs` class, `as_survey_srs()`,
+and `R/variance-srs.R`. After this refactor, SRS designs are created via `as_survey()` with
+no `ids` or `strata`, producing a `survey_taylor` object. The `survey_srs` class will not
+exist at implementation time.
+
+Additionally, Section IV lists `"srs"` as a valid `design_type` in `.meta`:
+```
+design_type: "taylor", "replicate", "twophase", "srs", or "calibrated"
+```
+
+`.build_meta()` in `analysis-helpers.R` has no branch for `survey_srs` — it checks
+`survey_taylor`, `survey_replicate`, `survey_twophase`, `survey_nonprob` only. SRS designs
+via `survey_taylor` would produce `design_type = "taylor"`.
+
+The print method example (Section VIII) shows `Design: Taylor series`, which is already
+correct for the post-removal world.
+
+Options:
+- **[A]** Remove `survey_srs` from Section I supported classes table. Remove `"srs"` from
+  Section IV `design_type` values. Update any test descriptions that reference `survey_srs`
+  specifically. SRS designs are tested via `survey_taylor` with no ids/strata. — Effort:
+  low, Risk: low, Impact: spec matches codebase, Maintenance: none
+- **[C] Do nothing** — Implementer cannot find `survey_srs` class.
+
+**Recommendation: [A]** — Spec must match the codebase.
+
+---
+
+#### Section: II. Architecture
+
+No new issues found.
+
+---
+
+#### Section: III. Function Specification
+
+**Issue 16: `name_style = "broom"` creates duplicate `estimate` columns**
+Severity: BLOCKING
+Violates correctness — `.apply_name_style()` produces a malformed tibble
+
+The `get_diffs()` output contains both `estimate` (treatment effect) and `mean`
+(treatment level mean) columns simultaneously when `show_means = TRUE`. The existing
+`.apply_name_style()` maps:
+```r
+broom_map <- c(
+  mean     = "estimate",
+  estimate = "estimate",
+  ...
+)
+```
+
+When both columns are present and `name_style = "broom"`, the function renames both to
+`"estimate"`, creating a tibble with duplicate column names. This silently corrupts the
+output.
+
+The spec's Section 3.2 description correctly lists only 4 renames (`se → std.error`,
+`ci_low → conf.low`, `ci_high → conf.high`, `p_value → p.value`) and does NOT mention
+renaming `mean` or `estimate`. But the execution flow (Section 7.1 Step 19) calls
+`.apply_name_style()`, which applies the full broom map including the conflicting
+`mean → estimate` mapping.
+
+In Phase 1, `get_means()` has `mean` but no `estimate`; `get_totals()` has `total` but
+no `estimate`. The broom map works because only one "point estimate" column exists per
+function. `get_diffs()` breaks this assumption by having both.
+
+Options:
+- **[A]** Exclude `mean` from broom renaming in `get_diffs()`. Before calling
+  `.apply_name_style()`, temporarily remove `mean` from the result, apply the rename,
+  then re-insert `mean`. Or: don't use `.apply_name_style()` — do the 4 renames manually
+  in `get_diffs()`. — Effort: low, Risk: low, Impact: correctness, Maintenance: low
+- **[B]** Rename the `mean` column to `fitted_mean` or `group_mean` in the surveycore
+  output to avoid the broom namespace collision entirely. Then `.apply_name_style()` would
+  skip it (no mapping for `fitted_mean`). — Effort: low, Risk: medium (API change),
+  Impact: avoids the problem structurally, Maintenance: none
+- **[C] Do nothing** — Duplicate columns in broom output.
+
+**Recommendation: [A]** — Exclude `mean` from broom renaming. The `mean` column in
+`get_diffs()` is contextual (not the point estimate), so it should keep its name in
+broom mode. Document in Section 3.2: "The `mean` column is not renamed under
+`name_style = 'broom'` because `estimate` already holds the point estimate."
+
+---
+
+**Issue 17: `treats` column labeling mechanism unspecified**
+Severity: REQUIRED
+Violates contract completeness (Lens 3) and `engineering-preferences.md` §5 (explicit)
+
+Section 3.2 says `label_values = TRUE` displays value labels ("Control", "Message A")
+instead of raw codes (1, 2) for `treats` and `group` columns. But the spec does not
+specify:
+
+1. **When labels are applied:** The `treats` column is built from factor levels after
+   `as.factor()` + `relevel()` (Section 3.6). If the source column has haven-style
+   numeric codes (1, 2, 3), `as.factor()` creates levels `"1"`, `"2"`, `"3"` — not
+   label strings. Labels must be applied later.
+
+2. **How labels are applied:** Phase 1 group columns use `.apply_group_labels()` from
+   `analysis-helpers.R`. Should `get_diffs()` use the same helper for the `treats` column?
+   This would require treating `treats` as a "group-like" column for labeling purposes.
+
+3. **Output type:** Section 5.2 says the `treats` column type is `character`. But
+   `.apply_group_labels()` returns `factor` for labeled columns (matching Phase 1 group
+   column behavior). The output type should be consistent.
+
+Options:
+- **[A]** Specify: after assembling the output tibble, apply `.apply_group_labels()` to
+  both `treats` and `group` columns (treating `treats` identically to group columns for
+  labeling). Update Section 5.2 to say `treats` type is `factor` when labels are applied,
+  `character` otherwise (matching group column behavior). — Effort: low, Risk: low,
+  Impact: reuses existing infrastructure, Maintenance: none
+- **[B]** Apply labels during factor construction in Section 3.6 (before GLM fit). Use
+  metadata value labels to build factor levels with label strings instead of raw codes.
+  — Effort: low, Risk: medium (factor level strings affect model term names in `clean()`
+  output, requiring careful term parsing), Maintenance: ongoing
+- **[C] Do nothing** — Implementer must reverse-engineer the labeling approach.
+
+**Recommendation: [A]** — Reuse `.apply_group_labels()` post-assembly, matching the
+Phase 1 pattern exactly. Applying labels before the GLM fit (option B) would change
+model term names and complicate `clean()` parsing.
+
+---
+
+**Issue 18: `n_weighted` for reference row not specified**
+Severity: REQUIRED
+Violates contract completeness (Lens 3)
+
+Section 5.4 (Reference Row Contract) specifies values for all columns in the reference
+row: `estimate = 0`, `se = NA`, `p_value = NA`, etc. But it does not include
+`n_weighted`. When `n_weighted = TRUE`, the reference row must have a value for this
+column — logically the sum of weights for the reference level.
+
+Options:
+- **[A]** Add `n_weighted` to Section 5.4: `n_weighted = sum of weights for the
+  reference level (within group if applicable)`. — Effort: low, Risk: low, Impact:
+  complete contract, Maintenance: none
+- **[C] Do nothing** — Implementer guesses.
+
+**Recommendation: [A]** — Complete the reference row contract.
+
+---
+
+#### Section: IV. `.meta` Contract
+
+Covered by Issue 15 (`"srs"` in `design_type`).
+
+---
+
+#### Section: V. Output Contract
+
+No new issues beyond Issues 16–18.
+
+---
+
+#### Section: VI. Error & Warning Conditions
+
+No new issues found.
+
+---
+
+#### Section: VII. Execution Flow
+
+No new issues found.
+
+---
+
+#### Section: VIII. Print Method
+
+No new issues found.
+
+---
+
+#### Section: IX. Testing Requirements
+
+**Issue 19: `label_vars` test missing from test plan**
+Severity: REQUIRED
+Violates Test Completeness category 7 (label_vars)
+
+Section 9.1 includes tests for `label_values = TRUE` and `label_values = FALSE` but
+has no explicit test for `label_vars`. The `label_vars` argument controls whether
+column-level `label` attributes on `treats` and `group` columns use variable labels
+from metadata vs raw variable names.
+
+Pass 1 Test Completeness Matrix (row 7) marked `label_vars` as N/A with "uses
+column-level labels instead." But the v1.2 spec adds `label_vars` as an argument with
+real behavior — it's no longer N/A.
+
+Options:
+- **[A]** Add to Section 9.1: "`label_vars = FALSE` — column-level `label` attributes
+  on `treats` and `group` columns use raw variable names instead of metadata labels." —
+  Effort: low, Risk: low, Impact: test coverage, Maintenance: one test
+- **[C] Do nothing** — `label_vars` behavior untested.
+
+**Recommendation: [A]** — Now that the argument has real behavior, it needs a test.
+
+---
+
+#### Section: Cross-Cutting (Lens 2 — Test Completeness Matrix)
+
+Updated 13-category assessment for v1.2:
+
+| # | Category | Status | Notes |
+|---|---|---|---|
+| 1 | Happy path | ✅ Covered | Extensive list in Section 9.1 |
+| 2 | Numerical oracle | ✅ Covered | Tolerances specified; logistic + Poisson included |
+| 3 | Grouped analysis | ✅ Covered | `DV ~ treats * group` with taylor design |
+| 4 | Domain estimation | ✅ Covered | Added in v1.2 |
+| 5 | Variance argument | ✅ Covered | `"se"`, `c("se", "ci")`, `NULL` tested |
+| 6 | label_values | ✅ Covered | `label_values = TRUE/FALSE` tests added in v1.2 |
+| 7 | label_vars | ❌ **Missing** | See Issue 19 |
+| 8 | meta() contract | ✅ Covered | Section 9.2 |
+| 9 | name_style = "broom" | ✅ Covered | Added in v1.2 |
+| 10 | Error paths | ✅ Covered | Dual pattern specified |
+| 11 | Edge cases | ✅ Covered | 10 edge cases in Section 9.1 |
+| 12 | Multi-variable | N/A | Single DV by design |
+| 13 | Print snapshot | ✅ Covered | Added in v1.2 |
+
+Mechanical rules — all pass:
+- `test_invariants()` — N/A (analysis function). ✓
+- Dual pattern for Layer 3 errors — specified. ✓
+- `class=` on every error and warning — all present. ✓
+
+---
+
+#### Section: Cross-Cutting (Lens 6 — API Coherence)
+
+**Issue 20: Unused factor levels in `treats` — behavior unspecified**
+Severity: SUGGESTION
+Violates `engineering-preferences.md` §4 (handle more edge cases)
+
+If the `treats` column is a factor with levels that have 0 observations in the data
+(or 0 in-domain observations after `filter()`), the GLM model matrix will have no
+coefficients for those levels. The clean path (`clean()`) and marginaleffects path
+(`avg_slopes()`) will silently omit those levels from the output.
+
+This is arguably correct behavior — you can't estimate a treatment effect for a level
+with no data. But the spec does not state this explicitly, and a user with a pre-defined
+factor might expect all levels in the output (with `NA` estimates for empty levels).
+
+Options:
+- **[A]** Add to Section 3.6 after Step 5: "Unused factor levels (levels with 0
+  observations after `na.action`) are silently dropped from the output. They do not
+  appear as rows." — Effort: low, Risk: low, Impact: explicit, Maintenance: none
+- **[B]** Add a warning when unused levels are detected:
+  `surveycore_warning_unused_treats_levels`. — Effort: low, Risk: low, Impact:
+  transparent, Maintenance: one warning class
+- **[C] Do nothing** — Behavior is implicit from GLM mechanics.
+
+**Recommendation: [A]** — One sentence of documentation prevents confusion.
+
+---
+
+**Issue 21: `group` with 1 unique value produces singular model matrix**
+Severity: SUGGESTION
+Missing edge case documentation
+
+Section 9.1 edge cases include "`group` with only 1 unique value — Degenerates to
+no-group case (verify)." But when `group` has 1 level, the formula
+`x ~ treats * group` creates interaction terms with a single-level factor. The model
+matrix becomes singular (the interaction columns are perfectly collinear with the main
+effect). `survey_glm()` would throw `surveycore_error_singular_model_matrix`.
+
+The edge case test description says "Degenerates to no-group case (verify)" — but it
+doesn't degenerate; it errors. The test should verify the error propagation, not expect
+a successful result.
+
+Options:
+- **[A]** Update the edge case description to: "`group` with only 1 unique value —
+  `survey_glm()` throws `surveycore_error_singular_model_matrix` due to collinear
+  interaction terms. Verify error propagation." — Effort: low, Risk: low, Impact:
+  correct test expectation, Maintenance: none
+- **[B]** Detect single-level groups before formula construction and drop the interaction
+  term, effectively falling back to the no-group case with a warning. — Effort: medium,
+  Risk: low, Impact: more graceful, Maintenance: low
+- **[C] Do nothing** — Implementer discovers the error empirically.
+
+**Recommendation: [A]** — At minimum, fix the test expectation. Option [B] is a nice
+enhancement but adds complexity; it can be a follow-up.
+
+---
+
+## Summary (Pass 2)
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 2 |
+| REQUIRED | 3 |
+| SUGGESTION | 2 |
+
+**Total new issues:** 7
+
+| # | Title | Lens | Severity |
+|---|---|---|---|
+| 15 | `survey_srs` removed but still in spec | 3, 6 | BLOCKING |
+| 16 | `name_style = "broom"` duplicate `estimate` columns | 1, 6 | BLOCKING |
+| 17 | `treats` column labeling mechanism unspecified | 3 | REQUIRED |
+| 18 | `n_weighted` for reference row not specified | 3 | REQUIRED |
+| 19 | `label_vars` test missing from test plan | 2 | REQUIRED |
+| 20 | Unused factor levels in `treats` unspecified | 4, 6 | SUGGESTION |
+| 21 | `group` with 1 level — singular matrix, not degenerate | 4, 6 | SUGGESTION |
+
+**Overall assessment:** All 14 Pass 1 issues are resolved — the v1.2 spec is substantially
+improved. Two new blocking issues emerged: (1) the `survey_srs` class removal invalidates
+the supported design classes table and `.meta` contract, and (2) `.apply_name_style()`
+creates duplicate `estimate` columns when `show_means = TRUE` and `name_style = "broom"`.
+The 3 required issues are contract gaps: unspecified `treats` labeling mechanism, missing
+`n_weighted` in the reference row contract, and missing `label_vars` test. All 7 issues
+are addressable without architectural changes. After resolving the 2 blocking issues, the
+spec is implementable.
+
+---
+
+## Pass 3 (2026-03-17)
+
+### Prior Issues (Pass 2)
+
+| # | Title | Status |
+|---|---|---|
+| 15 | `survey_srs` removed but still in spec | ✅ Resolved — Section I now lists 4 classes (taylor, replicate, twophase, nonprob); "srs" removed from Section IV `design_type` |
+| 16 | `name_style = "broom"` duplicate `estimate` columns | ✅ Resolved — Section 3.2 documents `mean` excluded from broom rename; Section 7.1 Step 19 specifies exclusion approach |
+| 17 | `treats` column labeling mechanism unspecified | ✅ Resolved — Section 3.2 (`label_values`) and Section 7.1 Step 17a specify `.apply_group_labels()` post-assembly for both `treats` and `group` columns |
+| 18 | `n_weighted` for reference row not specified | ✅ Resolved — Section 5.4 now includes `n_weighted` in reference row contract |
+| 19 | `label_vars` test missing from test plan | ✅ Resolved — Section 9.1 now has `label_vars = TRUE`, `label_vars = FALSE`, and `label_vars = TRUE` fallback tests |
+| 20 | Unused factor levels in `treats` unspecified | ✅ Resolved — Section 3.6 documents silent omission of unused levels from output |
+| 21 | `group` with 1 level — singular matrix, not degenerate | ✅ Resolved — Section 9.1 edge case updated to expect `surveycore_error_singular_model_matrix` |
+
+All 7 Pass 2 issues resolved.
+
+### New Issues
+
+#### Section: III. Function Specification
+
+**Issue 22: `avg_slopes()` missing `type = "link"` when `scale = "link"` on marginaleffects path**
+Severity: BLOCKING
+Violates correctness — produces response-scale AMEs labeled as link-scale coefficients
+
+Section 7.2 routing logic:
+```r
+use_marginaleffects <- has_covariates ||
+  has_group ||
+  (family_name != "gaussian" && scale == "ame")
+```
+
+When `scale = "link"` + non-gaussian + (covariates OR group), `use_marginaleffects = TRUE`.
+The marginaleffects path (Section 3.8.1) calls:
+```r
+slopes <- marginaleffects::avg_slopes(
+  fit,
+  variables = treats_name,
+  wts = TRUE,
+  df = res_df
+)
+```
+
+The default for `avg_slopes()` is `type = "response"`, which returns AMEs on the response
+scale (e.g., probability differences for logistic). But the user requested `scale = "link"`
+— they want link-scale coefficients (e.g., log-odds ratios).
+
+**Concrete example:** For `logit(P(y=1)) = β0 + β1*treatment + β2*age`:
+- With `type = "response"` (current spec): `avg_slopes()` returns ~0.05 (5pp probability
+  difference). This is the AME, NOT the coefficient.
+- With `type = "link"`: `avg_slopes()` returns β1 (~0.50 log-odds ratio). This is what
+  the user expects when `scale = "link"`.
+
+The `.meta$estimate_scale` would record `"coefficient"` (per Section IV: "With
+`scale = 'link'`, always `'coefficient'`"), but the actual value would be an AME. Silent
+mislabeling.
+
+The clean path (no covariates, no group) handles `scale = "link"` correctly because it
+extracts coefficients directly. The gap is only when covariates or groups force the
+marginaleffects path.
+
+Options:
+- **[A]** Add `type` argument to all `avg_slopes()` and `avg_predictions()` calls:
+  `type = if (scale == "link") "link" else "response"`. For `avg_predictions()`, this
+  only matters if means are not suppressed (they are suppressed for link + non-gaussian,
+  so `avg_predictions()` can be skipped entirely in that case). — Effort: low, Risk: low,
+  Impact: correctness, Maintenance: none
+- **[B]** Disallow `scale = "link"` when covariates or groups are present for
+  non-gaussian families. Error with a typed class. — Effort: low, Risk: low, Impact:
+  simplicity at cost of functionality, Maintenance: none
+- **[C] Do nothing** — Response-scale AMEs mislabeled as link-scale coefficients.
+
+**Recommendation: [A]** — Pass `type = "link"` when `scale = "link"`. This is a one-line
+fix in the spec's code blocks and maintains full functionality. `marginaleffects`
+supports the `type` argument in both `avg_slopes()` and `avg_predictions()`.
+
+---
+
+**Issue 23: `variance` argument accepts only `"se"` and `"ci"` but `.validate_shared_args()` accepts full set**
+Severity: REQUIRED
+Violates `engineering-preferences.md` §4 (handle more edge cases) and API coherence
+
+Section 3.2 defines:
+> `variance`: One or more of: `"se"`, `"ci"`. `NULL` = no uncertainty columns.
+
+But `.validate_shared_args()` defaults to `valid_variance = c("se", "ci", "var", "cv",
+"moe", "deff")`. If `get_diffs()` calls `.validate_shared_args()` without overriding
+`valid_variance`, a user passing `variance = "deff"` would:
+1. Pass validation (no error)
+2. Get no `deff` column in the output (silently missing)
+
+Phase 1 functions compute `"var"`, `"cv"`, `"moe"`, `"deff"` via `.add_variance_cols()`.
+`get_diffs()` does not call `.add_variance_cols()` — SEs and CIs come from `clean()` or
+`marginaleffects`. Computing `deff` or `cv` would require additional work not specified
+in the spec.
+
+Options:
+- **[A]** Specify that `get_diffs()` passes `valid_variance = c("se", "ci")` to
+  `.validate_shared_args()`. Users requesting unsupported variance types get
+  `surveycore_error_invalid_variance_arg` with the restricted set shown. — Effort: low,
+  Risk: low, Impact: prevents silent gap, Maintenance: none
+- **[B]** Expand variance support to include `"var"`, `"cv"`, `"moe"` by computing them
+  from the SE column (variance = SE², cv = SE/estimate, moe = t_crit * SE). `"deff"` is
+  not feasible without an SRS baseline. — Effort: medium, Risk: low, Impact: richer API,
+  Maintenance: low
+- **[C] Do nothing** — Silent gap when user passes unsupported type.
+
+**Recommendation: [A]** — Restrict the valid set. Option [B] is a nice follow-up but adds
+scope; the clean path and marginaleffects path both provide SEs, which is sufficient for
+`"se"` and `"ci"`.
+
+---
+
+#### Section: VII. Execution Flow
+
+**Issue 24: Step 7 omits forcing treatment contrasts — critical methodology fix invisible in summary**
+Severity: REQUIRED
+Violates `engineering-preferences.md` §5 (explicit over clever) — critical step hidden
+
+Section 7.1 execution flow Step 7:
+```
+Step 7:  Coerce treats to factor, relevel if needed
+```
+
+But Section 3.6 Step 5 specifies a critical step resolved from a BLOCKING methodology
+review issue (Issue 1, contrast validation):
+> **Force treatment contrasts:** After coercion and releveling, explicitly set
+> `contrasts(design@data[[treats_name]]) <- stats::contr.treatment(...)`.
+
+The forced contrasts step is the fix for a blocking correctness issue (non-treatment
+contrasts silently produce wrong reference means). An implementer following the execution
+flow as a checklist would miss it.
+
+Options:
+- **[A]** Expand Step 7 to: "Coerce treats to factor, relevel if needed, force treatment
+  contrasts (Section 3.6 Step 5)." — Effort: low, Risk: low, Impact: critical step visible
+  in summary, Maintenance: none
+- **[C] Do nothing** — Section 3.6 is authoritative; execution flow is a summary.
+
+**Recommendation: [A]** — The execution flow is the implementer's primary checklist.
+Critical steps should not be hidden in section cross-references.
+
+---
+
+**Issue 25: Execution flow missing validation of `covariates` and `pval_adj`**
+Severity: REQUIRED
+Violates contract completeness — error table entries have no corresponding execution step
+
+Section 6.1 defines two error classes with no corresponding step in the execution flow
+(Section 7.1):
+- `surveycore_error_covariates_not_character` — triggers when `covariates` is not a
+  character vector
+- `surveycore_error_invalid_pval_adj` — triggers when `pval_adj` is not a valid
+  `stats::p.adjust()` method
+
+The execution flow goes directly from "Step 4: Validate x is numeric, treats has ≥ 2
+levels" to "Step 5: Handle ref_level". Neither `covariates` type-checking nor `pval_adj`
+method validation appears in any step.
+
+Options:
+- **[A]** Add a validation sub-step to Step 4 (or a new Step 4a): "Validate `covariates`
+  is character or NULL; validate `pval_adj` is a valid `stats::p.adjust()` method or NULL."
+  — Effort: low, Risk: low, Impact: complete flow, Maintenance: none
+- **[C] Do nothing** — Implementer discovers from error table.
+
+**Recommendation: [A]** — The execution flow should be implementable as-is without
+requiring the implementer to scan the error table for missing steps.
+
+---
+
+#### Section: IX. Testing Requirements
+
+**Issue 26: `label_vars = TRUE` fallback test (no metadata label) missing**
+Severity: SUGGESTION
+Test completeness gap — fallback behavior untested
+
+Section 9.1 now includes:
+- `label_vars = TRUE` — column labels use variable labels from metadata
+- `label_vars = FALSE` — column labels use raw variable names
+
+But there is no test for the fallback case: when `label_vars = TRUE` (default) but the
+`treats` or `group` variable has **no metadata label** (neither in `@metadata` nor as a
+haven attribute). In this case, the column-level `label` attribute should fall back to the
+raw variable name. This fallback is implied but never explicitly tested.
+
+Options:
+- **[A]** Add to Section 9.1: "`label_vars = TRUE` fallback — when no metadata label
+  exists, column-level `label` attributes fall back to raw variable names." — Effort: low,
+  Risk: low, Impact: guards fallback path, Maintenance: one test
+- **[C] Do nothing** — Fallback behavior is implicit.
+
+**Recommendation: [A]** — Explicit test for the fallback prevents a missing-label scenario
+from silently producing `NULL` or `NA` as a column label.
+
+---
+
+#### Section: X. Quality Gates
+
+**Issue 27: Quality Gates stale "5 design classes" count**
+Severity: REQUIRED
+Violates contract completeness — count doesn't match spec
+
+Section X states:
+> All 5 design classes have at least one happy-path test
+
+But the spec now lists 4 supported design classes (taylor, replicate, twophase, nonprob)
+after `survey_srs` was removed in Pass 2 Issue 15 resolution. The quality gate count
+is stale.
+
+Options:
+- **[A]** Change to "All 4 design classes have at least one happy-path test." — Effort:
+  negligible, Risk: none, Impact: correctness, Maintenance: none
+- **[C] Do nothing** — Misleads implementer into searching for a 5th class.
+
+**Recommendation: [A]** — One-word fix.
+
+---
+
+#### Section: Cross-Cutting (Lens 1 — DRY)
+
+**Issue 28: `.meta$treats` structure inconsistent with `.extract_var_meta()` pattern**
+Severity: SUGGESTION
+Violates `engineering-preferences.md` §1 (DRY) — different structure for same concept
+
+Section IV defines `.meta$treats` as:
+> `list(name, variable_label, value_labels, ref_level)`
+
+Phase 1 `.meta$group` entries use `.extract_var_meta()`, which returns:
+> `list(variable_label, question_preface, value_labels)`
+
+The `treats` entry diverges by:
+1. Adding `name` (the variable name) — in group meta, the variable name is the list key
+2. Adding `ref_level` — unique to `get_diffs()`
+3. Omitting `question_preface` — present in group meta via `.extract_var_meta()`
+
+This means `.meta$treats` cannot be built by calling `.extract_var_meta()` and appending
+fields. Instead, it requires a custom construction path.
+
+Options:
+- **[A]** Build `.meta$treats` by calling `.extract_var_meta(design, treats_name)` and
+  then appending `name = treats_name` and `ref_level = ref_level` to the result. This
+  includes `question_preface` for consistency. — Effort: low, Risk: low, Impact: DRY,
+  Maintenance: none
+- **[C] Do nothing** — Custom construction.
+
+**Recommendation: [A]** — Reuse `.extract_var_meta()` and extend with diffs-specific
+fields. This keeps the pattern consistent and includes `question_preface` for free.
+
+---
+
+#### Section: Cross-Cutting (Lens 2 — Test Completeness Matrix)
+
+Updated 13-category assessment for v1.3:
+
+| # | Category | Status | Notes |
+|---|---|---|---|
+| 1 | Happy path | ✅ Covered | Extensive list in Section 9.1 |
+| 2 | Numerical oracle | ✅ Covered | Bivariate OLS, multivariate OLS, logistic AME, Poisson AME, SRS vcov, replicate df |
+| 3 | Grouped analysis | ✅ Covered | `DV ~ treats * group` with taylor design |
+| 4 | Domain estimation | ✅ Covered | `filter(design, condition) \|> get_diffs(...)` |
+| 5 | Variance argument | ✅ Covered | `"se"`, `c("se", "ci")`, `NULL` tested |
+| 6 | label_values | ✅ Covered | `label_values = TRUE/FALSE` tests |
+| 7 | label_vars | ✅ Covered | `label_vars = TRUE/FALSE` tests; fallback missing (Issue 26) |
+| 8 | meta() contract | ✅ Covered | Section 9.2 |
+| 9 | name_style = "broom" | ✅ Covered | Test specified including `mean` exclusion |
+| 10 | Error paths | ✅ Covered | Dual pattern specified |
+| 11 | Edge cases | ✅ Covered | 10+ edge cases including singular group, unused levels |
+| 12 | Multi-variable | N/A | Single DV by design |
+| 13 | Print snapshot | ✅ Covered | `expect_snapshot(print(result))` specified |
+
+Mechanical rules — all pass:
+- `test_invariants()` — N/A (analysis function). ✓
+- Dual pattern for Layer 3 errors — specified. ✓
+- `class=` on every error and warning — all present. ✓
+
+---
+
+#### Section: Cross-Cutting (Lens 6 — API Coherence)
+
+Traced realistic workflow: `get_diffs(d, dv, treatment, covariates = c("age", "gender"), scale = "link", family = quasibinomial())`. With this configuration:
+- `scale = "link"` + non-gaussian + covariates → marginaleffects path
+- `avg_slopes()` returns response-scale AMEs (default `type = "response"`)
+- User expects log-odds ratios, gets probability differences
+- `.meta$estimate_scale = "coefficient"` but actual values are AMEs
+
+This is Issue 22 — the most critical finding in this pass.
+
+No other API coherence issues identified. The `treats` labeling via `.apply_group_labels()`,
+the `name_style = "broom"` exclusion of `mean`, and the Phase 1 API uniformity additions
+all work correctly in realistic workflows.
+
+---
+
+## Summary (Pass 3)
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 1 |
+| REQUIRED | 4 |
+| SUGGESTION | 2 |
+
+**Total new issues:** 7
+
+| # | Title | Lens | Severity |
+|---|---|---|---|
+| 22 | `avg_slopes()` missing `type = "link"` for `scale = "link"` | 3, 6 | BLOCKING |
+| 23 | `variance` valid set not restricted in `.validate_shared_args()` call | 3 | REQUIRED |
+| 24 | Execution flow Step 7 omits forcing treatment contrasts | 3 | REQUIRED |
+| 25 | Execution flow missing covariates and pval_adj validation | 3 | REQUIRED |
+| 26 | `label_vars = TRUE` fallback test missing | 2 | SUGGESTION |
+| 27 | Quality Gates stale "5 design classes" count | 3 | REQUIRED |
+| 28 | `.meta$treats` structure inconsistent with `.extract_var_meta()` | 1 | SUGGESTION |
+
+**Overall assessment:** All 7 Pass 2 issues are resolved — the v1.3 spec is substantially
+improved. One new blocking issue emerged: `avg_slopes()` does not pass `type = "link"` when
+`scale = "link"` is active on the marginaleffects path, causing response-scale AMEs to be
+silently mislabeled as link-scale coefficients. This affects non-gaussian models with
+covariates or groups when `scale = "link"`. The 4 required issues are: restrictng the
+`variance` valid set, two execution flow completeness gaps (forced contrasts and
+covariates/pval_adj validation), and a stale design class count in Quality Gates. The 2
+suggestions are a missing fallback test and a minor structural inconsistency in
+`.meta$treats`. After resolving the blocking issue, the spec is implementable.

--- a/plans/spec-review-nonprob-zero-weights.md
+++ b/plans/spec-review-nonprob-zero-weights.md
@@ -1,0 +1,359 @@
+# Spec Review: nonprob-zero-weights — Pass 1 (2026-03-18)
+
+### New Issues
+
+#### Section: I. Scope
+
+No new issues found.
+
+#### Section: II. Architecture
+
+No new issues found.
+
+#### Section: III. Change 1 — Relax `survey_nonprob` Validator Condition 4
+
+**Issue 1: Condition 4b reuses `surveycore_error_weights_all_zero` but the existing condition 3 usage has a different message**
+Severity: REQUIRED
+Violates DRY (Lens 1) and contract completeness (Lens 3)
+
+The spec says condition 4b reuses `surveycore_error_weights_all_zero` and that conditions 3 and 4b are "mutually exclusive, so the shared class is unambiguous." This is correct for dispatching — but the *message text* differs between the two conditions. Condition 3 (all-NA) currently says `"Weight column {.field {weights_var}} has no non-NA values."` while the new condition 4b says `"Weight column {.field {weights_var}} has no positive values."` Snapshot tests match on exact message text, not just error class. Two different messages with the same class is fine for programmatic `tryCatch(class=)` usage but could confuse snapshot reviewers who see `surveycore_error_weights_all_zero` producing different text depending on the path.
+
+This is not blocking because the conditions are mutually exclusive and the error class semantics are correct. But it's worth noting explicitly in the spec that the two messages intentionally differ.
+
+Options:
+- **[A]** Add a note in §III acknowledging the different message text under the shared class. — Effort: low, Risk: low, Impact: clarifies for implementer and snapshot reviewer, Maintenance: none
+- **[B] Do nothing** — The implementer can figure this out from context.
+
+**Recommendation: A** — A one-line note prevents confusion during snapshot review.
+
+---
+
+**Issue 2: Spec says `as_survey_nonprob()` constructor "still requires positive weights at creation time" but doesn't state which validation function enforces this**
+Severity: SUGGESTION
+Lens 3 (Contract Completeness)
+
+The "What Does NOT Change" section says the constructor retains strict positivity via `.validate_weights()`, but doesn't name the file or function explicitly. The implementer needs to know that `.validate_weights()` in `R/core-validators.R` (line 95) is the function that enforces this — and that it must NOT be modified. This is inferrable from the code, but stating it explicitly prevents an implementer from accidentally relaxing `.validate_weights()` instead of the S7 validator.
+
+Options:
+- **[A]** Add a line: "The constructor's `.validate_weights()` (`R/core-validators.R`) retains `<= 0` check — do not modify." — Effort: low, Risk: low, Impact: prevents wrong-file edit, Maintenance: none
+- **[B] Do nothing** — The non-deliverables table already says constructor is unchanged.
+
+**Recommendation: A** — Cheap insurance against a common implementation mistake.
+
+---
+
+#### Section: IV. Change 2 — Update `test_invariants()`
+
+**Issue 3: `test_invariants()` change is not scoped to `survey_nonprob` — it will break other design types**
+Severity: BLOCKING
+Violates contract completeness (Lens 3)
+
+The spec shows the new `test_invariants()` code as:
+```r
+testthat::expect_true(
+  all(wt_col[!is.na(wt_col)] >= 0),
+  label = "weight column has all non-negative non-NA values"
+)
+```
+
+But `test_invariants()` already has a **separate code path** for `survey_nonprob` (lines 245–301 of `helper-test-data.R`). The weight positivity check at line 287 is inside the `survey_nonprob` branch. The spec doesn't mention that this is a nonprob-specific path — it reads as though there's a single weight check to update.
+
+The main branch (for `survey_taylor`, `survey_replicate`, etc.) also has a `> 0` weight check (around line 340+). If the implementer updates the wrong branch, `survey_taylor` objects would accept zero weights in tests, masking real bugs.
+
+The spec must explicitly state: **only the `survey_nonprob` branch of `test_invariants()` is modified.** The main branch retains `> 0`.
+
+Options:
+- **[A]** Add explicit scoping: "Update only the `survey_nonprob` branch of `test_invariants()` (lines ~286-289 in `helper-test-data.R`). The main branch (for `survey_taylor`, `survey_replicate`, `survey_twophase`) retains strict `> 0`." — Effort: low, Risk: low, Impact: prevents breaking all design type tests, Maintenance: none
+- **[B] Do nothing** — Implementer might update the wrong branch and break 2000+ tests.
+
+**Recommendation: A** — This is essential disambiguation.
+
+---
+
+#### Section: V. Error Table Changes
+
+**Issue 4: Error table row 33 narrowing note not specified precisely**
+Severity: SUGGESTION
+Lens 3 (Contract Completeness)
+
+The spec says to "add a note that [row 33] applies to `survey_taylor`/`survey_replicate` only." But it doesn't show the exact wording to add to `plans/error-messages.md`. Given how the error table is used as the single source of truth, the spec should show the exact change.
+
+Options:
+- **[A]** Add the exact text: update row 33's "Function" column from `S7 validator (survey_taylor)` to `S7 validator (survey_taylor, survey_replicate)` and add a note: "No longer thrown by `survey_nonprob` validator (see `surveycore_error_weights_negative`)." — Effort: low, Risk: low, Impact: keeps error table precise, Maintenance: none
+- **[B] Do nothing** — Implementer can infer the wording.
+
+**Recommendation: A** — The error table is a contract; changes to it should be exact.
+
+---
+
+**Issue 5: New error class `surveycore_error_weights_negative` needs a row number in `plans/error-messages.md`**
+Severity: REQUIRED
+Lens 3 (Contract Completeness)
+
+The spec's error table in §V shows the new class and its message template, but doesn't assign a row number for `plans/error-messages.md`. The error table uses sequential numbering (currently up to row 100 for `get_diffs()`). The new class needs row 101 (or similar) assigned explicitly so the coverage map in the error table stays traceable.
+
+Similarly, the reuse of `surveycore_error_weights_all_zero` for condition 4b needs a new row or a note on row 10, since the existing row 10 documents `as_survey()` usage, not the `survey_nonprob` validator.
+
+Options:
+- **[A]** Assign row 101 for `surveycore_error_weights_negative` (thrown by `survey_nonprob` validator) and add a note to row 10 that `surveycore_error_weights_all_zero` is also thrown by the `survey_nonprob` validator condition 4b. — Effort: low, Risk: low, Impact: traceability, Maintenance: none
+- **[B] Do nothing** — The implementer can assign the number.
+
+**Recommendation: A** — Spec should be complete before handing off.
+
+---
+
+#### Section: VI. Testing
+
+**Issue 6: Tests use `survey_nonprob()` constructor directly — but the constructor doesn't accept bare `data` + `variables` like that**
+Severity: BLOCKING
+Lens 2 (Test Completeness)
+
+The happy-path test in §VI constructs a `survey_nonprob` as:
+```r
+obj <- survey_nonprob(
+  data = df,
+  variables = list(weights = "w", probs_provided = FALSE)
+)
+```
+
+This is the raw S7 constructor, which works. But the `variables` list is incomplete — it's missing `ids`, `strata`, `fpc`, `nest`, and `visible_vars` keys. Per `code-style.md §2`, all keys must always be present. The existing tests (e.g., `test-s7-classes.R` line 754) pass the full list. The spec's test code would likely still work (S7 doesn't validate key completeness at the class level, `test_invariants()` does), but `test_invariants(obj)` will fail because it checks for specific keys.
+
+Looking at the `test_invariants()` nonprob branch: it checks `"weights" %in% names(design@variables)` and `"probs_provided" %in% names(design@variables)`, but the happy-path test calls `test_invariants(obj)`. Since the spec only passes `weights` and `probs_provided`, the invariant check will pass. BUT: if `test_invariants()` is ever expanded to check for `visible_vars` or other keys, these tests will break.
+
+More importantly, the tests should mirror the **realistic creation path**. The spec should use `as_survey_nonprob()` for happy-path tests (which exercises the constructor + validator) and the raw `survey_nonprob()` constructor only for validator-specific error tests.
+
+Options:
+- **[A]** Rewrite happy-path and edge-case tests to use `as_survey_nonprob()`, and use the raw constructor only for error-path tests where direct construction is needed. For error-path tests, use the full `variables` list. — Effort: low, Risk: low, Impact: tests match real usage, Maintenance: lower
+- **[B]** Keep raw constructor but add all required keys to the `variables` list. — Effort: low, Risk: low, Impact: consistent with existing test patterns
+- **[C] Do nothing** — Tests may pass but don't follow established patterns.
+
+**Recommendation: A** — Happy-path tests should use the public API. Error-path tests that need to bypass the constructor to test the S7 validator directly should use the full `variables` list (matching the pattern in existing `test-s7-classes.R` tests).
+
+BUT — there's a catch. The happy-path tests are testing whether the **validator** accepts zero weights. If you use `as_survey_nonprob()`, the constructor's `.validate_weights()` will reject zero weights before the S7 validator ever sees them. The spec explicitly says "zeros only arise from post-construction operations." So happy-path tests for zero weights must:
+
+1. Create a valid `survey_nonprob` via `as_survey_nonprob()` (positive weights)
+2. Then mutate the weights to include zeros (triggering the S7 validator)
+
+The spec's test approach of calling the raw constructor with zero weights will work, but it bypasses the intended workflow. The spec should include **both**: a raw-constructor test (proving the validator accepts zeros) and a workflow test (proving that post-construction weight assignment works).
+
+**Revised recommendation:** Add a workflow-style test that constructs via `as_survey_nonprob()` and then assigns zero weights via `@data<-`, which is the actual use case this change enables. This is the test that proves the surveywts integration works.
+
+---
+
+**Issue 7: No test for the S7 re-validation trigger path (the actual use case)**
+Severity: REQUIRED
+Violates Lens 6 (API Coherence & User Expectations)
+
+The entire motivation for this change (§I "Why This Change") is that S7 re-triggers the validator on `@data<-` assignment when surveywts sets nonrespondent weights to 0. But §VI has no test that exercises this path:
+
+```r
+test_that("survey_nonprob allows zero weights after post-construction assignment", {
+  df <- data.frame(x = 1:5, w = c(1, 2, 3, 4, 5))
+  obj <- as_survey_nonprob(df, weights = w)
+
+  # Simulate surveywts adjust_nonresponse() setting zeros
+  new_data <- obj@data
+  new_data$w <- c(1, 0, 0, 4, 0)
+  obj@data <- new_data  # This triggers S7 re-validation
+
+  test_invariants(obj)
+  expect_equal(sum(obj@data$w == 0), 3L)
+})
+```
+
+This is the test that proves the feature works for its intended purpose. Without it, all other tests are proving a tangential case (direct construction with zeros).
+
+Options:
+- **[A]** Add this test to §VI as a new category: "Workflow path — post-construction weight assignment triggers validator." — Effort: low, Risk: low, Impact: tests the actual use case, Maintenance: none
+- **[B] Do nothing** — The raw-constructor tests prove the validator logic is correct, but don't prove the integration path works.
+
+**Recommendation: A** — This is the most important test in the spec.
+
+---
+
+**Issue 8: Missing Layer 1 vs Layer 3 testing distinction**
+Severity: REQUIRED
+Violates `testing-surveycore.md` (Layer 1 vs Layer 3 error testing)
+
+Per `testing-surveycore.md`, Layer 1 (S7 validator) errors use `class=` only — no snapshot. Layer 3 (constructor) errors use the dual pattern (`class=` + snapshot). The spec's error-path tests for conditions 4a and 4b use the raw constructor (`survey_nonprob()`), which means they're testing Layer 1 errors. The spec correctly uses only `expect_error(class=)` without snapshots — good.
+
+However, the "Existing Tests to Update" section says existing tests that assert `surveycore_error_weights_nonpositive` for `survey_nonprob` must be updated. The existing test at `test-constructors.R:1672` uses the dual pattern (class= + snapshot) because it goes through `as_survey_nonprob()` (Layer 3). The spec needs to clarify: the constructor test at `test-constructors.R:1672` still uses `.validate_weights()` which retains `<= 0`, so that test should NOT be updated — it should remain as-is with `surveycore_error_weights_nonpositive`.
+
+The tests that DO need updating are:
+- `test-constructors.R:1835` — uses raw `survey_nonprob()` constructor, currently asserts `surveycore_error_weights_nonpositive` for negative weights → change to `surveycore_error_weights_negative`
+- `test-constructors.R:1672` — uses `as_survey_nonprob()` with zero weight → this will STILL error via `.validate_weights()` with `surveycore_error_weights_nonpositive` because the constructor validator is unchanged. **Do not update this test.**
+
+The spec's §VI "Existing Tests to Update" section is imprecise about which tests use the raw constructor vs. `as_survey_nonprob()`.
+
+Options:
+- **[A]** Add an explicit table of existing tests that need updating vs. those that should remain unchanged, distinguishing Layer 1 (raw constructor) from Layer 3 (`as_survey_nonprob()`) tests. — Effort: medium, Risk: low, Impact: prevents implementer from breaking working tests, Maintenance: none
+- **[B] Do nothing** — Implementer must figure out which tests to touch by reading the test files.
+
+**Recommendation: A** — The distinction is subtle and important.
+
+---
+
+**Issue 9: Snapshot update guidance is vague**
+Severity: SUGGESTION
+Lens 2 (Test Completeness)
+
+§VI "Snapshot Updates" says "Snapshot files in `_snaps/test-s7-classes.md` will need updating via `snapshot_review()`." But the `survey_nonprob` validator tests in `test-s7-classes.R` currently only have `class=` assertions (Layer 1 — no snapshots). The tests in `test-constructors.R` that use `as_survey_nonprob()` do have snapshots, but those tests are unchanged (the constructor still rejects zero weights).
+
+So which snapshots actually need updating? Likely none — unless the spec's new tests add snapshots. The spec should state: "No existing snapshots are affected. New validator tests use `class=` only per Layer 1 convention."
+
+Options:
+- **[A]** Replace the vague guidance with: "No existing snapshots are affected by this change. New S7 validator tests use `class=` only (Layer 1 convention — no snapshot)." — Effort: low, Risk: low, Impact: saves implementer time investigating, Maintenance: none
+- **[B] Do nothing** — Implementer runs `snapshot_review()` and finds nothing to review.
+
+**Recommendation: A** — Precision saves time.
+
+---
+
+**Issue 10: Test completeness — 13 categories audit**
+Severity: SUGGESTION
+Lens 2 (Test Completeness)
+
+This spec modifies a validator, not an exported analysis function, so most of the 13 test categories are N/A. For completeness:
+
+1. **Happy path** — ✅ Covered (zero weights accepted)
+2. **Numerical oracle** — N/A (validator, not estimator)
+3. **Grouped analysis** — N/A
+4. **Domain estimation** — N/A
+5. **Variance argument** — N/A
+6. **label_values** — N/A
+7. **label_vars** — N/A
+8. **meta() contract** — N/A
+9. **name_style = "broom"** — N/A
+10. **Error paths** — ✅ Covered (conditions 4a, 4b)
+11. **Edge cases** — ✅ Covered (single positive among zeros, mix of zeros+NAs, mix of zeros+negatives)
+12. **Multi-variable** — N/A
+13. **Print snapshot** — N/A
+
+Mechanic checks:
+- `test_invariants()` as first assertion? ✅ Specified in happy-path tests
+- Dual pattern for Layer 3? N/A — no Layer 3 changes
+- `class=` only for Layer 1? ✅ Correctly specified
+- `class=` on every error/warning? ✅
+
+No issues found in this audit.
+
+---
+
+#### Section: VII. Quality Gates
+
+No new issues found. The gates are comprehensive and match the deliverables.
+
+#### Section: VIII. Integration
+
+No new issues found. The dependency chain and release order are clear.
+
+---
+
+## Summary (Pass 1)
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 2 |
+| REQUIRED | 3 |
+| SUGGESTION | 5 |
+
+**Total issues:** 10
+
+**Overall assessment:** The spec is well-structured and the core logic change is clearly defined. The two blocking issues are: (1) the `test_invariants()` change lacks scoping to the `survey_nonprob` branch only, which could break all other design type tests if implemented carelessly; and (2) the test code uses incomplete `variables` lists and doesn't test the actual workflow path (post-construction `@data<-` assignment). Both are straightforward to fix. The required issues involve error table precision and test layer distinctions that prevent implementer mistakes. Once these are resolved, the spec is ready for implementation.
+
+---
+
+# Spec Review: nonprob-zero-weights — Pass 2 (2026-03-18)
+
+### Prior Issues (Pass 1)
+
+| # | Title | Status |
+|---|---|---|
+| 1 | Condition 4b reuses `surveycore_error_weights_all_zero` with different message text | ✅ Resolved — §III lines 138–143 now explicitly note that "the message text intentionally differs between the three call sites that use this class" |
+| 2 | Constructor `.validate_weights()` location not stated explicitly | ✅ Resolved — §III lines 153–158 now name `.validate_weights()` (`R/core-validators.R`, line ~135) with an explicit "Do not modify" directive |
+| 3 | `test_invariants()` change not scoped to `survey_nonprob` branch | ✅ Resolved — §IV lines 164–170 explicitly scope to the `survey_nonprob` branch (~line 287), note the main branch retains `> 0`, and reference the early `return(invisible(design))` separator at ~line 301 |
+| 4 | Error table row 33 narrowing note not precisely specified | ✅ Resolved — §V lines 222–225 show the exact row 33 edit (Function column text + cross-reference note) |
+| 5 | New error class needs row number in error table | ✅ Resolved — §V assigns row 101 for `surveycore_error_weights_negative` and adds a note to row 10 for the `survey_nonprob` condition 4b reuse |
+| 6 | Tests use incomplete `variables` lists in raw constructor | ✅ Resolved — all raw-constructor tests in §VI now use the full `variables` list (all 7 keys: `weights`, `probs_provided`, `ids`, `strata`, `fpc`, `nest`, `visible_vars`) |
+| 7 | No test for S7 re-validation trigger path | ✅ Resolved — §VI now leads with a "Workflow path" test that creates via `as_survey_nonprob()` then mutates weights via `@data<-` |
+| 8 | Missing Layer 1 vs Layer 3 testing distinction | ✅ Resolved — §VI now has an "Existing Tests — Action Table" with explicit Layer, current class, and required action per test, including "Unchanged" for Layer 3 constructor tests |
+| 9 | Snapshot update guidance vague | ✅ Resolved — §VI "Snapshot Updates" now states "No existing snapshots are affected" and clarifies Layer 1 convention |
+| 10 | Test completeness 13-category audit | ✅ No action needed (informational — all categories audited, no gaps found) |
+
+### New Issues
+
+#### Section: I. Scope
+
+No new issues found.
+
+#### Section: II. Architecture
+
+No new issues found.
+
+#### Section: III. Change 1 — Relax `survey_nonprob` Validator Condition 4
+
+No new issues found. The two-check split (4a negative, 4b all-zero) is clearly specified with exact code, rationale, and explicit "What Does NOT Change" boundaries.
+
+#### Section: IV. Change 2 — Update `test_invariants()`
+
+No new issues found. The scoping to the `survey_nonprob` branch is explicit, the replacement code mirrors the validator logic, and the main branch is explicitly protected.
+
+#### Section: V. Error Table Changes
+
+No new issues found. Row assignments (101 new, row 10 note, row 33 update) are precise.
+
+#### Section: VI. Testing
+
+**Issue 11: Missing edge case — all-zero weights with NAs**
+Severity: SUGGESTION
+Lens 4 (Edge Cases)
+
+The test section covers `c(0, 0, 0)` (all-zero, no NAs) and `c(0, NA, 1, 0)` (zeros+NAs with one positive). But there is no test for the boundary between conditions 3 and 4b: weights like `c(0, NA, 0)` where non-NA values exist (condition 3 doesn't fire) but none are positive (condition 4b fires with `surveycore_error_weights_all_zero`).
+
+The logic is simple (`length(non_na) == 2L` so condition 3 passes, `!any(c(0, 0) > 0)` so condition 4b fires), but this exact boundary is worth an explicit test since conditions 3 and 4b share the same error class with different messages.
+
+Options:
+- **[A]** Add an edge-case test with `w = c(0, NA, 0)` asserting `class = "surveycore_error_weights_all_zero"`. — Effort: low, Risk: low, Impact: covers condition 3/4b boundary, Maintenance: none
+- **[B] Do nothing** — The existing all-zero test (`c(0, 0, 0)`) and zeros+NAs test (`c(0, NA, 1, 0)`) cover the individual paths; the boundary is inferrable.
+
+**Recommendation: A** — One extra test block for a boundary between two conditions that share a class name is cheap insurance.
+
+---
+
+**Issue 12: Action table line 1835 — test name should also update**
+Severity: SUGGESTION
+Lens 3 (Contract Completeness)
+
+The action table says to change the error class at `test-constructors.R:1835` from `surveycore_error_weights_nonpositive` to `surveycore_error_weights_negative`, but doesn't mention updating the test description from `"survey_nonprob validator rejects non-positive weight column"` to `"survey_nonprob validator rejects negative weight column"`. After the change, zero weights are no longer "non-positive" violations for `survey_nonprob`, so the old name is misleading.
+
+Options:
+- **[A]** Add a note to the action table: also rename the test to `"survey_nonprob validator rejects negative weights"`. — Effort: low, Risk: low, Impact: test names match behavior, Maintenance: none
+- **[B] Do nothing** — The implementer can infer the rename.
+
+**Recommendation: A** — Test names should describe the behavior they verify.
+
+---
+
+#### Section: VII. Quality Gates
+
+No new issues found.
+
+#### Section: VIII. Integration
+
+No new issues found.
+
+---
+
+## Summary (Pass 2)
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 0 |
+| REQUIRED | 0 |
+| SUGGESTION | 2 |
+
+**Total new issues:** 2
+
+**Prior issues:** 10/10 resolved
+
+**Overall assessment:** The spec comprehensively addressed all 10 Pass 1 issues. The two remaining suggestions are minor polish — an additional edge-case test for the condition 3/4b boundary and a test rename in the action table. Neither blocks implementation. The spec is ready for implementation.

--- a/tests/testthat/helper-test-data.R
+++ b/tests/testthat/helper-test-data.R
@@ -284,8 +284,12 @@ test_invariants <- function(design) {
         label = "weight column has at least one non-NA value"
       )
       testthat::expect_true(
-        all(wt_col[!is.na(wt_col)] > 0),
-        label = "weight column has all positive non-NA values"
+        all(wt_col[!is.na(wt_col)] >= 0),
+        label = "weight column has all non-negative non-NA values"
+      )
+      testthat::expect_true(
+        any(wt_col[!is.na(wt_col)] > 0),
+        label = "weight column has at least one positive non-NA value"
       )
     }
 

--- a/tests/testthat/test-constructors.R
+++ b/tests/testthat/test-constructors.R
@@ -1794,25 +1794,6 @@ test_that("survey_nonprob validator rejects missing weight column in @data", {
   )
 })
 
-test_that("survey_nonprob validator rejects non-numeric weight column", {
-  df <- data.frame(y = 1:5, w = letters[1:5])
-  expect_error(
-    survey_nonprob(
-      data = df,
-      variables = list(
-        weights = "w",
-        probs_provided = FALSE,
-        ids = NULL,
-        strata = NULL,
-        fpc = NULL,
-        nest = FALSE,
-        visible_vars = NULL
-      )
-    ),
-    class = "surveycore_error_weights_not_numeric"
-  )
-})
-
 test_that("survey_nonprob validator rejects all-NA weight column", {
   df <- data.frame(y = 1:5, w = NA_real_)
   expect_error(
@@ -1832,7 +1813,7 @@ test_that("survey_nonprob validator rejects all-NA weight column", {
   )
 })
 
-test_that("survey_nonprob validator rejects non-positive weight column", {
+test_that("survey_nonprob validator rejects negative weights", {
   df <- data.frame(y = 1:5, w = c(1, -1, 1, 1, 1))
   expect_error(
     survey_nonprob(
@@ -1847,7 +1828,7 @@ test_that("survey_nonprob validator rejects non-positive weight column", {
         visible_vars = NULL
       )
     ),
-    class = "surveycore_error_weights_nonpositive"
+    class = "surveycore_error_weights_negative"
   )
 })
 

--- a/tests/testthat/test-s7-classes.R
+++ b/tests/testthat/test-s7-classes.R
@@ -764,3 +764,153 @@ test_that("survey_nonprob validator rejects non-numeric weight column", {
     class = "surveycore_error_weights_not_numeric"
   )
 })
+
+# ── survey_nonprob validator: zero weights ────────────────────────────────────
+
+test_that("survey_nonprob allows zero weights after post-construction assignment", {
+  df <- data.frame(x = 1:5, w = c(1, 2, 3, 4, 5))
+  obj <- as_survey_nonprob(df, weights = w)
+  new_data <- obj@data
+  new_data$w <- c(1, 0, 0, 4, 0)
+  obj@data <- new_data
+  test_invariants(obj)
+  expect_equal(sum(obj@data$w == 0), 3L)
+})
+
+test_that("survey_nonprob validator accepts zero weights with at least one positive", {
+  df <- data.frame(x = 1:5, w = c(1, 0, 0, 2, 0))
+  obj <- survey_nonprob(
+    data = df,
+    variables = list(
+      weights        = "w",
+      probs_provided = FALSE,
+      ids            = NULL,
+      strata         = NULL,
+      fpc            = NULL,
+      nest           = FALSE,
+      visible_vars   = NULL
+    )
+  )
+  test_invariants(obj)
+  expect_s3_class(obj@data, "data.frame")
+  expect_equal(sum(obj@data$w == 0), 3L)
+})
+
+test_that("survey_nonprob validator rejects negative weights", {
+  df <- data.frame(x = 1:3, w = c(1, -0.5, 2))
+  expect_error(
+    survey_nonprob(
+      data = df,
+      variables = list(
+        weights        = "w",
+        probs_provided = FALSE,
+        ids            = NULL,
+        strata         = NULL,
+        fpc            = NULL,
+        nest           = FALSE,
+        visible_vars   = NULL
+      )
+    ),
+    class = "surveycore_error_weights_negative"
+  )
+})
+
+test_that("survey_nonprob validator rejects all-zero weights", {
+  df <- data.frame(x = 1:3, w = c(0, 0, 0))
+  expect_error(
+    survey_nonprob(
+      data = df,
+      variables = list(
+        weights        = "w",
+        probs_provided = FALSE,
+        ids            = NULL,
+        strata         = NULL,
+        fpc            = NULL,
+        nest           = FALSE,
+        visible_vars   = NULL
+      )
+    ),
+    class = "surveycore_error_weights_all_zero"
+  )
+})
+
+test_that("survey_nonprob validator accepts single positive weight among zeros", {
+  df <- data.frame(x = 1:5, w = c(0, 0, 0, 0, 0.001))
+  obj <- survey_nonprob(
+    data = df,
+    variables = list(
+      weights        = "w",
+      probs_provided = FALSE,
+      ids            = NULL,
+      strata         = NULL,
+      fpc            = NULL,
+      nest           = FALSE,
+      visible_vars   = NULL
+    )
+  )
+  test_invariants(obj)
+})
+
+test_that("survey_nonprob validator accepts mix of zeros and NAs with one positive", {
+  df <- data.frame(x = 1:4, w = c(0, NA, 1, 0))
+  obj <- survey_nonprob(
+    data = df,
+    variables = list(
+      weights        = "w",
+      probs_provided = FALSE,
+      ids            = NULL,
+      strata         = NULL,
+      fpc            = NULL,
+      nest           = FALSE,
+      visible_vars   = NULL
+    )
+  )
+  test_invariants(obj)
+})
+
+test_that("survey_nonprob validator rejects mix of zeros and negatives", {
+  df <- data.frame(x = 1:3, w = c(0, -1, 0))
+  expect_error(
+    survey_nonprob(
+      data = df,
+      variables = list(
+        weights        = "w",
+        probs_provided = FALSE,
+        ids            = NULL,
+        strata         = NULL,
+        fpc            = NULL,
+        nest           = FALSE,
+        visible_vars   = NULL
+      )
+    ),
+    class = "surveycore_error_weights_negative"
+  )
+})
+
+test_that("survey_nonprob validator rejects all-zero weights with NAs", {
+  df <- data.frame(x = 1:3, w = c(0, NA, 0))
+  expect_error(
+    survey_nonprob(
+      data = df,
+      variables = list(
+        weights        = "w",
+        probs_provided = FALSE,
+        ids            = NULL,
+        strata         = NULL,
+        fpc            = NULL,
+        nest           = FALSE,
+        visible_vars   = NULL
+      )
+    ),
+    class = "surveycore_error_weights_all_zero"
+  )
+})
+
+test_that("test_invariants() passes for survey_nonprob with zero weights", {
+  df <- data.frame(x = 1:5, w = c(1, 2, 3, 4, 5))
+  obj <- as_survey_nonprob(df, weights = w)
+  new_data <- obj@data
+  new_data$w <- c(1, 0, 0, 2, 0)
+  obj@data <- new_data
+  expect_no_error(test_invariants(obj))
+})


### PR DESCRIPTION
## Release: v0.6.1

## What's in this release

### Bug fixes

* `survey_nonprob` validator now accepts zero weights when at least one positive
  weight exists, unblocking the surveywts `adjust_nonresponse()` workflow.
  Previously, any zero weight triggered an error. Negative weights are still
  rejected.

## Release checklist

- [x] All planned feature PRs are merged to `develop`
- [x] NEWS.md updated with all `feat:` and `fix:` entries since last release
- [x] DESCRIPTION version bumped: `0.6.0.9000` → `0.6.1`
- [x] `devtools::check()` passes: 0 errors, 0 warnings, ≤2 notes
- [ ] After merge: tag `v0.6.1` on main
- [ ] After tagging: bump `develop` to `0.6.1.9000`