### PR TITLE
feat(metadata): add sata property to survey_metadata

### DIFF
--- a/R/core-classes.R
+++ b/R/core-classes.R
@@ -38,6 +38,9 @@
 #' @param missing_codes A named list mapping variable names to atomic
 #'   vectors of missing-value codes
 #'   (e.g., `list(age = c(Refused = 99L, DK = 98L))`).
+#' @param sata A named list mapping variable names to `TRUE` for variables
+#'   that are select-all-that-apply (SATA). Only variables explicitly marked
+#'   as SATA appear in this list — absence means the variable is not SATA.
 #' @param transformations A named list tracking variable transformation
 #'   history (populated automatically during operations).
 #' @param weighting_history A list recording weighting operations applied to
@@ -88,6 +91,10 @@ survey_metadata <- S7::new_class(
       default = quote(list())
     ),
     missing_codes = S7::new_property(
+      S7::class_list,
+      default = quote(list())
+    ),
+    sata = S7::new_property(
       S7::class_list,
       default = quote(list())
     ),

--- a/R/core-validators.R
+++ b/R/core-validators.R
@@ -458,6 +458,7 @@ NULL
     rename_map
   )
   metadata@notes <- .rename_list_keys(metadata@notes, rename_map)
+  metadata@sata <- .rename_list_keys(metadata@sata, rename_map)
   metadata@transformations <- .rename_list_keys(
     metadata@transformations,
     rename_map

--- a/R/utils.R
+++ b/R/utils.R
@@ -491,3 +491,14 @@ SURVEYCORE_DOMAIN_COL <- "..surveycore_domain.."
     fpcs = fpcs
   )
 }
+
+
+# ── .get_data_for_select() ────────────────────────────────────────────────────
+#
+# Returns the data frame to pass to tidyselect::eval_select().
+# For data frames, returns x directly. For survey objects, returns x@data.
+# Two confirmed call sites: set_sata() and extract_sata().
+#' @noRd
+.get_data_for_select <- function(x) {
+  if (is.data.frame(x)) x else x@data
+}

--- a/changelog/sata-metadata/feature-sata-property.md
+++ b/changelog/sata-metadata/feature-sata-property.md
@@ -1,0 +1,27 @@
+# feat(metadata): add sata property to survey_metadata
+
+**Date**: 2026-04-16
+**Branch**: feature/sata-property
+**Phase**: Phase sata-metadata
+
+## Changes
+
+- Add `sata` property (`S7::class_list`, default `list()`) to `survey_metadata`
+  S7 class for sparse storage of select-all-that-apply flags per variable
+- Add `.get_data_for_select()` internal helper to `R/utils.R` for returning
+  the correct data frame to pass to `tidyselect::eval_select()` in upcoming
+  `set_sata()` and `extract_sata()` functions
+- Update `.rename_metadata_keys()` in `R/core-validators.R` to propagate
+  `sata` flags when variables are renamed
+
+## Files Modified
+
+- `R/core-classes.R` — added `sata` property to `survey_metadata` with
+  `S7::class_list` type and `list()` default; updated `@param` roxygen doc
+- `R/utils.R` — added `.get_data_for_select()` helper (not exported)
+- `R/core-validators.R` — added `metadata@sata <- .rename_list_keys(...)` call
+  in `.rename_metadata_keys()`
+- `tests/testthat/test-s7-classes.R` — added two test blocks covering `sata`
+  property default and named-list acceptance
+- `tests/testthat/test-metadata-system.R` — added test block verifying
+  `.rename_metadata_keys()` propagates `sata` flags through rename operations

--- a/man/survey_metadata.Rd
+++ b/man/survey_metadata.Rd
@@ -11,6 +11,7 @@ survey_metadata(
   notes = list(),
   universe = list(),
   missing_codes = list(),
+  sata = list(),
   transformations = list(),
   weighting_history = list()
 )
@@ -34,6 +35,10 @@ population to which a variable applies.}
 \item{missing_codes}{A named list mapping variable names to atomic
 vectors of missing-value codes
 (e.g., \code{list(age = c(Refused = 99L, DK = 98L))}).}
