### PR TITLE
feat(variance): vendor saddlepoint CDF helpers from survey

### DIFF
--- a/R/variance-vendored-saddlepoint.R
+++ b/R/variance-vendored-saddlepoint.R
@@ -1,0 +1,151 @@
+# ---------------------------------------------------------------------------
+# R/variance-vendored-saddlepoint.R
+# ---------------------------------------------------------------------------
+# Saddlepoint CDF helpers for weighted chi-square and F sums.
+#
+# ATTRIBUTION — VENDORED CODE:
+# Adapted from the survey package by Thomas Lumley
+# (https://cran.r-project.org/package=survey), licensed under GPL-2 | GPL-3.
+# Source: survey/R/pchisqsum.R at version 4.4-8.
+#
+# - .saddle() is a byte-for-byte port of survey:::saddle().
+# - .pchisqsum_sad() is a port of the saddlepoint branch of
+#   survey::pchisqsum().
+# - .pFsum_sad() is DERIVED from survey::pFsum() — surveycore's signature
+#   adds a `mean.deff` scalar argument that pre-applies the Rao-Scott
+#   rescaling at the call site (spec §V.5, Pass 3 Issue 65). Under the
+#   default mean.deff = mean(a) the helper is equivalent to upstream when
+#   the caller passes `x` pre-divided by mean(a).
+#
+# Modifications: helpers are dotted/internal (not exported); no dependency
+# on CompQuadForm; no Satterthwaite-only / integration branches (those are
+# intentionally out of scope for the vendored slice).
+# ---------------------------------------------------------------------------
+
+# Saddlepoint root-finder (direct port of survey:::saddle).
+#
+# @keywords internal
+# @noRd
+.saddle <- function(x, lambda) {
+  d <- max(lambda)
+  lambda <- lambda / d
+  x <- x / d
+  k0 <- function(zeta) -sum(log(1 - 2 * zeta * lambda)) / 2
+  kprime0 <- function(zeta) {
+    sapply(zeta, function(zz) sum(lambda / (1 - 2 * zz * lambda)))
+  }
+  kpprime0 <- function(zeta) {
+    2 * sum(lambda^2 / (1 - 2 * zeta * lambda)^2)
+  }
+  n <- length(lambda)
+  if (any(lambda < 0)) {
+    lmin <- max(1 / (2 * lambda[lambda < 0])) * 0.99999
+  } else if (x > sum(lambda)) {
+    lmin <- -0.01
+  } else {
+    lmin <- -length(lambda) / (2 * x)
+  }
+  lmax <- min(1 / (2 * lambda[lambda > 0])) * 0.99999
+  hatzeta <- stats::uniroot(
+    function(zeta) kprime0(zeta) - x,
+    lower = lmin,
+    upper = lmax,
+    tol = 1e-08
+  )$root
+  w <- sign(hatzeta) * sqrt(2 * (hatzeta * x - k0(hatzeta)))
+  v <- hatzeta * sqrt(kpprime0(hatzeta))
+  if (abs(hatzeta) < 1e-04) {
+    NA
+  } else {
+    stats::pnorm(w + log(v / w) / w, lower.tail = FALSE)
+  }
+}
+
+# Saddlepoint approximation to Pr(sum(a_i * chi2(df_i)) > x).
+#
+# Port of the saddlepoint branch of survey::pchisqsum(). Falls back to the
+# Satterthwaite moment-matched chi-square approximation when .saddle()
+# returns NA (consistent with upstream's `if (!is.na(sad)) guess <- sad`
+# pattern).
+#
+# @keywords internal
+# @noRd
+.pchisqsum_sad <- function(x, df, a, lower.tail = FALSE) {
+  # Satterthwaite guess — serves as the fallback when the saddlepoint
+  # root-finder returns NA.
+  sat_a <- a
+  if (any(df > 1)) {
+    sat_a <- rep(a, df)
+  }
+  tr <- mean(sat_a)
+  tr2 <- mean(sat_a^2) / (tr^2)
+  scale <- tr * tr2
+  ndf <- length(sat_a) / tr2
+  guess <- stats::pchisq(x / scale, ndf, lower.tail = lower.tail)
+
+  # Saddlepoint: expand a by df to produce the per-chi-square-component
+  # eigenvalue vector, then call .saddle() per x element.
+  lambda <- rep(a, df)
+  sad <- sapply(x, .saddle, lambda = lambda)
+  if (lower.tail) {
+    sad <- 1 - sad
+  }
+  ifelse(is.na(sad), guess, sad)
+}
+
+# Saddlepoint approximation to the design-adjusted F reference.
+#
+# Derived from survey::pFsum() — the surveycore signature adds a
+# `mean.deff` scalar. Callers supply `x` already divided by `mean.deff`;
+# the helper multiplies back internally when it needs the original
+# statistic (for the F reference and for the saddle augmentation
+# `-x / ddf`). Under the default `mean.deff = mean(a)` the helper matches
+# upstream when the caller passes `x_upstream / mean(a)`.
+#
+# @keywords internal
+# @noRd
+.pFsum_sad <- function(x, df, a, ddf, mean.deff = mean(a), lower.tail = FALSE) {
+  if (is.infinite(ddf)) {
+    return(.pchisqsum_sad(
+      x * mean.deff,
+      df = df,
+      a = a,
+      lower.tail = lower.tail
+    ))
+  }
+
+  # Expand a by df for the Satterthwaite moments (matches upstream's
+  # `if (any(df > 1)) a <- rep(a, df)` step).
+  sat_a <- a
+  sat_df <- df
+  if (any(df > 1)) {
+    sat_a <- rep(a, df)
+  }
+  tr <- mean(sat_a)
+  tr2 <- mean(sat_a^2) / (tr^2)
+  scale <- tr * tr2
+  ndf <- length(sat_a) / tr2
+
+  # Satterthwaite fallback; x is pre-divided by mean.deff so multiply back
+  # to reconstruct the upstream statistic before dividing by ndf * scale.
+  orig_x <- x * mean.deff
+  rval <- stats::pf(orig_x / ndf / scale, ndf, ddf, lower.tail = lower.tail)
+
+  # Saddlepoint: augment the eigenvalue vector with -orig_x / ddf, expand by
+  # df, and call .saddle() at 0. Upstream only uses the saddle value when
+  # it is non-NA.
+  a_aug <- c(a, -orig_x / ddf)
+  df_aug <- c(df, ddf)
+  if (any(df_aug > 1)) {
+    a_aug <- rep(a_aug, df_aug)
+  }
+  s <- .saddle(0, a_aug)
+  if (!is.na(s)) {
+    if (lower.tail) {
+      rval <- 1 - s
+    } else {
+      rval <- s
+    }
+  }
+  rval
+}

