### PR TITLE
chore(release): bump version to 0.6.2

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,6 +14,9 @@
 ^docs$
 ^pkgdown$
 ^cran-comments\.md$
+^SOPs$
+^archive$
+^Rplots\.pdf$
 
 # Vignette build artifacts (pre-built HTML from local development)
 ^vignettes/.*_files$

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # R CMD check artifacts
 *.Rcheck/
 *.tar.gz
+Rplots.pdf
 
 # Large raw data files — re-download with data-raw/download-*.R
 data-raw/brfss/LLCP2023.XPT

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: surveycore
 Title: Core Survey Analysis Infrastructure
-Version: 0.6.1
+Version: 0.6.1.9000
 Authors@R:
     person(
         "Jacob", "Dennen", 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: surveycore
 Title: Core Survey Analysis Infrastructure
-Version: 0.6.1.9000
+Version: 0.6.2
 Authors@R:
     person(
         "Jacob", "Dennen", 
@@ -35,7 +35,6 @@ Suggests:
     survey (>= 4.0),
     survival,
     srvyr (>= 1.0),
-    surveytidy,
     haven (>= 2.5.0),
     lifecycle (>= 1.0.0),
     broom (>= 1.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Imports:
     tidyselect (>= 1.2.0),
     cli (>= 3.6.0),
     tibble (>= 3.1.0),
+    dplyr (>= 1.1.0),
     marginaleffects (>= 0.18.0),
     stats
 Suggests:
@@ -34,8 +35,8 @@ Suggests:
     survey (>= 4.0),
     survival,
     srvyr (>= 1.0),
+    surveytidy,
     haven (>= 2.5.0),
-    dplyr (>= 1.1.0),
     lifecycle (>= 1.0.0),
     broom (>= 1.0.0),
     covr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,21 @@
-# surveycore (development version)
+# surveycore 0.6.2
+
+## Bug fixes
 
 * Moved `dplyr` from Suggests to Imports (used unguarded in metadata
   functions).
 * Fixed broken `vignette("estimation")` cross-reference in
   `creating-survey-objects` vignette.
+* Fixed non-canonical CRAN URLs in `surveycore-vs-survey` vignette.
+
+## Documentation
+
 * Updated README to reflect current API: `as_survey_replicate()` (not
   `as_survey_rep()`), added `get_diffs()`, `survey_glm()`, and
   `survey_nonprob`.
+* Added `@examples` to 12 exported functions and `@return` to
+  `survey_base` for CRAN compliance.
+* Added `surveytidy` to Suggests for vignette dependency.
 
 # surveycore 0.6.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,6 @@
   `survey_nonprob`.
 * Added `@examples` to 12 exported functions and `@return` to
   `survey_base` for CRAN compliance.
-* Added `surveytidy` to Suggests for vignette dependency.
 
 # surveycore 0.6.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# surveycore (development version)
+
+* Moved `dplyr` from Suggests to Imports (used unguarded in metadata
+  functions).
+* Fixed broken `vignette("estimation")` cross-reference in
+  `creating-survey-objects` vignette.
+* Updated README to reflect current API: `as_survey_replicate()` (not
+  `as_survey_rep()`), added `get_diffs()`, `survey_glm()`, and
+  `survey_nonprob`.
+
 # surveycore 0.6.1
 
 ## Bug fixes

--- a/R/core-classes.R
+++ b/R/core-classes.R
@@ -49,6 +49,19 @@
 #'
 #' @return A `survey_metadata` object.
 #'
+#' @examples
+#' # Empty metadata (default)
+#' m <- survey_metadata()
+#' m@variable_labels
+#'
+#' # Pre-populated metadata
+#' m <- survey_metadata(
+#'   variable_labels = list(age = "Respondent age", income = "Annual income"),
+#'   value_labels = list(sex = c(Male = 1L, Female = 2L))
+#' )
+#' m@variable_labels$age
+#' m@value_labels$sex
+#'
 #' @family metadata
 #' @export
 survey_metadata <- S7::new_class(
@@ -117,6 +130,9 @@ survey_metadata <- S7::new_class(
 #'     or `NULL`.}
 #' }
 #'
+#' @return Cannot be instantiated directly. See [survey_taylor],
+#'   [survey_replicate], [survey_twophase], or [survey_nonprob] for
+#'   concrete subclasses.
 #' @keywords internal
 #' @export
 survey_base <- S7::new_class(
@@ -185,6 +201,13 @@ survey_base <- S7::new_class(
 #'   groups = character(0),
 #'   call = NULL
 #' )
+#'
+#' @examples
+#' # Prefer as_survey() over calling survey_taylor() directly
+#' d <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
+#'                strata = vstrat, nest = TRUE)
+#' class(d)
+#'
 #' @seealso [as_survey()] to create a `survey_taylor` object.
 #' @family constructors
 #' @export
@@ -348,6 +371,16 @@ survey_taylor <- S7::new_class(
 #'   groups = character(0),
 #'   call = NULL
 #' )
+#'
+#' @examples
+#' # Prefer as_survey_replicate() over calling survey_replicate() directly
+#' set.seed(1)
+#' df <- data.frame(y = rnorm(20), wt = runif(20, 1, 3),
+#'                  rep1 = runif(20, 0.5, 2), rep2 = runif(20, 0.5, 2))
+#' d <- as_survey_replicate(df, weights = wt,
+#'                          repweights = starts_with("rep"), type = "BRR")
+#' class(d)
+#'
 #' @seealso [as_survey_replicate()] to create a `survey_replicate` object.
 #' @family constructors
 #' @export
@@ -481,6 +514,17 @@ survey_replicate <- S7::new_class(
 #'   groups = character(0),
 #'   call = NULL
 #' )
+#'
+#' @examples
+#' # Prefer as_survey_twophase() over calling survey_twophase() directly
+#' set.seed(1)
+#' df <- data.frame(id = 1:100, y = rnorm(100), x = rnorm(100),
+#'                  wt = runif(100, 1, 3),
+#'                  in_phase2 = c(rep(TRUE, 40), rep(FALSE, 60)))
+#' phase1 <- as_survey(df, weights = wt)
+#' d <- as_survey_twophase(phase1, subset = in_phase2)
+#' class(d)
+#'
 #' @seealso [as_survey_twophase()] to create a `survey_twophase` object.
 #' @family constructors
 #' @export

--- a/R/core-metadata.R
+++ b/R/core-metadata.R
@@ -516,6 +516,12 @@ extract_val_labels <- function(x, ..., format = "list", fill = NULL) {
 #' - `"data_frame"`: tibble with columns `variable` and `preface`. Empty:
 #'   zero-row tibble.
 #'
+#' @examples
+#' d <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
+#'                strata = vstrat, nest = TRUE)
+#' d <- set_question_preface(d, happy = "Taken all together...")
+#' extract_question_preface(d, happy)
+#'
 #' @seealso [set_question_preface()] to set a question preface
 #' @family metadata
 #' @export
@@ -565,6 +571,12 @@ extract_question_preface <- function(
 #' - `"list"`: named list of character scalars. Empty: `list()`.
 #' - `"data_frame"`: tibble with columns `variable` and `note`. Empty:
 #'   zero-row tibble.
+#'
+#' @examples
+#' d <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
+#'                strata = vstrat, nest = TRUE)
+#' d <- set_var_note(d, age = "Top-coded at 89")
+#' extract_var_note(d, age)
 #'
 #' @seealso [set_var_note()] to set a note
 #' @family metadata
@@ -1064,6 +1076,12 @@ set_val_labels <- function(x, ..., variable = NULL, labels = NULL) {
 #'
 #' @return The modified object, invisibly.
 #'
+#' @examples
+#' d <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
+#'                strata = vstrat, nest = TRUE)
+#' d <- set_question_preface(d, happy = "Taken all together...")
+#' extract_question_preface(d, happy)
+#'
 #' @seealso [extract_question_preface()] to retrieve a preface
 #' @family metadata
 #' @export
@@ -1120,6 +1138,12 @@ set_question_preface <- function(x, ..., variable = NULL, preface = NULL) {
 #'   `variable`.
 #'
 #' @return The modified object, invisibly.
+#'
+#' @examples
+#' d <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
+#'                strata = vstrat, nest = TRUE)
+#' d <- set_var_note(d, age = "Top-coded at 89")
+#' extract_var_note(d, age)
 #'
 #' @seealso [extract_var_note()] to retrieve a note
 #' @family metadata
@@ -1178,6 +1202,12 @@ set_var_note <- function(x, ..., variable = NULL, note = NULL) {
 #'
 #' @return The modified object, invisibly.
 #'
+#' @examples
+#' d <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
+#'                strata = vstrat, nest = TRUE)
+#' d <- set_universe(d, age = "All respondents 18+")
+#' extract_metadata(d, age)
+#'
 #' @family metadata
 #' @export
 set_universe <- function(x, ..., variable = NULL, universe = NULL) {
@@ -1235,6 +1265,12 @@ set_universe <- function(x, ..., variable = NULL, universe = NULL) {
 #'   When `variable` has length 1, a bare named atomic vector is also accepted.
 #'
 #' @return The modified object, invisibly.
+#'
+#' @examples
+#' d <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
+#'                strata = vstrat, nest = TRUE)
+#' d <- set_missing_codes(d, happy = c(Refused = -1L, DK = -2L))
+#' extract_missing_codes(d, happy)
 #'
 #' @family metadata
 #' @export

--- a/R/glm-clean.R
+++ b/R/glm-clean.R
@@ -306,6 +306,13 @@
 #'   `c("survey_glm_tidy", "survey_result", "tbl_df", "tbl", "data.frame")`.
 #'   Metadata is accessed via [meta()].
 #'
+#' @examples
+#' d <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
+#'                strata = vstrat, nest = TRUE)
+#' fit <- survey_glm(d, age ~ sex)
+#' clean(fit)
+#' clean(fit, conf_level = 0.99, exponentiate = FALSE)
+#'
 #' @seealso [survey_glm()] to fit the model, [meta()] to access metadata.
 #' @family analysis
 #' @export

--- a/R/glm.R
+++ b/R/glm.R
@@ -50,6 +50,13 @@
 #'
 #' @return A `survey_glm_fit` object.
 #'
+#' @examples
+#' # survey_glm_fit objects are created by survey_glm(), not directly
+#' d <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
+#'                strata = vstrat, nest = TRUE)
+#' fit <- survey_glm(d, age ~ sex)
+#' fit@coefficients
+#'
 #' @seealso [survey_glm()] to create a `survey_glm_fit`.
 #' @family constructors
 #' @export

--- a/README.Rmd
+++ b/README.Rmd
@@ -44,12 +44,16 @@ pak::pak("JDenn0514/surveycore")
 
 ## What surveycore provides
 
-- **S7 survey objects**: `survey_taylor`, `survey_replicate`, `survey_twophase`
-- **Constructors**: `as_survey()`, `as_survey_rep()`, `as_survey_twophase()`
+- **S7 survey objects**: `survey_taylor`, `survey_replicate`, `survey_twophase`,
+  `survey_nonprob`
+- **Constructors**: `as_survey()`, `as_survey_replicate()`,
+  `as_survey_twophase()`, `as_survey_nonprob()`
 - **Metadata system**: `set_var_label()`, `set_val_labels()`, `extract_var_label()`,
   `extract_val_labels()` — with automatic haven attribute import
 - **Analysis functions**: `get_freqs()`, `get_means()`, `get_totals()`,
-  `get_corr()`, `get_quantiles()`, `get_ratios()`
+  `get_corr()`, `get_quantiles()`, `get_ratios()`, `get_diffs()`
+- **Regression**: `survey_glm()` for survey-weighted GLMs with `clean()` for
+  tidy coefficient tables
 - **Design utilities**: `update_design()`, `as_svydesign()`, `from_svydesign()`,
   `as_tbl_svy()`, `from_tbl_svy()`
 
@@ -89,7 +93,7 @@ df_rep <- data.frame(
   rep4 = runif(20, 0.5, 2)
 )
 
-d_rep <- as_survey_rep(
+d_rep <- as_survey_replicate(
   df_rep,
   weights = wt,
   repweights = starts_with("rep"),
@@ -104,8 +108,8 @@ surveycore preserves haven-style labels automatically when reading `.xpt` or
 `.sav` files. You can also set labels manually:
 
 ```{r labels}
-d2 <- set_var_label(d, income, "Annual household income (USD)")
-d2 <- set_var_label(d2, age, "Respondent age in years")
+d2 <- set_var_label(d, income = "Annual household income (USD)")
+d2 <- set_var_label(d2, age = "Respondent age in years")
 
 extract_var_label(d2, income)
 extract_var_label(d2, age)

--- a/README.md
+++ b/README.md
@@ -37,14 +37,16 @@ pak::pak("JDenn0514/surveycore")
 ## What surveycore provides
 
 - **S7 survey objects**: `survey_taylor`, `survey_replicate`,
-  `survey_twophase`
-- **Constructors**: `as_survey()`, `as_survey_rep()`,
-  `as_survey_twophase()`
+  `survey_twophase`, `survey_nonprob`
+- **Constructors**: `as_survey()`, `as_survey_replicate()`,
+  `as_survey_twophase()`, `as_survey_nonprob()`
 - **Metadata system**: `set_var_label()`, `set_val_labels()`,
   `extract_var_label()`, `extract_val_labels()` — with automatic haven
   attribute import
 - **Analysis functions**: `get_freqs()`, `get_means()`, `get_totals()`,
-  `get_corr()`, `get_quantiles()`, `get_ratios()`
+  `get_corr()`, `get_quantiles()`, `get_ratios()`, `get_diffs()`
+- **Regression**: `survey_glm()` for survey-weighted GLMs with `clean()`
+  for tidy coefficient tables
 - **Design utilities**: `update_design()`, `as_svydesign()`,
   `from_svydesign()`, `as_tbl_svy()`, `from_tbl_svy()`
 
@@ -111,7 +113,7 @@ df_rep <- data.frame(
   rep4 = runif(20, 0.5, 2)
 )
 
-d_rep <- as_survey_rep(
+d_rep <- as_survey_replicate(
   df_rep,
   weights = wt,
   repweights = starts_with("rep"),
@@ -145,13 +147,15 @@ surveycore preserves haven-style labels automatically when reading
 `.xpt` or `.sav` files. You can also set labels manually:
 
 ``` r
-d2 <- set_var_label(d, income, "Annual household income (USD)")
-d2 <- set_var_label(d2, age, "Respondent age in years")
+d2 <- set_var_label(d, income = "Annual household income (USD)")
+d2 <- set_var_label(d2, age = "Respondent age in years")
 
 extract_var_label(d2, income)
-#> [1] "Annual household income (USD)"
+#>                          income 
+#> "Annual household income (USD)"
 extract_var_label(d2, age)
-#> [1] "Respondent age in years"
+#>                       age 
+#> "Respondent age in years"
 ```
 
 ## Conversion to/from survey and srvyr

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -19,7 +19,7 @@ for the ANES data.
 
 ## Package size
 
-Installed package size is approximately 5.2 MB (4.7 MB in the `data/`
+Installed package size is approximately 6.4 MB (5.1 MB in the `data/`
 subdirectory). The package includes several bundled survey teaching datasets
 (ANES, NHANES, ACS PUMS, Pew Research) that are the primary examples for the
 package functionality.

--- a/man/clean.Rd
+++ b/man/clean.Rd
@@ -53,6 +53,14 @@ with one row per model coefficient (plus optional reference rows for factor
 predictors), design-based standard errors, confidence intervals, and
 structured metadata.
 }
+\examples{
+d <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
+               strata = vstrat, nest = TRUE)
+fit <- survey_glm(d, age ~ sex)
+clean(fit)
+clean(fit, conf_level = 0.99, exponentiate = FALSE)
+
+}
 \seealso{
 \code{\link[=survey_glm]{survey_glm()}} to fit the model, \code{\link[=meta]{meta()}} to access metadata.
 

--- a/man/extract_question_preface.Rd
+++ b/man/extract_question_preface.Rd
@@ -30,6 +30,13 @@ zero-row tibble.
 Returns question preface text for one or more variables in a survey design
 object or data frame.
 }
+\examples{
+d <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
+               strata = vstrat, nest = TRUE)
+d <- set_question_preface(d, happy = "Taken all together...")
+extract_question_preface(d, happy)
+
+}
 \seealso{
 \code{\link[=set_question_preface]{set_question_preface()}} to set a question preface
 

--- a/man/extract_var_note.Rd
+++ b/man/extract_var_note.Rd
@@ -30,6 +30,13 @@ zero-row tibble.
 Returns analyst notes for one or more variables in a survey design object
 or data frame.
 }
+\examples{
+d <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
+               strata = vstrat, nest = TRUE)
+d <- set_var_note(d, age = "Top-coded at 89")
+extract_var_note(d, age)
+
+}
 \seealso{
 \code{\link[=set_var_note]{set_var_note()}} to set a note
 

--- a/man/set_missing_codes.Rd
+++ b/man/set_missing_codes.Rd
@@ -30,6 +30,13 @@ Supports Conventions 1, 2, and 3 — see \code{\link[=set_var_label]{set_var_lab
 the calling conventions. For Convention 3 with a single variable, a bare
 named atomic vector is accepted in addition to a list.
 }
+\examples{
+d <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
+               strata = vstrat, nest = TRUE)
+d <- set_missing_codes(d, happy = c(Refused = -1L, DK = -2L))
+extract_missing_codes(d, happy)
+
+}
 \seealso{
 Other metadata: 
 \code{\link{extract_metadata}()},

--- a/man/set_question_preface.Rd
+++ b/man/set_question_preface.Rd
@@ -27,6 +27,13 @@ are the shared introductory text for a battery of related questions.
 \details{
 Supports Conventions 1, 2, and 3 — see \code{\link[=set_var_label]{set_var_label()}} for details.
 }
+\examples{
+d <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
+               strata = vstrat, nest = TRUE)
+d <- set_question_preface(d, happy = "Taken all together...")
+extract_question_preface(d, happy)
+
+}
 \seealso{
 \code{\link[=extract_question_preface]{extract_question_preface()}} to retrieve a preface
 

--- a/man/set_universe.Rd
+++ b/man/set_universe.Rd
@@ -28,6 +28,13 @@ describes the population to which a variable applies
 \details{
 Supports Conventions 1, 2, and 3 — see \code{\link[=set_var_label]{set_var_label()}} for details.
 }
+\examples{
+d <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
+               strata = vstrat, nest = TRUE)
+d <- set_universe(d, age = "All respondents 18+")
+extract_metadata(d, age)
+
+}
 \seealso{
 Other metadata: 
 \code{\link{extract_metadata}()},

--- a/man/set_var_note.Rd
+++ b/man/set_var_note.Rd
@@ -28,6 +28,13 @@ or other context.
 \details{
 Supports Conventions 1, 2, and 3 — see \code{\link[=set_var_label]{set_var_label()}} for details.
 }
+\examples{
+d <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
+               strata = vstrat, nest = TRUE)
+d <- set_var_note(d, age = "Top-coded at 89")
+extract_var_note(d, age)
+
+}
 \seealso{
 \code{\link[=extract_var_note]{extract_var_note()}} to retrieve a note
 

--- a/man/survey_base.Rd
+++ b/man/survey_base.Rd
@@ -12,6 +12,11 @@ survey_base(
   call = NULL
 )
 }
+\value{
+Cannot be instantiated directly. See \link{survey_taylor},
+\link{survey_replicate}, \link{survey_twophase}, or \link{survey_nonprob} for
+concrete subclasses.
+}
 \description{
 All survey design objects (\code{survey_taylor}, \code{survey_replicate},
 \code{survey_twophase}, \code{survey_nonprob}) inherit from \code{survey_base}. This

--- a/man/survey_glm_fit.Rd
+++ b/man/survey_glm_fit.Rd
@@ -71,6 +71,14 @@ survey-weighted generalised linear model: design-based coefficient
 estimates, variance-covariance matrix, fitted values, residuals, and
 model metadata.
 }
+\examples{
+# survey_glm_fit objects are created by survey_glm(), not directly
+d <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
+               strata = vstrat, nest = TRUE)
+fit <- survey_glm(d, age ~ sex)
+fit@coefficients
+
+}
 \seealso{
 \code{\link[=survey_glm]{survey_glm()}} to create a \code{survey_glm_fit}.
 

--- a/man/survey_metadata.Rd
+++ b/man/survey_metadata.Rd
@@ -54,6 +54,20 @@ transformation history for variables in a survey design object.
 Automatically populated from haven-style attributes when
 \code{\link[=as_survey]{as_survey()}} or related constructors are called.
 }
+\examples{
+# Empty metadata (default)
+m <- survey_metadata()
+m@variable_labels
+
+# Pre-populated metadata
+m <- survey_metadata(
+  variable_labels = list(age = "Respondent age", income = "Annual income"),
+  value_labels = list(sex = c(Male = 1L, Female = 2L))
+)
+m@variable_labels$age
+m@value_labels$sex
+
+}
 \seealso{
 Other metadata: 
 \code{\link{extract_metadata}()},

--- a/man/survey_replicate.Rd
+++ b/man/survey_replicate.Rd
@@ -55,6 +55,16 @@ a property.}
 }
 }
 
+\examples{
+# Prefer as_survey_replicate() over calling survey_replicate() directly
+set.seed(1)
+df <- data.frame(y = rnorm(20), wt = runif(20, 1, 3),
+                 rep1 = runif(20, 0.5, 2), rep2 = runif(20, 0.5, 2))
+d <- as_survey_replicate(df, weights = wt,
+                         repweights = starts_with("rep"), type = "BRR")
+class(d)
+
+}
 \seealso{
 \code{\link[=as_survey_replicate]{as_survey_replicate()}} to create a \code{survey_replicate} object.
 

--- a/man/survey_taylor.Rd
+++ b/man/survey_taylor.Rd
@@ -50,6 +50,13 @@ rather than \code{weights} to \code{\link[=as_survey]{as_survey()}}.}
 }
 }
 
+\examples{
+# Prefer as_survey() over calling survey_taylor() directly
+d <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
+               strata = vstrat, nest = TRUE)
+class(d)
+
+}
 \seealso{
 \code{\link[=as_survey]{as_survey()}} to create a \code{survey_taylor} object.
 

--- a/man/survey_twophase.Rd
+++ b/man/survey_twophase.Rd
@@ -49,6 +49,17 @@ indicates Phase 2 membership (\code{TRUE} = selected into Phase 2).}
 }
 }
 
+\examples{
+# Prefer as_survey_twophase() over calling survey_twophase() directly
+set.seed(1)
+df <- data.frame(id = 1:100, y = rnorm(100), x = rnorm(100),
+                 wt = runif(100, 1, 3),
+                 in_phase2 = c(rep(TRUE, 40), rep(FALSE, 60)))
+phase1 <- as_survey(df, weights = wt)
+d <- as_survey_twophase(phase1, subset = in_phase2)
+class(d)
+
+}
 \seealso{
 \code{\link[=as_survey_twophase]{as_survey_twophase()}} to create a \code{survey_twophase} object.
 

--- a/vignettes/creating-survey-objects.Rmd
+++ b/vignettes/creating-survey-objects.Rmd
@@ -39,7 +39,7 @@ It is written for three audiences:
   raking weights, skip ahead to [Section 6](#sec-calibrated).
 
 This vignette covers object *creation* only. Estimation functions (`get_means()`,
-`get_totals()`, etc.) are covered in `vignette("estimation")`.
+`get_totals()`, etc.) are covered in `vignette("getting-started")`.
 
 ---
 

--- a/vignettes/surveycore-vs-survey.Rmd
+++ b/vignettes/surveycore-vs-survey.Rmd
@@ -18,8 +18,6 @@ knitr::opts_chunk$set(comment = "#>")
 
 has_survey     <- requireNamespace("survey",     quietly = TRUE)
 has_srvyr      <- requireNamespace("srvyr",      quietly = TRUE)
-has_surveytidy <- requireNamespace("surveytidy", quietly = TRUE)
-if (has_surveytidy) loadNamespace("surveytidy")
 
 if (has_survey) {
   library(survey)
@@ -612,107 +610,7 @@ information is lost after estimation.
 
 ---
 
-## 5. Data Manipulation with `surveytidy` (Optional)
-
-`surveytidy` is surveycore's companion package for data manipulation. It
-provides dplyr verbs — `filter()`, `mutate()`, `select()`, `group_by()`,
-`rename()` — that work directly on survey design objects while preserving
-the survey weights and design structure. srvyr bundles design + analysis +
-manipulation in one package; surveycore separates them, keeping surveycore's
-dependency footprint small.
-
-```{r surveytidy-install, eval=FALSE}
-pak::pak("jacobdennen/surveytidy")
-```
-
-```{r surveytidy-load, eval=FALSE, include=FALSE}
-# surveytidy loaded via loadNamespace() in setup chunk
-```
-
-### 5.1 `mutate()` — Creating New Variables
-
-**survey** — modify the data frame before (or after) creating the design; the
-design must be recreated if variables are added after construction
-
-```{r mutate-survey, eval=has_survey}
-ns_wave1$fav_diff <- ns_wave1$cand_favorability_trump -
-  ns_wave1$cand_favorability_biden
-ns_sv_mod <- svydesign(ids = ~1, weights = ~weight, data = ns_wave1)
-```
-
-**surveytidy** — create variables in-pipe; design is preserved
-
-```{r mutate-sc, eval=has_surveytidy}
-ns_sc |>
-  mutate(fav_diff = cand_favorability_trump - cand_favorability_biden) |>
-  get_means(fav_diff)
-```
-
-### 5.2 `filter()` — Domain Estimation
-
-Domain estimation restricts *what is estimated* without removing rows from
-the design — all three approaches keep the full design to compute correct
-standard errors.
-
-**survey**
-
-```{r filter-survey, eval=has_survey}
-# Subset returns a domain-restricted design
-under_40_sv <- subset(ns_sv, age < 40)
-svymean(~discrimination_blacks, under_40_sv, na.rm = TRUE)
-```
-
-**surveytidy**
-
-```{r filter-sc, eval=has_surveytidy}
-ns_sc |>
-  filter(age < 40) |>
-  get_means(discrimination_blacks)
-```
-
-### 5.3 `group_by()` vs. `group =`
-
-surveycore provides two equivalent ways to compute grouped estimates:
-
-```{r groupby-sc, eval=has_surveytidy}
-# group_by() — persistent grouping; works in pipelines
-ns_sc |>
-  group_by(pid3) |>
-  get_freqs(consider_trump)
-```
-
-```{r group-arg-sc}
-# group = — ad hoc; no surveytidy required
-get_freqs(ns_sc, consider_trump, group = pid3)
-```
-
-Both return identical results. Use `group =` for one-off analyses; use
-`group_by()` in pipelines where the grouping should persist across steps.
-
-### 5.4 Complete Pipeline
-
-**srvyr**
-
-```{r pipeline-srvyr, eval=has_survey && has_srvyr}
-ns_wave1 |>
-  as_survey_design(weights = weight) |>
-  group_by(pid3) |>
-  summarise(
-    mean_disc = survey_mean(discrimination_blacks, vartype = "ci", na.rm = TRUE)
-  )
-```
-
-**surveycore + surveytidy**
-
-```{r pipeline-sc, eval=has_surveytidy}
-as_survey_nonprob(ns_wave1, weights = weight) |>
-  filter(age < 65) |>
-  get_means(discrimination_blacks, group = pid3)
-```
-
----
-
-## 6. Notable Differences
+## 5. Notable Differences
 
 | | survey | srvyr | surveycore |
 |--|--------|-------|------------|
@@ -724,12 +622,12 @@ as_survey_nonprob(ns_wave1, weights = weight) |>
 | **Weighted N** | Separate call | Separate call | `n_weighted = TRUE` |
 | **Correlation CIs** | None (`svycor()`) | No verb | Fisher-Z CIs via `get_corr()` |
 | **Non-probability design** | No dedicated constructor | No dedicated constructor | `as_survey_nonprob()` |
-| **Manipulation** | Pre/post construction | Bundled via pipe | `surveytidy` (separate package) |
+| **Manipulation** | Pre/post construction | Bundled via pipe | `surveytidy` (companion package) |
 | **Runtime `survey` dep.** | Is `survey` | Wraps `survey` | Vendored — `survey` not required |
 
 ---
 
-## 7. Function Reference Table
+## 6. Function Reference Table
 
 | Task | survey | srvyr | surveycore |
 |------|--------|-------|------------|
@@ -751,15 +649,15 @@ as_survey_nonprob(ns_wave1, weights = weight) |>
 | Value labels | Manual recode | Manual recode | `label_values = TRUE` (default) |
 | Min-cell warning | ✗ | ✗ | `min_cell_n = 30L` (default) |
 | Weighted N | Separate call | Separate call | `n_weighted = TRUE` |
-| Domain filter | `subset(d, cond)` | `filter(cond)` | `filter(cond)` (surveytidy) |
-| Mutate | Modify df, recreate | `mutate(...)` | `mutate(...)` (surveytidy) |
-| Group by | `svyby(...)` | `group_by(...)` | `group_by(...)` or `group=` arg |
+| Domain filter | `subset(d, cond)` | `filter(cond)` | `filter(cond)` (`surveytidy`) |
+| Mutate | Modify df, recreate | `mutate(...)` | `mutate(...)` (`surveytidy`) |
+| Group by | `svyby(...)` | `group_by(...)` | `group_by(...)` (`surveytidy`) or `group=` arg |
 
 ⚠ = partial / workaround; ✗ = no equivalent
 
 ---
 
-## 8. Learning More
+## 7. Learning More
 
 - `vignette("getting-started")` — full surveycore overview with worked examples
 - `vignette("creating-survey-objects")` — all five constructors, including

--- a/vignettes/surveycore-vs-survey.Rmd
+++ b/vignettes/surveycore-vs-survey.Rmd
@@ -43,7 +43,7 @@ section shows the same task three ways: `survey`, `srvyr`, and `surveycore`.
 
 **Constructor comparisons** use the `api` dataset from the `survey` package —
 the same reference dataset as the
-[srvyr comparison vignette](https://cran.r-project.org/web/packages/srvyr/vignettes/srvyr-vs-survey.html),
+[srvyr comparison vignette](https://CRAN.R-project.org/package=srvyr),
 so cross-referencing is easy. **Analysis comparisons** use `ns_wave1`
 (Nationscape Wave 1, Democracy Fund + UCLA) from surveycore's bundled data.
 
@@ -764,6 +764,6 @@ as_survey_nonprob(ns_wave1, weights = weight) |>
 - `vignette("getting-started")` — full surveycore overview with worked examples
 - `vignette("creating-survey-objects")` — all five constructors, including
   two-phase designs and the `nest` argument
-- [srvyr comparison vignette](https://cran.r-project.org/web/packages/srvyr/vignettes/srvyr-vs-survey.html)
+- [srvyr comparison vignette](https://CRAN.R-project.org/package=srvyr)
   — the original side-by-side that this vignette is modeled on
 - @lumley2010 — the definitive reference on complex survey analysis in R


### PR DESCRIPTION
## Release: v0.6.2

## What's in this release

### Bug fixes

* Moved `dplyr` from Suggests to Imports (used unguarded in metadata functions).
* Fixed broken `vignette("estimation")` cross-reference in `creating-survey-objects` vignette.
* Fixed non-canonical CRAN URLs in `surveycore-vs-survey` vignette.

### Documentation

* Updated README to reflect current API: `as_survey_replicate()` (not `as_survey_rep()`), added `get_diffs()`, `survey_glm()`, and `survey_nonprob`.
* Added `@examples` to 12 exported functions and `@return` to `survey_base` for CRAN compliance.

## Release checklist

- [x] All planned feature PRs are merged to `develop`
- [x] NEWS.md updated with all `feat:` and `fix:` entries since last release
- [x] DESCRIPTION version bumped: `0.6.1.9000` → `0.6.2`
- [x] `devtools::check()` passes: 0 errors, 0 warnings, 0 notes
- [x] CI passes on all platforms
- [ ] After merge: tag `v0.6.2` on main
- [ ] After tagging: bump `develop` to `0.6.2.9000`