+
+\item{sata}{A named list mapping variable names to \code{TRUE} for variables
+that are select-all-that-apply (SATA). Only variables explicitly marked
+as SATA appear in this list — absence means the variable is not SATA.}
 
 \item{transformations}{A named list tracking variable transformation
 history (populated automatically during operations).}

--- a/tests/testthat/test-metadata-system.R
+++ b/tests/testthat/test-metadata-system.R
@@ -2381,3 +2381,18 @@ test_that("snapshot: extract_metadata() surveycore_error_fill_invalid", {
   d <- make_labeled_design()
   expect_snapshot(error = TRUE, extract_metadata(d, fill = NA_character_))
 })
+
+
+# ── .rename_metadata_keys() sata integration ───────────────────────────────────
+
+test_that(".rename_metadata_keys() propagates sata flag through rename", {
+  d <- as_survey(nhanes_2017, ids = sdmvpsu, weights = wtint2yr,
+                 strata = sdmvstra, nest = TRUE)
+  d@metadata@sata[["riagendr"]] <- TRUE
+  d@metadata <- surveycore:::.rename_metadata_keys(
+    d@metadata,
+    c(riagendr = "gender")
+  )
+  expect_null(d@metadata@sata[["riagendr"]])
+  expect_true(isTRUE(d@metadata@sata[["gender"]]))
+})

--- a/tests/testthat/test-s7-classes.R
+++ b/tests/testthat/test-s7-classes.R
@@ -914,3 +914,18 @@ test_that("test_invariants() passes for survey_nonprob with zero weights", {
   obj@data <- new_data
   expect_no_error(test_invariants(obj))
 })
+
+
+# ── survey_metadata sata property ─────────────────────────────────────────────
+
+test_that("survey_metadata has a sata property with list() default", {
+  m <- survey_metadata()
+  expect_true(S7::S7_inherits(m, survey_metadata))
+  expect_identical(m@sata, list())
+  expect_identical(length(m@sata), 0L)
+})
+
+test_that("survey_metadata sata accepts a named list", {
+  m <- survey_metadata(sata = list(news_tv = TRUE, news_online = TRUE))
+  expect_identical(m@sata$news_tv, TRUE)
+})


### PR DESCRIPTION
## What this does

This PR adds the `sata` (select-all-that-apply) property to `survey_metadata` — the first step toward full SATA metadata support. The new property is a named logical list that stores SATA flags per variable, with a sparse representation (only `TRUE` entries stored, absent = not SATA). It also adds the `.get_data_for_select()` internal helper used by upcoming `set_sata()` and `extract_sata()` functions, and updates `.rename_metadata_keys()` so SATA flags follow variables when they are renamed.

## Technical changes

- **Modified classes:** `survey_metadata` — new `sata` property (`S7::class_list`, default `list()`)
- **New helpers:** `.get_data_for_select()` in `R/utils.R`
- **Modified helpers:** `.rename_metadata_keys()` in `R/core-validators.R`
- **New tests:** 3 new test blocks across `test-s7-classes.R` and `test-metadata-system.R`
- **Modified files:** `R/core-classes.R`, `R/utils.R`, `R/core-validators.R`, `tests/testthat/test-s7-classes.R`, `tests/testthat/test-metadata-system.R`
- **Plan section:** `feature/sata-property` — PR 1 from `plans/impl-sata-metadata.md`

## Spec coverage

**From `plans/spec-sata-metadata.md §III. sata Property on survey_metadata`:**
- [x] `sata` property on `survey_metadata` with `list()` default
- [x] Only `TRUE` entries stored (sparse representation)
- [x] `S7::class_list` type

**From `plans/spec-sata-metadata.md §VIII. .rename_metadata_keys() Integration`:**
- [x] `.rename_metadata_keys()` includes `sata`

## Test results

`devtools::test()`: 0 failures (257 pass in s7-classes, 440 pass in metadata-system)
`devtools::check()`: 0 errors, 0 warnings, 2 notes (pre-existing: timestamp check + surveytidy vignette)

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)