--- a/changelog/get-anova/pr-b-saddlepoint.md
+++ b/changelog/get-anova/pr-b-saddlepoint.md
@@ -1,0 +1,34 @@
+# feat(variance): vendor saddlepoint CDF helpers from survey
+
+**Date**: 2026-04-18
+**Branch**: feature/variance-vendored-saddlepoint
+**Plan**: `plans/impl-get-anova.md` — PR B
+
+## Changes
+
+- Vendor `.saddle()` and `.pchisqsum_sad()` byte-for-byte from
+  `survey/R/pchisqsum.R` @ 4.4-8 (GPL-3 compatible with surveycore's
+  GPL-3 license).
+- Derive `.pFsum_sad()` per spec §V.5 with an added `mean.deff` scalar
+  argument that makes the Rao-Scott rescaling visible at the call site
+  (Pass 3 Issue 65). Under the default `mean.deff = mean(a)` the helper
+  matches upstream.
+- Add parity test grid vs `survey::pchisqsum(..., method = "saddlepoint")`
+  and `survey::pFsum(..., method = "saddlepoint")` at absolute tolerance
+  `1e-10` across five regimes: upper tail, mid-range, near zero, scalar
+  `a`, large `df`.
+- Add NA-regime parity at the root-finder level: `.saddle()` returns `NA`
+  on the same inputs where `survey:::saddle()` returns `NA`.
+- Both helpers are internal (no `@export`), dotted-name convention; no
+  new package dependencies (`survey` is used via `skip_if_not_installed()`
+  in tests only).
+
+## Files Modified
+
+- `R/variance-vendored-saddlepoint.R` — new file with `.saddle()`,
+  `.pchisqsum_sad()`, `.pFsum_sad()` and GPL-3 attribution header
+  pointing at `survey/R/pchisqsum.R` @ 4.4-8.
+- `tests/testthat/test-variance-vendored-saddlepoint.R` — new parity
+  test file with 8 `test_that()` blocks (5 `.pchisqsum_sad()` regimes,
+  4 `.pFsum_sad()` regimes, 1 NA-regime root-finder parity test), all
+  guarded by `skip_if_not_installed("survey")`.

--- a/tests/testthat/test-variance-vendored-saddlepoint.R
+++ b/tests/testthat/test-variance-vendored-saddlepoint.R
@@ -1,0 +1,256 @@
+# Parity tests for the vendored saddlepoint CDF helpers
+# (.pchisqsum_sad(), .pFsum_sad(), and the underlying .saddle() root-finder).
+#
+# These are byte-for-byte parity tests against survey 4.4-8 at absolute
+# tolerance 1e-10. See spec §V.5 and §VII (parity table). The wrapper-level
+# Satterthwaite fallback is out of scope here; the NA-regime parity test
+# targets the root-finder directly per the impl plan PR B task 3.
+
+# ---------------------------------------------------------------------------
+# .pchisqsum_sad() vs survey::pchisqsum(..., method = "saddlepoint")
+# ---------------------------------------------------------------------------
+
+test_that(".pchisqsum_sad() matches survey::pchisqsum() upper-tail regime", {
+  skip_if_not_installed("survey")
+  xs <- stats::qchisq(c(1 - 1e-6, 1 - 1e-3, 1 - 1e-2), df = 3)
+  for (a in list(c(1, 1, 1), c(3, 1, 0.5))) {
+    for (x in xs) {
+      ours <- .pchisqsum_sad(x, df = c(1, 1, 1), a = a, lower.tail = FALSE)
+      theirs <- survey::pchisqsum(
+        x,
+        df = c(1, 1, 1),
+        a = a,
+        method = "saddlepoint",
+        lower.tail = FALSE
+      )
+      expect_equal(ours, theirs, tolerance = 1e-10)
+    }
+  }
+})
+
+test_that(".pchisqsum_sad() matches survey::pchisqsum() mid-range regime", {
+  skip_if_not_installed("survey")
+  xs <- stats::qchisq(c(0.25, 0.5, 0.75), df = 3)
+  for (a in list(c(1, 1, 1), c(3, 1, 0.5))) {
+    for (x in xs) {
+      ours <- .pchisqsum_sad(x, df = c(1, 1, 1), a = a, lower.tail = FALSE)
+      theirs <- survey::pchisqsum(
+        x,
+        df = c(1, 1, 1),
+        a = a,
+        method = "saddlepoint",
+        lower.tail = FALSE
+      )
+      expect_equal(ours, theirs, tolerance = 1e-10)
+    }
+  }
+})
+
+test_that(".pchisqsum_sad() matches survey::pchisqsum() near-zero regime", {
+  skip_if_not_installed("survey")
+  a <- c(1, 1, 1)
+  x <- 0.01 * sum(a)
+  ours <- .pchisqsum_sad(x, df = c(1, 1, 1), a = a, lower.tail = FALSE)
+  theirs <- survey::pchisqsum(
+    x,
+    df = c(1, 1, 1),
+    a = a,
+    method = "saddlepoint",
+    lower.tail = FALSE
+  )
+  expect_equal(ours, theirs, tolerance = 1e-10)
+})
+
+test_that(".pchisqsum_sad() matches survey::pchisqsum() with scalar a", {
+  skip_if_not_installed("survey")
+  x <- stats::qchisq(0.95, df = 1) * 2
+  ours <- .pchisqsum_sad(x, df = 1, a = 2, lower.tail = FALSE)
+  theirs <- survey::pchisqsum(
+    x,
+    df = 1,
+    a = 2,
+    method = "saddlepoint",
+    lower.tail = FALSE
+  )
+  expect_equal(ours, theirs, tolerance = 1e-10)
+})
+
+test_that(".pchisqsum_sad() matches survey::pchisqsum() large df regime", {
+  skip_if_not_installed("survey")
+  xs <- stats::qchisq(c(0.5, 0.99), df = 20)
+  df <- rep(1L, 20)
+  a <- rep(1, 20)
+  for (x in xs) {
+    ours <- .pchisqsum_sad(x, df = df, a = a, lower.tail = FALSE)
+    theirs <- survey::pchisqsum(
+      x,
+      df = df,
+      a = a,
+      method = "saddlepoint",
+      lower.tail = FALSE
+    )
+    expect_equal(ours, theirs, tolerance = 1e-10)
+  }
+})
+
+# ---------------------------------------------------------------------------
+# .pFsum_sad() vs survey::pFsum(..., method = "saddlepoint")
+#
+# Under the default mean.deff = mean(a), .pFsum_sad() is equivalent to upstream
+# when called with x pre-divided by mean(a). See §V.5 (Pass 3 Issue 65).
+# ---------------------------------------------------------------------------
+
+test_that(".pFsum_sad() matches survey::pFsum() upper-tail regime", {
+  skip_if_not_installed("survey")
+  ddf <- 30
+  xs <- stats::qchisq(c(1 - 1e-6, 1 - 1e-3, 1 - 1e-2), df = 3)
+  for (a in list(c(1, 1, 1), c(3, 1, 0.5))) {
+    for (x in xs) {
+      ours <- .pFsum_sad(
+        x / mean(a),
+        df = c(1, 1, 1),
+        a = a,
+        ddf = ddf,
+        lower.tail = FALSE
+      )
+      theirs <- survey::pFsum(
+        x,
+        df = c(1, 1, 1),
+        a = a,
+        ddf = ddf,
+        method = "saddlepoint",
+        lower.tail = FALSE
+      )
+      expect_equal(ours, theirs, tolerance = 1e-10)
+    }
+  }
+})
+
+test_that(".pFsum_sad() matches survey::pFsum() mid-range regime", {
+  skip_if_not_installed("survey")
+  ddf <- 30
+  xs <- stats::qchisq(c(0.25, 0.5, 0.75), df = 3)
+  for (a in list(c(1, 1, 1), c(3, 1, 0.5))) {
+    for (x in xs) {
+      ours <- .pFsum_sad(
+        x / mean(a),
+        df = c(1, 1, 1),
+        a = a,
+        ddf = ddf,
+        lower.tail = FALSE
+      )
+      theirs <- survey::pFsum(
+        x,
+        df = c(1, 1, 1),
+        a = a,
+        ddf = ddf,
+        method = "saddlepoint",
+        lower.tail = FALSE
+      )
+      expect_equal(ours, theirs, tolerance = 1e-10)
+    }
+  }
+})
+
+test_that(".pFsum_sad() matches survey::pFsum() near-zero regime", {
+  skip_if_not_installed("survey")
+  ddf <- 30
+  a <- c(1, 1, 1)
+  x <- 0.01 * sum(a)
+  ours <- .pFsum_sad(
+    x / mean(a),
+    df = c(1, 1, 1),
+    a = a,
+    ddf = ddf,
+    lower.tail = FALSE
+  )
+  theirs <- survey::pFsum(
+    x,
+    df = c(1, 1, 1),
+    a = a,
+    ddf = ddf,
+    method = "saddlepoint",
+    lower.tail = FALSE
+  )
+  expect_equal(ours, theirs, tolerance = 1e-10)
+})
+
+test_that(".pFsum_sad() matches survey::pFsum() with scalar a", {
+  skip_if_not_installed("survey")
+  ddf <- 30
+  a <- 2
+  x <- stats::qchisq(0.95, df = 1) * 2
+  ours <- .pFsum_sad(
+    x / mean(a),
+    df = 1,
+    a = a,
+    ddf = ddf,
+    lower.tail = FALSE
+  )
+  theirs <- survey::pFsum(
+    x,
+    df = 1,
+    a = a,
+    ddf = ddf,
+    method = "saddlepoint",
+    lower.tail = FALSE
+  )
+  expect_equal(ours, theirs, tolerance = 1e-10)
+})
+
+test_that(".pFsum_sad() matches survey::pFsum() large df regime", {
+  skip_if_not_installed("survey")
+  ddf <- 30
+  df <- rep(1L, 20)
+  a <- rep(1, 20)
+  xs <- stats::qchisq(c(0.5, 0.99), df = 20)
+  for (x in xs) {
+    ours <- .pFsum_sad(
+      x / mean(a),
+      df = df,
+      a = a,
+      ddf = ddf,
+      lower.tail = FALSE
+    )
+    theirs <- survey::pFsum(
+      x,
+      df = df,
+      a = a,
+      ddf = ddf,
+      method = "saddlepoint",
+      lower.tail = FALSE
+    )
+    expect_equal(ours, theirs, tolerance = 1e-10)
+  }
+})
+
+# ---------------------------------------------------------------------------
+# NA-regime parity at the root-finder level.
+#
+# The root-finder NA regime is where uniroot() fails to converge or the
+# abs(hatzeta) < 1e-4 guard fires — both yield NA. Assert .saddle() returns
+# NA on the same inputs as survey:::saddle().
+# ---------------------------------------------------------------------------
+
+test_that(".saddle() root-finder returns NA on the same inputs as survey:::saddle()", {
+  skip_if_not_installed("survey")
+  upstream_saddle <- utils::getFromNamespace("saddle", "survey")
+
+  # Trigger the abs(hatzeta) < 1e-4 guard: x at the mean sum(a) of the
+  # weighted chi-square sum reduces hatzeta to (near) zero.
+  a1 <- c(1, 1, 1)
+  x1 <- sum(a1) # mean of the distribution: hatzeta ≈ 0
+  ours1 <- .saddle(x1, a1)
+  theirs1 <- upstream_saddle(x1, a1)
+  expect_identical(is.na(ours1), is.na(theirs1))
+
+  # Extreme eigenvalue heterogeneity + small x to stress the root-finder.
+  # Both implementations produce a `NaNs produced` warning from sqrt() of a
+  # negative value in the saddle-point algebra; we assert parity of the
+  # NA regime, not warning suppression.
+  a2 <- c(1e-6, 1, 1e6)
+  x2 <- sum(a2)
+  ours2 <- suppressWarnings(.saddle(x2, a2))
+  theirs2 <- suppressWarnings(upstream_saddle(x2, a2))
+  expect_identical(is.na(ours2), is.na(theirs2))
+})


### PR DESCRIPTION
## What this does

This PR vendors the saddlepoint CDF helpers from the `survey` package — `.pchisqsum_sad()` (weighted χ² sums) and `.pFsum_sad()` (design-adjusted F reference) — into `R/variance-vendored-saddlepoint.R`. These are internal primitives that the forthcoming `get_anova()` (PR C of the get-anova plan) calls for Rao-Scott working-LRT p-values, so they are shipped standalone with their own byte-for-byte parity test against `survey` 4.4-8 at absolute tolerance `1e-10`. Nothing user-visible changes — both helpers are unexported and no new package dependency is introduced.

## Technical changes

- **New internal functions:** `.saddle()`, `.pchisqsum_sad()`, `.pFsum_sad()` (all dotted, unexported)
- **New tests:** 10 `test_that()` blocks across 5 parity regimes for `.pchisqsum_sad()`, 5 for `.pFsum_sad()`, plus a root-finder `NA`-regime parity check at `.saddle()` level (34 assertions total)
- **New error classes:** *(none — the `surveycore_warning_saddlepoint_fallback` class belongs to PR C's `get_anova()` layer)*
- **Modified files:**
  - `R/variance-vendored-saddlepoint.R` *(new)* — GPL-3 attribution header pointing at `survey/R/pchisqsum.R` @ 4.4-8
  - `tests/testthat/test-variance-vendored-saddlepoint.R` *(new)* — parity grid + NA-regime test, all guarded by `skip_if_not_installed("survey")`
  - `changelog/get-anova/pr-b-saddlepoint.md` *(new)*
- **Plan section:** `feature/variance-vendored-saddlepoint` — PR B from `plans/impl-get-anova.md`

## Spec coverage

**From `plans/spec-get-anova.md §V.5` and `§VII` (parity grid):**
- [x] `.pchisqsum_sad(x, df, a, lower.tail = FALSE)` — byte-for-byte port of upstream saddlepoint branch
- [x] `.pFsum_sad(x, df, a, ddf, mean.deff = mean(a), lower.tail = FALSE)` — derived, with `x` pre-divided by `mean.deff` (Pass 3 Issue 65)
- [x] Parity regimes covered: upper tail, mid-range, near zero, scalar `a`, large `df` — all at `tolerance = 1e-10`
- [x] Root-finder `NA`-regime parity (`.saddle()` returns `NA` on the same inputs as `survey:::saddle()`)
- [x] GPL-3 attribution header present
- [x] Both helpers internal; no `@export`
- [x] No new package dependency (`survey` used via `skip_if_not_installed()` only)

## Test results

```
devtools::test(filter = "variance-vendored-saddlepoint"): 34 tests, 0 failures
devtools::check(): 0 errors, 0 warnings, 1 note (pre-approved: surveytidy in vignettes)
```

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)