### PR TITLE
chore(plans): add get_variance() planning artifacts

### DIFF
--- a/plans/comprehension-get-variance.md
+++ b/plans/comprehension-get-variance.md
@@ -1,0 +1,453 @@
+# Comprehension — get-variance
+
+## Problem
+
+Add `get_variance()` to the surveycore `get_*()` analysis family. Given a
+survey design and one or more numeric variables selected via tidy-select, it
+must compute the design-based estimate of the finite-population variance of
+each variable, together with a design-based SE (and the usual opt-in
+uncertainty columns: `var`, `cv`, `ci_low`, `ci_high`, `moe`, `deff`). The
+estimand is `V(Y) = E[(Y - μ_Y)^2]`, estimated with Kish's `n/(n-1)`
+small-sample correction so that surveycore agrees numerically with
+`survey::svyvar()` across Taylor, replicate, twophase, and nonprob designs.
+The function must handle grouping, the surveycore-standard domain mask, an
+`na.rm` default of `TRUE`, and `survey_collection` dispatch via `.id` /
+`.on_missing` — in every respect a drop-in sibling of `get_means()` whose
+point-estimate column is `variance` (renamed to `estimate` when
+`name_style = "broom"`).
+
+Semantically: `get_variance()` is `get_means()` run on the centred-squared
+deviations of `y`, with weights fixed (not re-normalized by the centring
+step) and with an additional `n/(n-1)` scale factor. That reduction is the
+backbone of `survey::svyvar.survey.design`, and it's what makes this
+"variance of variance" problem tractable — for both Taylor and replicate
+paths it is literally a mean of `(y - ȳ)^2 * n/(n-1)` under the design.
+
+## Formulas
+
+Let the population be indexed by $i = 1, \ldots, N$ and the realized sample
+by $i \in s$. Let $w_i$ be the survey weight (full sample), $d_i \in \{0, 1\}$
+the domain/group active indicator (from `.apply_domain()` combined with any
+`group_by()` mask), and $m_i = \mathbb{1}(y_i \text{ non-NA})$ the NA mask.
+Write $a_i = d_i m_i$ for the "effective" membership indicator under
+`na.rm = TRUE`; under `na.rm = FALSE` set $a_i = d_i$ and let NA propagate
+through the arithmetic.
+
+Bindings to surveycore objects:
+
+| Symbol | Binding |
+|---|---|
+| $y_i$ | `design@data[[y_col]][i]` |
+| $w_i$ | `design@data[[design@variables$weights]][i]` (Taylor / replicate / nonprob) or calibrated weight `design@data[[phase1$weights]] / .compute_phase2_probs()` on Phase 2 rows (twophase) |
+| $d_i$ | `.apply_domain(design)` combined elementwise with group combo mask |
+| $a_i$ | `.mean_domain_vec(active_mask, y_col, na.rm)` — exactly the helper `get_means()` already calls |
+| $n$ | `sum(a_i)` (unweighted, in-domain, non-NA) |
+| $W$ | `sum(w_i * a_i)` |
+| $\bar y$ | `sum(w_i * a_i * y_i) / W` |
+| replicate weights | `design@data[, design@variables$repweights]` as matrix |
+| cluster / strata / FPC | `.build_cluster_matrices(design@data, design@variables)` |
+| two-phase `pi_{2|1,i}` | `.compute_phase2_probs(design, subset)` |
+
+### 1. Population-variance estimator with Kish correction
+
+Weighted Horvitz-Thompson plug-in estimator of $V(Y)$ with the finite-sample
+correction that `survey::svyvar` uses:
+
+$$
+\hat V(Y) \;=\; \frac{n}{n-1} \cdot \frac{\sum_{i \in s} w_i\, a_i\, (y_i - \bar y)^2}{\sum_{i \in s} w_i\, a_i}
+\;=\; \frac{n}{n-1} \cdot \frac{1}{W} \sum_{i \in s} w_i\, a_i\, (y_i - \bar y)^2.
+$$
+
+Equivalently (and this is the trick `svyvar.survey.design` uses):
+
+$$
+\hat V(Y) \;=\; \widehat{\mathrm{mean}}\!\big( z_i \big) \quad\text{where}\quad z_i \;=\; a_i \cdot (y_i - \bar y)^2 \cdot \frac{n}{n-1}.
+$$
+
+So the point estimate is a weighted mean of a derived variable `z`. This
+reduction is what makes reuse of `get_means()` style scaffolding possible.
+
+### 2. Taylor-linearization variance of $\hat V(Y)$
+
+Treat $\hat V(Y)$ as the HT-linearised weighted mean of $z_i$. The
+influence function (per-unit contribution to $\hat V$), evaluated at the
+sample, is:
+
+$$
+u_i \;=\; \frac{w_i\, a_i \cdot \big( \tfrac{n}{n-1}(y_i - \bar y)^2 \;-\; \hat V(Y) \big)}{W}.
+$$
+
+Then $\mathrm{Var}(\hat V(Y))$ is estimated by plugging $u_i$ into the same
+recursive stratified-clustered variance engine `get_means()` uses — i.e.,
+`.svy_recvar(matrix(u_i, ncol=1), clusters, strata, fpcs, lonely.psu)`.
+This is the exact construction already used inside `.vcov_pair_taylor()`
+for the $c$ (i.e. $\mathrm{Var}(Y)$) diagonal, **except** that
+`.vcov_pair_taylor()` uses the uncorrected (ML) form $w_i a_i (y_i - \bar y)^2 / W$
+inside the influence, without the `n/(n-1)` factor. For `get_variance()`
+parity with `svyvar`, the `n/(n-1)` factor must appear in the estimand
+(multiply the per-row "score" $(y_i - \bar y)^2$ by $n/(n-1)$ before
+centring by $\hat V$). See Gotcha 1.
+
+Out-of-domain rows contribute $u_i = 0$, preserving correct
+cluster/strata FPC assembly — the standard domain-estimation construction.
+
+### 3. Replicate-weight variance of $\hat V(Y)$
+
+For replicate weights $w_i^{(r)}$, $r = 1, \ldots, R$, recompute the
+estimate per replicate:
+
+$$
+W^{(r)} = \sum_{i} w_i^{(r)} a_i, \qquad \bar y^{(r)} = \frac{\sum_i w_i^{(r)} a_i y_i}{W^{(r)}},
+$$
+
+$$
+\hat V^{(r)}(Y) \;=\; \frac{n}{n-1} \cdot \frac{\sum_i w_i^{(r)} a_i (y_i - \bar y^{(r)})^2}{W^{(r)}}.
+$$
+
+Note $n$ (the unweighted in-domain non-NA count) is **held fixed across
+replicates** — replicates perturb the weights, not the sample size. This
+matches `svyvar.svyrep.design`, where `n <- NROW(x)` is fixed after
+`na.rm` and the per-replicate formula multiplies by `n/(n-1)`.
+
+Then
+
+$$
+\widehat{\mathrm{Var}}(\hat V(Y)) \;=\; \mathrm{scale} \cdot \sum_{r=1}^{R} \mathrm{rscales}_r \cdot \big(\hat V^{(r)}(Y) - \hat V^{*}(Y)\big)^2,
+$$
+
+with $\hat V^{*} = \hat V(Y)$ when `mse = TRUE` (surveycore default) and
+the mean of replicate estimates otherwise — exactly `.svy_rep_var()`.
+
+### 4. Twophase-design variance of $\hat V(Y)$
+
+`survey` does **not** define `svyvar.twophase`. `svyvar(x, twophase_design)`
+dispatches to `svyvar.survey.design`, which calls
+`svymean(x*x*n/(n-1), design)`, which in turn dispatches to
+`svymean.twophase` to do the actual variance work via the twophase
+machinery. The structural consequence for surveycore: the point estimate of
+$\hat V(Y)$ under twophase is the twophase-weighted mean of
+$(y_i - \bar y)^2 \cdot n/(n-1)$, and its SE is obtained by applying
+`.twophasevar()` to the twophase influence function for that derived mean.
+
+With calibrated weights $\tilde w_i = w^{(1)}_i / \pi_{2|1,i}$ restricted to
+Phase 2 rows, the two-phase influence function for $\hat V(Y)$ is (after
+constructing the full-length vector with 0 on Phase 1-only rows):
+
+$$
+u_i \;=\; \tilde w_i \cdot a_i \cdot \frac{\tfrac{n}{n-1}(y_i - \bar y)^2 - \hat V(Y)}{W},
+\qquad W = \sum_i \tilde w_i a_i, \quad n = \sum_i a_i,
+$$
+
+then $\widehat{\mathrm{Var}}(\hat V(Y)) = \texttt{.twophasevar}(u, \text{design}, \text{lonely.psu})$,
+which dispatches to `"simple"` / `"approx"` / `"full"` per
+`@variables$method`. Twophase Phase 2 rows only contribute (both to $n$ and
+to $W$); Phase 1-only rows have $u_i = 0$.
+
+### 5. Nonprob / survey_srs estimator
+
+For `survey_nonprob` (and `survey_srs` when it inherits from the nonprob
+path — it uses `.calibrated_mean_cell()`): point estimate is the same as
+(1). Its SE uses the HT linearisation for a single-stage SRS-with-weights
+design, matching `svydesign(ids = ~1, weights = ~w)`:
+
+$$
+\widehat{\mathrm{Var}}(\hat V(Y)) \;=\; \frac{n}{n-1} \cdot \sum_{i \in s} \Big( \frac{w_i\, a_i \cdot (\tfrac{n}{n-1}(y_i - \bar y)^2 - \hat V(Y))}{W} \Big)^2.
+$$
+
+This mirrors `.calibrated_mean_cell()`'s construction with the outer
+$n/(n-1)$ factor pulled from the variance-of-mean formula.
+
+### 6. How domain / grouping specialise the above
+
+- `d_i` (and hence $a_i$) multiplicatively masks every term: the weighted
+  mean, the squared deviation, and the influence function.
+- $W$ and $n$ are **recomputed for the domain only** — the domain mean $\bar y$
+  is the in-domain weighted mean, and $\hat V(Y)$ is the in-domain variance
+  with its own $n_d / (n_d - 1)$ correction.
+- Cluster / strata / FPC structure is built from the **full dataset**
+  before domain filtering (design property, not a sample property). This
+  matches `.taylor_mean_cell()` and `.vcov_pair_taylor()`.
+- The domain mean $\bar y$ and thus the centering used in the
+  score $(y_i - \bar y)^2$ is plugged-in (not a separately estimated quantity
+  whose variance feeds back into the variance of $\hat V$). This is the
+  same approximation `svyvar.survey.design` uses — Taylor linearisation
+  treats $\bar y$ as a known constant in the score function, reusing the
+  influence-function-of-a-weighted-mean construction.
+- Replicate path: $\bar y^{(r)}$ is re-estimated per replicate, so the
+  variability of $\bar y$ is implicitly captured by the replicate spread.
+- Twophase path: same plug-in approximation; the two-phase engine already
+  propagates Phase 1 and Phase 2 contributions via the influence vector.
+
+## Gotchas
+
+### G1. `n/(n-1)` vs ML form — the headline numerical divergence from `.vcov_pair_taylor()`
+
+`.vcov_pair_taylor()` uses
+`a = sum(w * cx^2) / W_d` (no `n/(n-1)` factor) and its influence function
+is `w * pair_mask * (cx^2 - a) / W_d`. This is the ML / plug-in form. The
+surveycore correlation path uses ML on both numerator and denominator, so
+the ratio matches `survey::svyvar(...)` only in the limit. That's
+**fine for `get_corr()`** (where the correction cancels in the ratio),
+but it is **wrong for `get_variance()`**.
+
+`get_variance()` must apply `n/(n-1)` to the estimand AND to the influence
+score. Specifically, use
+
+```
+score_i = a_i * ( (n / (n - 1)) * (y_i - ybar)^2 )
+V_hat   = sum(w * score) / W
+infl_i  = w * a_i * (score_i - V_hat) / W
+```
+
+Do **not** "fix" `.vcov_pair_taylor()` to adopt this form — `get_corr()`
+still needs the ML form. Instead, introduce a parallel helper
+`.vcov_var_taylor()` (or reuse the `z_i` = mean-as-a-function reduction and
+call `.taylor_mean_cell()` on `z`). The spec should make this split
+explicit, because a single helper cannot serve both consumers without
+breaking one of them.
+
+### G2. Single-PSU-per-stratum (`lonely.psu` option) for the variance-of-variance
+
+`getOption("survey.lonely.psu", "remove")` governs the engine; it's
+inherited unchanged by `.svy_recvar()` inside any `get_variance()`
+implementation. The gotcha: **`svyvar()` can trigger `lonely.psu`
+warnings even when `svymean()` on the same design does not**, because the
+derived quantity $(y_i - \bar y)^2$ is far more leveraged than $y_i$ by a
+single lonely PSU. Spec decision: surface the lonely-PSU behaviour through
+the option as the family already does; do not trap or emit extra warnings
+beyond what `.svy_recvar()` already emits via cli.
+
+### G3. Replicate-weight DoF
+
+`get_means()` uses `degf = Inf` (normal approximation). `survey::svyvar`
+does likewise — CIs and `deff` on variance estimates are constructed with
+normal quantiles, not Satterthwaite-adjusted t's. Follow `get_means()`
+precedent and use `Inf`. (This is distinct from `get_quantiles()` which
+does use the design df.)
+
+### G4. Twophase — Phase 1 vs Phase 2 contributions
+
+Two rules to get right:
+
+- $n$ (in `n/(n-1)`) counts **Phase 2 in-domain non-NA rows only**. Phase
+  1-only rows are *never* part of $n$ or $W$ — they contribute zero
+  influence by construction of the full-length $u_i$ vector.
+- The phase-1 centring in `.twophase_phase1_var()` is applied to the
+  *influence* $u_i$, not to the raw $y$. So the two-phase machinery is
+  agnostic to the fact that $u_i$ was built from a squared deviation — it
+  just sees a full-length influence vector. Implementation can reuse
+  `.twophasevar(u, design, lonely.psu)` directly, following the same
+  pattern as `.twophase_mean_cell()`.
+
+### G5. Domain masking at zero weight / all-NA / single-observation domain
+
+- `n_d = 0`: return `mean = NaN`, `se = NaN`, `n = 0L`, `n_weighted = 0`,
+  fire `surveycore_warning_empty_domain` or `surveycore_warning_all_na`
+  depending on cause. The request asks for an **`NaN` return, not `NA`**,
+  for "all-NA variable" (see Edge cases in request.md).
+- `n_d = 1`: $n/(n-1) = \infty$ and the numerator is exactly 0, giving
+  $0 \cdot \infty = \text{NaN}$. Return `NaN` for both point and SE, `n = 1L`,
+  and fire a warning (`surveycore_warning_insufficient_n`, new class —
+  see G6). This matches the request's "single non-NA observation → `NaN`"
+  edge.
+- `n_d = 2`: $n/(n-1) = 2$. This is the minimum case where the estimator
+  is defined. Does not warn.
+
+### G6. New warning classes — what needs to enter `plans/error-messages.md`
+
+Existing family classes largely apply (`surveycore_warning_small_cell`,
+`surveycore_warning_single_level`, `surveycore_error_non_numeric_variable`,
+`surveycore_error_wrong_variable_count` if single-var mode, the shared-arg
+validations, etc.). New rows likely needed:
+
+- `surveycore_warning_variance_all_na` — `"All values of {.field {var}} are {.code NA}. Returning {.code NaN}."` (analogous to `surveycore_warning_all_na_freqs`)
+- `surveycore_warning_variance_insufficient_n` — `"{.field {var}} has {n} non-NA observation{?s} in the active domain; variance requires at least 2. Returning {.code NaN}."`
+- `surveycore_warning_zero_variance` — optional; currently the request says "no warning" for constant variable. Confirm with user. If we keep no-warning behaviour, this row is **not** needed.
+
+The request should be validated with the user on whether the two warnings
+above should be separate classes or rolled into existing ones. The
+comprehension flags this but does not decide.
+
+### G7. `na.rm = TRUE` interacts with multi-variable mode differently than `svyvar()`
+
+`svyvar.survey.design` uses **listwise** deletion when $x$ is
+multi-column: any row with an NA in *any* of the $x$ columns is excluded
+from $n$. This is correct for a multivariate variance-covariance matrix,
+but surveycore's `get_variance()` returns a **per-variable** diagonal
+estimate (one row per variable, no off-diagonals). Listwise deletion would
+be wrong here — each row's per-variable $n$ should reflect the non-NA rows
+for **that** variable, not the intersection across all requested variables.
+Use **pairwise (per-variable) NA removal** for `get_variance()`, matching
+`get_freqs()`'s multi-var behaviour. State this explicitly in the spec.
+
+### G8. Constant (zero-variance) variable — numerical stability
+
+If all in-domain non-NA `y_i` are identical, $\bar y = y_i$ everywhere and
+$(y_i - \bar y)^2 \equiv 0$. Then $\hat V = 0$, the influence vector is
+$u_i \equiv 0$, and the variance engine returns exactly 0 for SE. No
+`0/0` pathologies — denominators $W$ and $n-1$ remain strictly positive
+as long as $n \ge 2$ and all weights positive. Request explicitly specifies
+"zero-variance (constant) variable → `0` with `se = 0`, no warning".
+Implementation note: use `sqrt(max(0, v))` defensively for replicate paths,
+since a tiny negative residual from replicate subtraction is possible for a
+near-constant variable.
+
+### G9. `deff` for variance — what does it mean, and is `survey`'s analog the right one?
+
+`survey::svyvar(..., deff = TRUE)` is not a supported argument; `svyvar`'s
+design-effect is only wired through `svymean(x^2, ..., deff = TRUE)` via
+the reduction. The family `deff` column for `get_variance()` should
+compute the design effect of the derived mean $\hat z = \hat V$ — i.e.,
+`deff = var(V_hat) / var_srs(z)` where `var_srs(z)` uses the same
+`.taylor_mean_cell()`-style SRS variance of the score variable $z_i = a_i
+(y_i - \bar y)^2 n/(n-1)$, matching how `.add_variance_cols()` derives
+`deff` in the rest of the family. Spec this out rather than leaving it to
+builder discretion.
+
+### G10. Factor / character input silently dropped by `svyvar()`?
+
+`svyvar.survey.design` will coerce a factor to numeric via `model.frame`
+(and error if it can't). surveycore's precedent in `get_means()` is to
+**reject** non-numeric input with `surveycore_error_non_numeric_variable`,
+and the request confirms this is the desired surveycore behaviour. So the
+numerical-parity oracle tests should pre-coerce or pre-filter inputs to
+numeric on both sides — do **not** test surveycore's error path against
+`svyvar()`'s silent coercion.
+
+### G11. `subset == 0` rows in survey package — zero-weight row semantics
+
+`svyvar.survey.design` excludes rows where `weights(design, "sampling") == 0` from
+`n` (see line 703 of survey.R). surveycore weights are strictly positive by
+validator (S7 `surveycore_error_weights_nonpositive`), so this case cannot
+arise via constructor-built designs. But `survey_nonprob` validators
+accept zero weights (row 101 in error-messages.md allows `>= 0`). Safest:
+define $n = \sum_i a_i \cdot \mathbb{1}(w_i > 0)$ to match survey and to
+guard numerical stability when a nonprob weight column happens to contain
+zeros. Tests with `survey_nonprob` + zero weights should confirm parity.
+
+### G12. Column labels for gt — don't forget
+
+Per `project_column_labels.md` memory entry, every family output sets
+column-level `label` attributes for gt integration. The `variance`
+column should get a label like `"Variance"` (or the focal variable label
+when known), `se` → `"SE"`, `ci_low` / `ci_high` with the conf-level
+interpolated, etc. Follow the template in `.add_variance_cols()` and in
+whichever helper `get_means()` uses to set the point-estimate label.
+
+## Reference mapping
+
+| Reference | Specific mapping |
+|---|---|
+| `survey::svyvar.survey.design` (survey.R:696–730) | Defines the **estimand** including the `n/(n-1)` factor and the reduction "variance = mean of centred-squared, with Kish scale". Drives the point-estimate formula in §1 and the Taylor-path reduction in §2. |
+| `svyvar.survey.design` reliance on `svymean(...)` | Confirms the engine re-use: `get_variance()` Taylor path should be implemented as a call to the same stratified/clustered `.svy_recvar()` engine `get_means()` uses, on the derived score. |
+| `svyvar.svyrep.design` (surveyrep.R:766–831) | Defines the **replicate-weight variance** — per-replicate recomputation of $\bar y^{(r)}$ and the Kish-corrected estimate, fed to `svrVar`. Drives §3 and Gotcha G3. Confirms that `n` (sample size) is frozen across replicates. |
+| Absence of `svyvar.twophase` in survey | Confirms that under twophase, `get_variance()` should **not** invent its own phase-1/phase-2 decomposition — it should build the influence vector from the score and hand to `.twophasevar()`, mirroring how `svymean.twophase` handles derived means. Drives §4. |
+| Lumley (2010) *Complex Surveys* §2.4 | Justifies Taylor linearisation of plug-in estimators: the variance of $\hat V(Y)$ is the variance of the HT total of its influence function. Equation (2.12) corresponds to our §2 formula. |
+| `surveycore::.vcov_pair_taylor` (variance-taylor.R:339) | Structural **template** for the Taylor path: how to build the influence-matrix + feed into `.svy_recvar()`, including domain masking via `pair_mask` and safe handling of `x_safe` for out-of-domain rows. `get_variance()` replaces `pair_mask` → single-variable $a_i$, and the 3x3 infl matrix → 1-column infl vector; crucially, adds the `n/(n-1)` factor that `.vcov_pair_taylor()` omits (Gotcha G1). |
+| `surveycore::.build_cluster_matrices`, `.svy_recvar` | Reused verbatim; no change required. |
+| `surveycore::.svy_rep_var` (variance-replicate.R:26) | Reused verbatim for replicate path (§3). |
+| `surveycore::.twophasevar`, `.compute_phase2_probs` (variance-twophase.R:24, 322) | Reused verbatim for twophase path (§4). Influence vector construction mirrors `.twophase_mean_cell()`. |
+| `surveycore::.apply_domain`, `.resolve_groups`, `.mean_domain_vec` | Reused verbatim for domain / grouping / NA handling — exact same semantics as `get_means()`. |
+| `surveycore::.calibrated_mean_cell` (analysis-means-helpers.R:242) | Template for nonprob path (§5): same HT form, with an outer `n/(n-1)` and a different score. |
+| `surveycore::.add_variance_cols`, `.make_result_tibble`, `.apply_name_style`, `.apply_decimals` | Reused verbatim for result assembly. `name_style = "broom"` remap: add `variance` → `estimate`. |
+| `plans/error-messages.md` rows 43, 45, 45a, 45b, 46, 49, 50, 54, 81, 64 | All reused. New rows G6 introduces (if accepted) should be added with IDs after the `A-*` / `C-*` block — propose `V-1`, `V-2`. |
+
+## Assumptions
+
+### A1. Point-estimate column name
+
+The request fixes `variance` as the column name (not `var`, which is already
+used for the optional variance-as-uncertainty column in `.add_variance_cols()`).
+This is a minor design break from `svyvar` (whose printed column is labelled
+`"variance"` via `attr(v, "statistic")`) but matches the surveycore naming
+pattern (`mean`, `total`, `pct`, `corr`, `ratio`, ..., all short and
+unambiguous). No conflict with the opt-in `var` column — they have different
+semantics (estimand vs uncertainty of estimand). Spec should be crystal
+clear about this.
+
+### A2. `survey::svyvar` silently converts factor inputs via `model.frame`
+
+surveycore rejects non-numeric input at the `get_*()` call site. The
+numerical-parity tests must pre-coerce on both sides, or select numeric
+columns only, or compare against a numeric-only svyvar call.
+
+### A3. `(n/(n-1))` uses unweighted $n$, not weighted $W$
+
+The Kish `n/(n-1)` correction is a **sample-size** correction (unweighted
+count of in-domain non-NA rows in the **estimation** set), not a weighted
+correction. `svyvar.survey.design` computes
+`n <- sum((weights != 0) & (rowSums(is.na(x)) == 0))`, confirming: unweighted
+count, non-NA in any of the focal columns, weight strictly positive. For
+surveycore's per-variable mode, $n$ is the per-variable non-NA count in
+the active domain with positive weight.
+
+### A4. Single-vs-multi-var in `x`
+
+Unlike `get_means()` (single variable only, errors on `length(x) != 1`),
+`get_variance()` accepts one or more numeric variables via tidy-select
+(matching `get_freqs()`'s input API). Output is one row per variable. No
+`names_to` / `values_to` arguments are needed (variance has no category
+dimension). The variable name lives in the `name` column (per request) —
+not as a column named after the variable — because with multiple variables
+a single column-name convention would clash.
+
+### A5. No off-diagonal covariances
+
+The request is explicit: "tidy variances only; no off-diagonals". This is
+a meaningful restriction from `svyvar.survey.design`, which when called
+with a multi-column `x` returns a $p \times p$ covariance matrix with
+off-diagonals. `get_variance()` returns only the diagonals. Any future
+`get_covariance()` is out of scope for this plan.
+
+### A6. No standard-deviation estimand
+
+Request is explicit. Callers take `sqrt(meta(result) / result$variance)`
+themselves, just as they would with `survey::svyvar`.
+
+### A7. `conf_level` normal approximation for CI bounds
+
+Consistent with `get_means()`, CI bounds use the normal approximation
+(`degf = Inf`). `conf_level = 0.95` gives `z = 1.959964`, applied to the
+design SE. Note: a variance estimate's sampling distribution is
+asymptotically normal but **right-skewed** at finite $n$ — the normal-based
+CI can dip below zero. Spec should **not** clamp to zero silently
+(that would be wrong inference); it should mention the behaviour in the
+docstring. An optional log-CI refinement is out of scope.
+
+### A8. `deff` denominator
+
+Per G9, the SRS comparator for `deff` is the SRS variance of the score
+$z_i = a_i (y_i - \bar y)^2 n/(n-1)$, not the SRS variance of $y_i$.
+This matches how `survey` computes `deff` for `svyvar` internally (via
+`svymean(x^2 * n/(n-1))`). Spec should codify this and the test-spec
+should include a numerical parity test.
+
+### A9. Design effect for nonprob
+
+`survey_nonprob` reports deff just like the rest of the family; the SRS
+comparator is the same unweighted sample-SRS variance of $z$ with the
+nonprob weights ignored. Follow the `.calibrated_mean_cell()` precedent.
+
+### A10. `label_values` / `label_vars` — accepted for API uniformity
+
+`get_variance()` output has no categorical value cells and no stacked
+variable-name column (variable names go in the `name` column as raw names
+or with the variable label substituted if `label_vars = TRUE`). Accept
+both arguments for API uniformity; `label_vars = TRUE` substitutes the
+variable-label-if-present for the `name` column value. `label_values` has
+no visible effect (same as `get_means()`).
+
+### A11. `n` column semantics
+
+`n` is the unweighted count of in-domain, non-NA rows with positive weight
+used to compute the variance for each variable's row. When two variables
+are requested, their `n` values can differ (pairwise deletion — Gotcha G7).
+`n_weighted = sum(w_i * a_i * 1(w_i > 0))` when opted in.
+
+### A12. Empty `x` (tidy-select matches 0 columns)
+
+Follows the precedent of `get_means()` `surveycore_error_wrong_variable_count`
+vs `get_freqs()` (which allows 0 and returns 0 rows with a warning? — check
+in spec). The request implies at least one numeric variable is required; if
+tidy-select resolves to 0 variables, error with
+`surveycore_error_wrong_variable_count` (reusing row 138 family behaviour).

--- a/plans/error-messages.md
+++ b/plans/error-messages.md
@@ -180,6 +180,8 @@ against the messages defined here.
 | D-2 | `classify_question_type()` | Neither `...` nor `variable` provided (or `variable = character(0)`) | ERROR | `surveycore_error_detect_no_vars` | `"x" = "{.fn classify_question_type} requires at least one variable name."` |
 | D-3 | `classify_question_type()` | SATA variable has no shared `question_preface` with other requested variables | WARN | `surveycore_warning_sata_no_preface` | `"!" = "Variable {.field {var_name}} is marked SATA but has no shared {.code question_preface} with other variables. Classified as {.val single}."` |
 | D-4 | `classify_question_type()` | Mixed SATA status within a `question_preface` group | WARN | `surveycore_warning_sata_mixed_group` | `"!" = "Variables sharing {.code question_preface} {.val {preface}} have mixed SATA status. Treating entire group as {.val sata}. Use {.fn set_sata} to mark all variables in the group."` |
+| V-1 | `get_variance()` | All values of a focal variable are `NA` in the active domain (per-variable, after `na.rm`) | WARN | `surveycore_warning_variance_all_na` | `"!" = "All values of {.field {var}} are {.code NA} in the active domain. Returning {.code NaN} with {.code n = 0}."` |
+| V-2 | `get_variance()` | Focal variable has fewer than 2 non-NA observations (with positive weight) in the active domain | WARN | `surveycore_warning_variance_insufficient_n` | `"!" = "{.field {var}} has {n} non-NA observation{?s} in the active domain; variance requires at least 2. Returning {.code NaN}."` |
 
 ### survey_collection rows (PR 1)
 

--- a/plans/implementation-plan-get-variance.md
+++ b/plans/implementation-plan-get-variance.md
@@ -1,0 +1,241 @@
+# Implementation plan — get-variance
+
+**Target version**: 0.7.1.9000
+**PR range**: PR 1–2
+**Pipeline split**: recommended (inherited from `spec.md`)
+
+## Sequencing note
+
+PR 1 and PR 2 are **sequential, not concurrent**. PR 2 branches from
+`develop` only after PR 1 has merged, and PR 2 edits files that PR 1
+created or modified (`R/analysis-variance.R`,
+`R/analysis-variance-helpers.R`, plus PR-2-only test files). Because
+the two PRs are not open at the same time, the shared-file edits do
+**not** violate the "disjoint write surfaces across concurrent PRs"
+rule. PR 2 consumes PR 1's helpers; it does not re-author them.
+
+## PR map
+
+- [ ] **PR 1: feature/get-variance-core** — Ship the full `get_variance()` public API with Taylor + replicate dispatch, the `FAMILY_META_KEYS` refactor, the `survey_variance` print method, the broom adapter rename, and the full non-dispatch-specific test suite.
+
+  - **Tasks** (2–5 min each, TDD sub-steps explicit)
+
+    1. Create feature branch `feature/get-variance-core` off `develop`.
+    2. Bump `DESCRIPTION` version field to `0.7.1.9000`; add a stub `# surveycore (development version)` heading block to `NEWS.md` with a placeholder entry for `get_variance()`.
+    3. Write failing test: Taylor-design single-variable happy path — point estimate parity against `survey::svyvar(~ridageyr, design, na.rm = TRUE)` on `nhanes_2017`, tolerance `1e-10`. Assert `test_invariants(design)` first.
+    4. Write failing test: same scenario, SE parity against `survey::SE(svyvar(...))`, tolerance `1e-8`.
+    5. Write failing test: same scenario, default-CI computed as `coef ± qnorm(0.975) * SE`, tolerance `1e-6`.
+    6. Refactor `R/analysis-meta.R`: extract the shared `FAMILY_META_KEYS` constant from the existing per-function `*_META_KEYS` definitions; update every current caller (`get_means`, `get_freqs`, `get_totals`, `get_corr`, `get_quantiles`, `get_ratios`, `get_diffs`, `get_t_test`, `get_pairwise`, `get_anova`) to reference the shared constant. Run `devtools::test()` — all currently-passing tests still pass (no behavioral change).
+    7. Register a new `survey_variance` meta constructor in `R/analysis-meta.R` using `FAMILY_META_KEYS`.
+    8. Create `R/analysis-variance-helpers.R`. Define `.score_variance(y, weights, domain, na_vec)` returning `z_i = a_i · (y_i − ȳ_d)² · n_d / (n_d − 1)` with `ȳ_d` and `n_d` computed on the active domain-restricted, non-NA, positive-weight subset.
+    9. In the same file, define `.variance_cell(design, y, weights, domain, na_vec, ...)` that (a) builds the score via `.score_variance()`, (b) dispatches on `class(design)` to `.taylor_mean_cell()` for `survey_taylor` and `.replicate_mean_cell()` for `survey_replicate`, (c) returns the cell payload (point, var-of-estimate, n, n_weighted components) expected by the result assembler. Leave `survey_twophase` / `survey_nonprob` branches as explicit "not implemented in PR 1" stubs that `cli_abort(class = "surveycore_error_unsupported_class")` — removed in PR 2.
+    10. Create `R/analysis-variance.R`. Implement the exported `get_variance()` wrapper with the full signature from spec (all arguments including `na_handling`, `.id`, `.on_missing`). Route through `.validate_shared_args()`, `.check_unsupported_class()`, `.resolve_groups()`, `.apply_domain()`, and the multi-variable iteration loop. Each variable call delegates to `.variance_cell()`; results are row-bound and passed through `.add_variance_cols()`, `.apply_decimals()`, `.make_result_tibble()`, `.apply_name_style()`, and the column-label pass. Class the tibble `c("survey_variance", "survey_result", "tbl_df", "tbl", "data.frame")`.
+    11. Run tests from tasks 3–5. Iterate until they pass (Taylor happy path green).
+    12. Regenerate `NAMESPACE` and `man/get_variance.Rd` via `devtools::document()`.
+    13. Write failing test: replicate (BRR) parity against `svyvar()` on `acs_pums_wy` wrapped as `survey_replicate`, point `1e-10` and SE `1e-8`. Verify dispatch into `.replicate_mean_cell()` returns correct values. Iterate.
+    14. Write failing test: multi-variable pairwise — `c(ridageyr, bpxsy1)` against two separate per-variable `svyvar()` calls. Implement or extend the multi-variable loop; verify.
+    15. Write failing test: multi-variable listwise — same input, `na_handling = "listwise"` — against `svyvar(~ridageyr + bpxsy1, design, na.rm = TRUE)` diagonal. Implement the shared-active-mask branch; verify.
+    16. Write failing test: grouped estimate via `group_by(design, g)` against `survey::svyby(~focal, ~g, design, svyvar, na.rm = TRUE)`. Verify grouping wiring; iterate.
+    17. Write failing test: grouped estimate via `group =` argument — same oracle as task 16. Verify.
+    18. Write failing test: constant variable returns `variance = 0`, `se = 0`, `ci_low = ci_high = 0`, `moe = 0`, `deff = 0`, `cv = NA` with `surveycore_warning_cv_undefined` fired when `variance = "cv"` is requested. Implement the constant-variable guard in `.variance_cell()`. Verify.
+    19. Write failing test: `name_style = "broom"` renames `variance → estimate`, `se → std.error`, `ci_low → conf.low`, `ci_high → conf.high`. Extend `.apply_name_style()` to include the `variance → estimate` entry in the broom rename map. Verify.
+    20. Write failing test: `n_weighted = TRUE` appends `n_weighted = sum(w[in_domain & !is.na(y) & w > 0])` to tolerance `1e-10`. Verify.
+    21. Write failing test: column-level `label` attribute on every output column (`variance`, `se`, `var`, `ci_low`, `ci_high`, `cv`, `moe`, `deff`, `n`, `n_weighted`, `name`, group columns); interpolated CI label reads `"{conf}% CI low"` / `"{conf}% CI high"`. Implement the label-attribute pass in `R/analysis-variance.R`; verify.
+    22. Write failing test: `.meta` top-level structure — keys are the exact `FAMILY_META_KEYS` plus `design_class`, `conf_level`, `name_style`, `min_cell_n`, `na_handling`; **no `function_name` or `variable` keys**; `.meta$group` empty when no grouping, populated when grouping; `.meta$x` has one entry per focal variable with `variable_label`, `question_preface`, `value_labels`. Verify.
+    23. Write failing test: `label_vars = TRUE` substitutes the variable label into the `name` column (falling back to raw name when unset); `label_vars = FALSE` keeps the raw name. Verify.
+    24. Write failing test: `decimals = 3` rounds every numeric output column to exactly 3 decimals (exact equality after `round()`). Verify.
+    25. Write failing test: `deff` column equals `var(V_hat) / var_srs(score)` using `svymean` on the score under SRS, tolerance `1e-8`. Verify.
+    26. Add the `survey_variance` print method to `R/methods-print.R` following the existing family template; write a smoke test asserting `print(result)` returns invisibly and does not error on a single-variable and a multi-variable result.
+    27. Add the `survey_variance` broom `tidy` / `glance` adapters to `R/methods-compat.R`; write smoke tests for both (tidy returns a tibble; glance returns a 1-row tibble with the expected columns). No new semantics, just registration.
+    28. Error paths — write dual-pattern tests (`expect_error(class = ...)` + `expect_snapshot(error = TRUE)`) for every error class that PR 1 can trigger:
+        - `surveycore_error_unsupported_class` (pass a plain data frame)
+        - `surveycore_error_wrong_variable_count` (empty `x` selection)
+        - `surveycore_error_non_numeric_variable` (factor column)
+        - `surveycore_error_non_numeric_variable` (character column)
+        - `surveycore_error_invalid_variance_arg` (`variance = "foo"`)
+        - `surveycore_error_invalid_conf_level` (three cases: `0`, `1`, `NA`)
+        - `surveycore_error_invalid_decimals` (two cases: `-1`, `1.5`)
+        - `surveycore_error_invalid_name_style` (`"foo"`)
+        - `surveycore_error_na_rm_not_logical` (two cases: `NA`, `1`)
+        - `na_handling = "foo"` — `match.arg()` error; `expect_error()` only (no snapshot), consistent with row 18 pattern
+    29. Warning paths — write `expect_warning(class = ...)` tests for:
+        - `surveycore_warning_small_cell` (construct a domain where any row has `n < min_cell_n = 30L`)
+        - `surveycore_warning_single_level` (grouping var with one observed level)
+        - `surveycore_warning_cv_undefined` (request `variance = "cv"` on a constant variable)
+        - `surveycore_warning_variance_all_na` (focal variable all-NA in active domain, `na.rm = TRUE`)
+        - `surveycore_warning_variance_all_na` (`na_handling = "listwise"` with empty intersection)
+        - `surveycore_warning_variance_insufficient_n` (focal variable with exactly one non-NA row)
+    30. Edge-case tests reachable from PR 1 dispatch:
+        - All-NA focal variable with `na.rm = TRUE` → `variance = NaN`, all uncertainty cols `NaN`, `n = 0L`
+        - Single non-NA observation → `variance = NaN`, `n = 1L`
+        - Constant variable with `n ≥ 2` → exact `0` for point + SE + CI + moe + deff; `cv = NA` only when `"cv"` requested
+        - `na.rm = FALSE` with NAs in focal var → `variance = NaN`, `n` reflects all in-domain rows
+        - Grouping var with one level → single output row per focal variable
+        - `na_handling = "listwise"` with some rows NA in one var → all output rows share `n` equal to intersection count
+        - `na_handling = "pairwise"` with rows NA in different vars → per-variable `n` differs across rows
+        - Replicate near-constant variable with tiny negative replicate residual → `se = 0` (not `NaN`) via `max(0, v)` guard in `.replicate_mean_cell()` — add the guard only if it isn't already in place; verify
+        - CI bounds below zero (construct a near-zero-variance case with wide SE) → `ci_low` returned as-is, not clamped
+    31. Add a roxygen `@details` block to `get_variance()` explicitly documenting: CIs use the normal-Wald approximation on the SE of the variance estimate; `ci_low` may be negative when the point estimate is near zero; bounds are not clamped; users may clamp at `0` if desired; matches `survey::svyvar()`.
+    32. Run `devtools::document()`; commit regenerated `NAMESPACE` and `man/get_variance.Rd`.
+    33. Run `devtools::test()` — every test passes.
+    34. Run `devtools::check()` — 0 errors, 0 warnings, ≤2 pre-approved notes.
+    35. Update `NEWS.md` entry under `# surveycore (development version)` to name the new function, the new `survey_variance` class, and the two new warning classes.
+
+  - **Acceptance criteria** — observable outcomes before merge
+
+    All tests below pass at the tolerances named in `test-spec.md`:
+
+    1. Taylor happy-path: point parity to `svyvar()` at `1e-10`; SE parity at `1e-8`; CI at `1e-6`.
+    2. Replicate (BRR) happy-path on `acs_pums_wy`: point `1e-10`, SE `1e-8`.
+    3. Multi-variable pairwise parity to per-variable `svyvar()`: point `1e-10`, SE `1e-8`.
+    4. Multi-variable listwise parity to `svyvar(~y1 + y2, ...)` diagonal: point `1e-10`, SE `1e-8`.
+    5. Grouped estimate (via `group_by(design, g)`) parity to `svyby(~y, ~g, ..., svyvar)`: point `1e-10`, SE `1e-8`.
+    6. Grouped estimate (via `group =`) parity to same oracle: point `1e-10`, SE `1e-8`.
+    7. Constant variable returns exact `0` for `variance`, `se`, `ci_low`, `ci_high`, `moe`, `deff`; exact `NA` for `cv` when requested; `surveycore_warning_cv_undefined` fires exactly once.
+    8. `name_style = "broom"` renames the four columns (`variance → estimate`, `se → std.error`, `ci_low → conf.low`, `ci_high → conf.high`) and their `label` attributes.
+    9. `n_weighted` column equals the manual weighted sum at `1e-10`.
+    10. Every output column has a non-`NULL` `label` attribute; CI labels are conf-level-interpolated.
+    11. `.meta` top-level keys equal the `FAMILY_META_KEYS` set plus `design_class`, `conf_level`, `name_style`, `min_cell_n`, `na_handling`; contains no `function_name` and no `variable` keys; `.meta$x` has one entry per focal variable with `variable_label`, `question_preface`, `value_labels`; `.meta$group` empty when no grouping, populated when grouping.
+    12. `label_vars = TRUE` substitutes variable label into `name`; `label_vars = FALSE` keeps raw name; fallback to raw name when a label is unset.
+    13. `decimals = 3` rounds every numeric output column exactly.
+    14. `deff` parity at `1e-8` against the manual SRS-of-score comparator.
+    15. Print method and broom `tidy`/`glance` adapters dispatch without error on single-variable and multi-variable results.
+    16. Dual-pattern (`expect_error(class = ...)` + `expect_snapshot`) green for all error classes listed in task 28.
+    17. `expect_warning(class = ...)` green for all warning classes listed in task 29.
+    18. Edge cases listed in task 30 behave as specified.
+    19. `test_invariants(design)` is the first assertion of every test that constructs a survey design.
+    20. `R CMD check`: 0 errors, 0 warnings, ≤2 pre-approved notes.
+    21. `devtools::document()` is idempotent after commit (re-running produces no diff).
+    22. Existing test suite (pre-refactor) remains fully green after the `FAMILY_META_KEYS` refactor — no other family member's behavior changes.
+
+  - **Files touched** — exact write surface
+
+    | File | Action |
+    |---|---|
+    | `R/analysis-variance.R` | created |
+    | `R/analysis-variance-helpers.R` | created |
+    | `R/analysis-meta.R` | modified (introduce `FAMILY_META_KEYS`; register `survey_variance` meta constructor; mechanical update of existing callers) |
+    | `R/methods-print.R` | modified (add `survey_variance` print method) |
+    | `R/methods-compat.R` | modified (broom adapter for `survey_variance`; extend `.apply_name_style()` broom map with `variance → estimate`) |
+    | `NAMESPACE` | regenerated |
+    | `man/get_variance.Rd` | generated |
+    | `DESCRIPTION` | modified (version bump to `0.7.1.9000`) |
+    | `NEWS.md` | modified (dev-version entry) |
+    | `tests/testthat/test-analysis-variance.R` | created (all PR 1 tests live here: happy path + multi-variable + grouping + constant + broom + n_weighted + labels + meta + decimals + deff + print smoke + broom smoke + error paths + warning paths + edge cases) |
+    | `tests/testthat/_snaps/analysis-variance.md` | created (error-snapshot file generated by testthat) |
+
+    **Test-file convention waiver**: `R/analysis-variance-helpers.R` does **not** get its own `test-analysis-variance-helpers.R`. Per `.claude/rules/testing-surveycore.md` (precedent: `R/07-utils.R`), helper files may be covered inline by the parent module's test file when the helpers are exclusively private and exclusively reachable through the public function. `.variance_cell()` and `.score_variance()` are tested indirectly through `get_variance()` per the project's "Testing private functions" rule (default to indirect; direct only when public-API coverage is genuinely unreachable).
+
+  - **Pipeline split**: recommended
+
+- [ ] **PR 2: feature/get-variance-twophase-nonprob-collection** — Extend `.variance_cell()` to cover `survey_twophase` and `survey_nonprob`; wire `survey_collection` dispatch through `.dispatch_over_collection()`; add the numerical parity tests and collection edge-case coverage that PR 1 did not ship.
+
+  - **Tasks** (2–5 min each, TDD sub-steps explicit)
+
+    1. Branch `feature/get-variance-twophase-nonprob-collection` off `develop` **after** PR 1 has merged. Rebase on `develop` before opening.
+    2. Write failing test: twophase parity — synthetic `make_survey_data(n = 500, seed = 42, design = "twophase")`, parity against `survey::svyvar(~focal, design_sv, na.rm = TRUE)` on a `survey::twophase()`-wrapped equivalent, tolerance point `1e-10`, SE `1e-8`. Assert `test_invariants(design)` first.
+    3. In `R/analysis-variance-helpers.R`, extend `.variance_cell()` to add the `survey_twophase` branch — delegate to `.twophase_mean_cell()` passing the score from `.score_variance()`. Remove the PR-1 stub. Run task 2's test; iterate until green.
+    4. Write failing test: twophase Phase 1-only rows contribute zero influence (edge case from spec) — parity against `svyvar()` on the two-phase oracle design, tolerance point `1e-10`, SE `1e-8`. Verify (usually green from task 3, but retain the edge-case-specific test).
+    5. Write failing test: nonprob parity — synthetic nonprob design (weights only, no ids/strata), parity against `survey::svyvar(~focal, svydesign(ids = ~1, weights = ~w, data), na.rm = TRUE)`, tolerance point `1e-10`, SE `1e-8`.
+    6. In `R/analysis-variance-helpers.R`, extend `.variance_cell()` to add the `survey_nonprob` branch — delegate to `.nonprob_mean_cell()` passing the score. Remove the PR-1 stub. Iterate.
+    7. Write failing test: nonprob with zero-weight rows — zero-weight rows excluded from `n` and from the weighted mean (spec edge case); parity against an oracle where zero-weight rows are pre-filtered, tolerance `1e-10` / `1e-8`. Verify the `.score_variance()` domain mask excludes zero-weight rows; iterate only if needed.
+    8. Confirm `R/analysis-variance.R` dispatches `survey_collection` through `.dispatch_over_collection()` (this is typically free via the family wrapper). If `.dispatch_over_collection()` requires a surface-level registration, add it in `R/analysis-variance.R`.
+    9. Write failing test: `survey_collection` happy path — two-survey collection built from `make_survey_data()` twice with different seeds; result row-binds per-survey `get_variance()` output with a `.survey` id column keyed to survey names; parity at `1e-10` / `1e-8`. Iterate.
+    10. Write failing dual-pattern test: `surveycore_error_collection_missing_var` — two-survey collection, one survey missing the focal variable, `.on_missing = "error"`.
+    11. Write failing dual-pattern test: `surveycore_error_collection_all_skipped` — all surveys missing variable, `.on_missing = "skip"` → collapses to this error. Verify.
+    12. Write failing dual-pattern test: `surveycore_error_collection_id_collision` — `.id = "name"` (collides with the produced `name` column) and `.id = "variance"`.
+    13. Write failing dual-pattern test: `surveycore_error_collection_invalid_id` — `.id = ""` and `.id = c("a", "b")`.
+    14. Write failing dual-pattern test: `surveycore_error_variable_not_found` — per-survey path with a variable not in one design (distinct from the "collection" all-missing path).
+    15. Write failing `expect_message(class = ...)` test: `surveycore_message_collection_skipped_surveys` — `.on_missing = "skip"` with one survey missing the var; at least one survey has the var, so a non-empty result is returned. Verify.
+    16. Write failing `expect_warning(class = ...)` test: `surveycore_warning_collection_meta_divergence` — two surveys whose metadata for the same focal variable differs; top-level `.meta` reflects the first survey; `meta(result)$per_survey` is present. Verify.
+    17. Write failing `expect_warning(class = ...)` test: `surveycore_warning_collection_duplicate_name_repaired` — two surveys sharing the same name in the collection; repair fires the warning.
+    18. Run `devtools::test()` — every new test plus the full PR 1 suite green.
+    19. Update `NEWS.md` dev-version entry to note that `get_variance()` now supports `survey_twophase`, `survey_nonprob`, and `survey_collection` dispatch.
+    20. Run `devtools::document()` — no new `.Rd` expected (signature did not change); confirm NAMESPACE diff is empty.
+    21. Run `devtools::check()` — 0 errors, 0 warnings, ≤2 pre-approved notes.
+
+  - **Acceptance criteria** — observable outcomes before merge
+
+    All tests below pass at the tolerances named in `test-spec.md`:
+
+    1. Twophase parity to `svyvar()` on the `survey::twophase()`-wrapped design: point `1e-10`, SE `1e-8`.
+    2. Twophase Phase 1-only rows contribute zero influence (parity retained on the edge-case dataset).
+    3. Nonprob parity to `svyvar()` on `svydesign(ids = ~1, weights = ~w)`: point `1e-10`, SE `1e-8`.
+    4. Nonprob zero-weight rows excluded from `n` and from the weighted mean (parity against pre-filtered oracle).
+    5. `survey_collection` happy-path row-binds per-survey `get_variance()` output with the `.survey` id column; per-survey parity `1e-10` / `1e-8`.
+    6. Dual-pattern green for `surveycore_error_collection_missing_var`.
+    7. Dual-pattern green for `surveycore_error_collection_all_skipped`.
+    8. Dual-pattern green for `surveycore_error_collection_id_collision` (both collision cases).
+    9. Dual-pattern green for `surveycore_error_collection_invalid_id` (both invalid-id cases).
+    10. Dual-pattern green for `surveycore_error_variable_not_found` on the per-survey path.
+    11. `expect_message(class = "surveycore_message_collection_skipped_surveys")` green with `.on_missing = "skip"`.
+    12. `expect_warning(class = "surveycore_warning_collection_meta_divergence")` green; `meta(result)$per_survey` present.
+    13. `expect_warning(class = "surveycore_warning_collection_duplicate_name_repaired")` green.
+    14. PR 1's entire test suite remains green (no regression from the helper extensions).
+    15. `test_invariants(design)` is the first assertion of every test that constructs a survey design; collection tests additionally assert `test_invariants()` on each component survey.
+    16. `R CMD check`: 0 errors, 0 warnings, ≤2 pre-approved notes.
+
+  - **Files touched** — exact write surface
+
+    | File | Action |
+    |---|---|
+    | `R/analysis-variance-helpers.R` | modified (extend `.variance_cell()` with `survey_twophase` and `survey_nonprob` branches; remove PR-1 stubs) |
+    | `R/analysis-variance.R` | modified (confirm or add `survey_collection` dispatch wiring through `.dispatch_over_collection()`, if not free) |
+    | `NEWS.md` | modified (dev-version entry updated) |
+    | `tests/testthat/test-analysis-variance-twophase-nonprob.R` | created (twophase + nonprob parity + nonprob zero-weight + twophase phase-1 edge) |
+    | `tests/testthat/test-analysis-variance-collection.R` | created (collection happy path + C5, C6, C7, C13, C10 errors + C9 message + C11 divergence warning + C2a duplicate-name warning) |
+    | `tests/testthat/_snaps/analysis-variance-twophase-nonprob.md` | created (error-snapshot file generated by testthat) |
+    | `tests/testthat/_snaps/analysis-variance-collection.md` | created (error-snapshot file generated by testthat) |
+
+    Overlap with PR 1: `R/analysis-variance-helpers.R` and `R/analysis-variance.R` are edited in both PRs. This is **sequential** (PR 2 opens only after PR 1 merges); no "disjoint concurrent PRs" rule is violated.
+
+  - **Pipeline split**: recommended
+
+## Test-spec coverage map
+
+Every row in `test-spec.md` is scheduled under exactly one PR:
+
+| `test-spec.md` row family | PR |
+|---|---|
+| Happy path: Taylor point + SE + CI | PR 1 |
+| Happy path: multi-variable pairwise + listwise | PR 1 |
+| Happy path: replicate (BRR) parity | PR 1 |
+| Happy path: twophase parity | PR 2 |
+| Happy path: nonprob parity | PR 2 |
+| Happy path: grouped via `group_by()` + `group =` | PR 1 |
+| Happy path: constant variable → exact `0` | PR 1 |
+| Happy path: `name_style = "broom"` rename | PR 1 |
+| Happy path: `n_weighted` | PR 1 |
+| Happy path: column-level `label` attrs | PR 1 |
+| Happy path: `.meta` top-level + `$x` + `$group` structure | PR 1 |
+| Happy path: `label_vars` on/off | PR 1 |
+| Happy path: `decimals = 3` rounding | PR 1 |
+| Happy path: `deff` parity | PR 1 |
+| Happy path: `survey_collection` | PR 2 |
+| Error: unsupported_class / wrong_variable_count / non_numeric_variable (factor + char) / invalid_variance_arg / invalid_conf_level (3) / invalid_decimals (2) / invalid_name_style / na_rm_not_logical (2) / `na_handling` match.arg | PR 1 |
+| Error: collection_missing_var / collection_all_skipped / collection_id_collision / collection_invalid_id (2) / variable_not_found (per-survey) | PR 2 |
+| Warning: small_cell / single_level / cv_undefined / variance_all_na (2 trigger paths) / variance_insufficient_n | PR 1 |
+| Warning: collection_skipped_surveys (message) / collection_meta_divergence / collection_duplicate_name_repaired | PR 2 |
+| Edge: all-NA / single-obs / constant / `na.rm = FALSE` / single-level group / listwise-intersection / pairwise-differ / replicate near-zero | PR 1 |
+| Edge: CI below zero (not clamped) | PR 1 |
+| Edge: nonprob zero-weight / twophase phase-1 / collection all-missing (→ error) / collection per-survey meta divergence | PR 2 |
+| Invariants block (applies to every test) | PR 1 + PR 2 |
+| Tolerances block (applies to every test) | PR 1 + PR 2 |
+| Profile gates block | PR 1 (full pass); PR 2 (retain full pass) |
+
+## Spec contract coverage map
+
+Every item in `spec.md §Function contracts` is covered by at least one PR's acceptance criteria:
+
+| Contract item | PR |
+|---|---|
+| Signature (all 15 args including `na_handling`, `.id`, `.on_missing`) | PR 1 (full signature shipped) |
+| Arguments semantics (design classes, `x`, `group`, `variance`, `conf_level`, `n_weighted`, `decimals`, `min_cell_n`, `na.rm`, `na_handling`, `label_values`, `label_vars`, `name_style`, `.id`, `.on_missing`) | PR 1 for all except twophase/nonprob/collection-specific behavior which are PR 2 |
+| Returns (class, column order, column attrs, `.meta` shape) | PR 1 (full return shipped; PR 2 only extends dispatch paths) |
+| Errors (15 rows) | PR 1 for rows not requiring collection dispatch; PR 2 for collection-specific rows |
+| Warnings (9 rows) | PR 1 for non-collection; PR 2 for collection-specific |
+| Edge cases (14 rows) | PR 1 for non-dispatch-specific; PR 2 for twophase/nonprob/collection-specific |
+
+## HOLDs raised
+
+None. All PR ordering is unambiguous (sequential), and every row in `test-spec.md` maps to exactly one PR.

--- a/plans/spec-get-variance.md
+++ b/plans/spec-get-variance.md
@@ -1,0 +1,262 @@
+# Spec — get-variance
+
+**Status**: SPEC_REVIEWED
+**Target version**: 0.7.1.9000
+**PR range**: PR 1–2
+
+## Scope
+
+### In
+
+- A new exported analysis function `get_variance()` that estimates the
+  design-based finite-population variance of one or more numeric variables
+  with the Kish `n/(n-1)` correction.
+- Dispatch across all currently supported survey design classes:
+  `survey_taylor`, `survey_replicate`, `survey_twophase`, `survey_nonprob`,
+  and `survey_collection` (via the standard `.id` / `.on_missing` reserved
+  arguments).
+- Design-based SE, the full family of opt-in uncertainty columns
+  (`se`, `var`, `cv`, `ci_low`, `ci_high`, `moe`, `deff`), and the standard
+  column-level `label` attributes required for gt integration.
+- Nested `.meta` structure (`group` / `x`) matching the rest of the
+  `get_*()` family.
+- `na.rm` control (scalar boolean) and a new `na_handling` control
+  (pairwise vs listwise) that governs multi-variable NA semantics.
+- Tidy, long-form output (one row per variable) with a required `name`
+  column carrying the raw variable name (or the variable label when
+  `label_vars = TRUE`).
+
+### Out
+
+- Off-diagonal covariances (no variance/covariance matrix output). A future
+  `get_covariance()` is explicitly out of scope.
+- Standard-deviation estimand (callers apply `sqrt()` themselves, matching
+  `survey::svyvar()`).
+- Coercion of factor / character inputs to numeric. These are rejected,
+  matching the `get_means()` precedent.
+- A log-transformed / Satterthwaite-refined CI for small-sample variance
+  inference. The normal-Wald CI (with no clamping) is the only interval
+  produced.
+- A `get_sd()` wrapper.
+
+## Architecture
+
+- **Files touched**
+  - `R/analysis-variance.R` — created. Houses exported `get_variance()`,
+    dispatch to design-specific cell helpers, result assembly, naming.
+  - `R/analysis-variance-helpers.R` — created. Houses a single
+    `.variance_cell(design, y, weights, domain, na_vec, ...)` dispatch
+    wrapper and the shared score-vector helper
+    `.score_variance(y, weights, domain, na_vec)` that returns the
+    derived score vector
+    `z_i = a_i · (y_i − ȳ_d)² · n_d/(n_d−1)`. `ȳ_d` and `n_d` are the
+    domain-restricted weighted mean and unweighted count respectively.
+    The cell wrapper builds the score and then delegates to the existing
+    per-design mean cell helper appropriate to `class(design)`:
+    `.taylor_mean_cell()` (→ `.svy_recvar()`), `.replicate_mean_cell()`
+    (replicate-weight loop), `.twophase_mean_cell()` (two-phase sum), or
+    `.nonprob_mean_cell()` (HT influence). The multi-variable case
+    iterates over selected columns (per-variable under
+    `na_handling = "pairwise"`; shared active mask under `"listwise"`),
+    calls `.variance_cell()` once per variable, and row-binds the
+    per-variable results.
+  - `R/analysis-meta.R` — modified. Introduces a shared
+    `FAMILY_META_KEYS` constant used by all `get_*()` meta constructors
+    (replacing the per-function `*_META_KEYS` duplicates) and registers
+    the `survey_variance` meta constructor call.
+  - `R/methods-print.R` — modified. Adds a `survey_variance` print method
+    following the existing family template.
+  - `R/methods-compat.R` — modified. Adds broom `tidy` / `glance` adapter
+    for `survey_variance` (matches the other family members; no new
+    method semantics).
+  - `NAMESPACE` — regenerated. New export `get_variance`.
+  - `man/get_variance.Rd` — generated.
+  - `DESCRIPTION` — version bump to `0.7.1.9000`.
+  - `NEWS.md` — add entry under `# surveycore (development version)`.
+  - `plans/error-messages.md` — already updated in this spec pass with
+    new rows V-1 and V-2.
+
+- **Functions added**
+  - `get_variance(design, x, group = NULL, variance = "ci",
+     conf_level = 0.95, n_weighted = FALSE, decimals = NULL,
+     min_cell_n = 30L, na.rm = TRUE,
+     na_handling = c("pairwise", "listwise"),
+     label_values = TRUE, label_vars = TRUE,
+     name_style = "surveycore", ..., .id = ".survey",
+     .on_missing = "error")`
+
+- **Functions modified**
+  - `.apply_name_style()` — extended so its broom rename map includes
+    `variance → estimate` (parallels `mean → estimate` already present
+    for `get_means()`). No signature change.
+  - `R/analysis-meta.R` — refactored to introduce a shared
+    `FAMILY_META_KEYS` constant consumed by every `get_*()` meta
+    constructor (replacing per-function `*_META_KEYS` duplicates); all
+    existing callers are updated mechanically, no behavioral change.
+  - All other existing helpers (`.apply_domain()`, `.resolve_groups()`,
+    `.add_variance_cols()`, `.validate_shared_args()`,
+    `.check_unsupported_class()`, `.build_cluster_matrices()`,
+    `.svy_recvar()`, `.svy_rep_var()`, `.twophasevar()`,
+    `.compute_phase2_probs()`, `.apply_decimals()`,
+    `.make_result_tibble()`, `.extract_var_meta()`,
+    `.build_group_meta()`, `.apply_group_labels()`,
+    `.dispatch_over_collection()`, and the per-design mean cell helpers
+    `.taylor_mean_cell()` / `.replicate_mean_cell()` /
+    `.twophase_mean_cell()` / `.nonprob_mean_cell()`) are reused as-is,
+    no signature changes.
+
+- **Class changes**
+  - `survey_variance` — new S3 class applied to the returned tibble,
+    inheriting `survey_result`, following the existing family convention
+    (`survey_mean`, `survey_corr`, etc.).
+
+## Function contracts
+
+### `get_variance(design, x, ...)`
+
+- **Signature**
+
+  ```
+  get_variance(
+    design,
+    x,
+    group = NULL,
+    variance = "ci",
+    conf_level = 0.95,
+    n_weighted = FALSE,
+    decimals = NULL,
+    min_cell_n = 30L,
+    na.rm = TRUE,
+    na_handling = c("pairwise", "listwise"),
+    label_values = TRUE,
+    label_vars = TRUE,
+    name_style = "surveycore",
+    ...,
+    .id = ".survey",
+    .on_missing = "error"
+  )
+  ```
+
+- **Arguments**
+
+  | Arg | Semantics |
+  |---|---|
+  | `design` | A survey design object: `survey_taylor`, `survey_replicate`, `survey_twophase`, `survey_nonprob`, or a `survey_collection`. (`survey_srs` dispatches through the `survey_nonprob` path.) Any other class is rejected. |
+  | `x` | `<tidy-select>`. One or more unquoted numeric variable names. Must resolve to at least one numeric column. Non-numeric columns cause an error (no silent drop, matching `get_means()`). |
+  | `group` | `<tidy-select>` or `NULL`. Optional grouping variable(s); combined elementwise with any grouping set by `group_by()` on the design. `NULL` means "no grouping beyond what the design carries." Grouping follows domain-estimation semantics: the variance is estimated separately within each group using that group's own weighted mean ȳ_g for centering (not a full-sample mean). Matches `get_means()` grouping behavior. |
+  | `variance` | `NULL` or character vector whose elements are drawn from `c("se", "ci", "var", "cv", "moe", "deff")`. Selects which uncertainty columns appear in the output. Default `"ci"`. `NULL` emits no uncertainty columns. |
+  | `conf_level` | Numeric scalar, strictly in `(0, 1)`. Default `0.95`. Normal-quantile based CIs (`degf = Inf`), matching `get_means()` precedent and `survey::svyvar()`. |
+  | `n_weighted` | Logical scalar. If `TRUE`, appends an `n_weighted` column with the sum of weights over in-domain, non-NA, positive-weight rows used in each row's estimate. Default `FALSE`. |
+  | `decimals` | Non-negative whole number or `NULL`. Rounds all numeric output columns (`variance`, `se`, `var`, `cv`, `ci_low`, `ci_high`, `moe`, `deff`, `n_weighted`). Default `NULL` (no rounding). |
+  | `min_cell_n` | Non-negative whole number. Minimum unweighted in-domain non-NA `n` below which `surveycore_warning_small_cell` fires. Default `30L` (AAPOR). |
+  | `na.rm` | Logical scalar. If `TRUE` (default), NA observations in any focal variable are excluded from that variable's per-row calculations, and rows where any grouping variable is `NA` are excluded from the output. If `FALSE`, NA focal values propagate (produces `NaN` estimates) and NA group values are collected into their own group row (matching `get_means()` / `get_freqs()` semantics). |
+  | `na_handling` | `"pairwise"` (default) or `"listwise"`. Interacts with `na.rm`: when `na.rm = TRUE`, controls which rows are treated as non-NA for each focal variable. `"pairwise"`: each focal variable's `n` reflects its own complete-case set (each row in the output uses that variable's own non-NA rows). `"listwise"`: one shared complete-case set — rows with `NA` in *any* of the selected focal variables are excluded from *every* variable's per-row calculation, and every output row shares the same `n`. When `na.rm = FALSE`, `na_handling` is ignored. `match.arg()` is used; unknown values fall through to an arg-matching error. |
+  | `label_values` | Logical scalar. If `TRUE` (default) and a grouping variable has value labels in metadata, the group column is converted to a labelled factor. Same behavior as `get_means()`. |
+  | `label_vars` | Logical scalar. If `TRUE` (default) and variable labels are set in metadata, the `name` column shows variable labels instead of raw names. Falls back to raw names when a label is unset. |
+  | `name_style` | `"surveycore"` (default) or `"broom"`. Under `"broom"`, the point-estimate column `variance` is renamed to `estimate` (matching the family's treatment of the point-estimate column — same as `get_means()`'s `mean → estimate`), along with `se → std.error`, `ci_low → conf.low`, `ci_high → conf.high`. `.apply_name_style()` must be extended so the broom map includes the `variance → estimate` entry. |
+  | `...` | Reserved (unused) for reserved named-only control args. |
+  | `.id` | Character scalar. Column name added when `design` is a `survey_collection` to identify each survey. Default `".survey"`. Must be non-empty, non-NA, length 1. |
+  | `.on_missing` | `"error"` (default) or `"skip"`. How to handle surveys in a collection that lack one of the requested NSE variables. |
+
+- **Returns**
+
+  A tibble of class `c("survey_variance", "survey_result", "tbl_df", "tbl", "data.frame")`.
+
+  Columns, in order:
+
+  1. `[group_cols...]` — one column per active grouping variable (from `group` argument combined with any `group_by()` on the design). Present only when grouping is active. Labelled factors when a group has value labels and `label_values = TRUE`; raw codes otherwise.
+  2. `name` — character (or labelled character when `label_vars = TRUE` and a variable label exists). Identifies the focal variable that each row summarizes. Always present (even when `x` selects a single variable).
+  3. `variance` — numeric. The design-based point estimate of the population variance (Kish `n/(n-1)` correction applied). `NaN` for degenerate cells; `0` for zero-variance (constant-within-domain) variables.
+  4. Zero or more uncertainty columns — included only when selected via `variance`. Column names: `se`, `var`, `ci_low`, `ci_high`, `cv`, `moe`, `deff`. (When `name_style = "broom"`, renamed per `.apply_name_style()`.)
+  5. `n` — integer. Unweighted count of in-domain, non-NA rows with positive weight contributing to that row's estimate. Under active grouping, reflects only rows in the current group's domain (per-variable under `na_handling = "pairwise"`; shared across variables under `na_handling = "listwise"`).
+  6. `n_weighted` — numeric. Present only when `n_weighted = TRUE`. Under `na_handling = "pairwise"`, each variable reports its own `sum(w · a)` over its own complete-case set. Under `na_handling = "listwise"`, all variables share the intersected `sum(w · a)`.
+
+  Attributes:
+
+  - Every column carries a `label` attribute for gt integration. `variance` → `"Variance"`, `se` → `"SE"`, `var` → `"Variance of estimate"`, `ci_low` / `ci_high` → conf-level-interpolated `"95% CI low"` / `"95% CI high"` (or equivalent for other `conf_level` values), `cv` → `"CV"`, `moe` → `"Margin of error"`, `deff` → `"Design effect"`, `n` → `"N"`, `n_weighted` → `"Weighted N"`, `name` → `"Variable"`. Group columns carry the group variable's metadata label when available.
+  - A `.meta` attribute with the family's nested shape — **no `function_name` or `variable` keys** (family parity: `get_means()` / `get_freqs()` do not carry them):
+    - `group` = named list, one entry per active grouping variable, each with `variable_label`, `question_preface`, `value_labels` (or empty list when no grouping)
+    - `x` = named list, one entry per focal variable, each with `variable_label`, `question_preface`, `value_labels`
+    - `design_class` — one of `"survey_taylor"`, `"survey_replicate"`, `"survey_twophase"`, `"survey_nonprob"`, or `"survey_collection"` (when dispatched through `.dispatch_over_collection()`)
+    - `conf_level`, `name_style`, `min_cell_n` — echoed for downstream consumers
+    - `na_handling` — echoed so consumers can interpret per-row `n`
+  - Class attribute listed above.
+
+- **Errors** — one row per named error class.
+
+  | Condition | Error class | Registry row |
+  |---|---|---|
+  | `design` is not a recognized survey class | `surveycore_error_unsupported_class` | 64 |
+  | `x` resolves to 0 columns | `surveycore_error_wrong_variable_count` | 138 |
+  | A selected `x` column is non-numeric | `surveycore_error_non_numeric_variable` | 43 |
+  | `variance` contains invalid values | `surveycore_error_invalid_variance_arg` | 45 |
+  | `conf_level` not a numeric scalar strictly in `(0, 1)` | `surveycore_error_invalid_conf_level` | 45a |
+  | `decimals` not a non-negative whole number or `NULL` | `surveycore_error_invalid_decimals` | 45b |
+  | `name_style` not `"surveycore"` or `"broom"` | `surveycore_error_invalid_name_style` | 46 |
+  | `na.rm` not `TRUE` or `FALSE` | `surveycore_error_na_rm_not_logical` | 81 |
+  | `na_handling` not `"pairwise"` or `"listwise"` | *(handled by `match.arg()`)* | — (consistent with row 18 pattern) |
+  | `survey_collection` survey lacks a requested variable with `.on_missing = "error"` | `surveycore_error_collection_missing_var` | C5 |
+  | All surveys in a collection skipped | `surveycore_error_collection_all_skipped` | C6 |
+  | `.id` collides with a produced column | `surveycore_error_collection_id_collision` | C7 |
+  | `.id` invalid | `surveycore_error_collection_invalid_id` | C13 |
+  | Selected variable not present on a per-survey path | `surveycore_error_variable_not_found` | C10 |
+
+- **Warnings** — one row per named warning class.
+
+  | Condition | Warning class | Registry row |
+  |---|---|---|
+  | Any row has `n < min_cell_n` | `surveycore_warning_small_cell` | 49 |
+  | A grouping variable has a single observed level | `surveycore_warning_single_level` | 50 |
+  | `variance = "cv"` cell has estimate 0 or negative (variance ≤ 0 case — only possible when variance = 0 under the estimand; still fires per family rule) | `surveycore_warning_cv_undefined` | 54 |
+  | A focal variable is all-NA in the active domain under `na.rm = TRUE` | `surveycore_warning_variance_all_na` | V-1 |
+  | A focal variable has fewer than 2 non-NA rows in the active domain | `surveycore_warning_variance_insufficient_n` | V-2 |
+  | (Collection) surveys skipped due to missing variable with `.on_missing = "skip"` | `surveycore_message_collection_skipped_surveys` | C9 |
+  | (Collection) per-survey metadata divergence for the same variable | `surveycore_warning_collection_meta_divergence` | C11 |
+  | (Collection) duplicate names repaired | `surveycore_warning_collection_duplicate_name_repaired` | C2a |
+  | Option `survey.lonely.psu` triggers inside `.svy_recvar()` | Inherited from the engine — no additional wrap or suppression |
+
+- **Edge cases**
+
+  | Case | Behavior |
+  |---|---|
+  | `x` selects 0 columns | Error, `surveycore_error_wrong_variable_count`. |
+  | `x` resolves to a matrix column (e.g., `cbind(a, b)` stored as a matrix-typed column) | Rejected via the existing non-numeric path. Tidy-select resolves the selection to a single column; the per-column numeric-vector check fails for matrix columns and fires `surveycore_error_non_numeric_variable`. No new error class required. |
+  | `x` selects 1 column, single-row input | Not reachable — `as_survey*` constructors reject <2 rows (registry row 4). Documented here only to affirm no guard is needed downstream. |
+  | Active domain empty for a given row (0 in-domain non-NA observations, post-group-split) | `variance = NaN`, `se = NaN`, any CI / moe / cv / deff columns `NaN`, `n = 0L`, `n_weighted = 0`. Algorithmic warning condition: `if n_d == 0L && sum(!is.na(x[active_mask])) == 0L && sum(active_mask) > 0L` → fire `surveycore_warning_variance_all_na` (rows are present in the domain but every value of `x` is NA). Otherwise silent — the active domain is empty because filtering/grouping removed all rows, not because `x` is pathologically NA. |
+  | Variable is all-NA in the active domain (`na.rm = TRUE`) | `variance = NaN`, all uncertainty cols `NaN`, `n = 0L`. Fires `surveycore_warning_variance_all_na`. |
+  | Variable has exactly one non-NA observation in the active domain | `variance = NaN`, all uncertainty cols `NaN`, `n = 1L`. Fires `surveycore_warning_variance_insufficient_n`. |
+  | Variable is constant (zero variance) in the active domain, `n >= 2` | `variance = 0`, `se = 0`, `ci_low = ci_high = 0`, `moe = 0`, `deff = 0` (0/0 guard: return 0 when SRS comparator is also 0), `cv` set to `NA` with `surveycore_warning_cv_undefined` (family rule). `n` and `n_weighted` populated normally. No variance-specific warning. |
+  | Grouping variable with a single observed level | Fires `surveycore_warning_single_level`; output has a single row per variable. |
+  | `na.rm = FALSE`, variable contains NAs | NAs propagate: `variance = NaN`, uncertainty cols `NaN` for rows whose focal variable has any NA contribution. `n` is unweighted count of in-domain rows regardless of NA status. No variance-specific warning fires. |
+  | `na_handling = "listwise"`, some rows NA in one variable | Each output row's `n` reflects the intersection complete-case set. Fires `surveycore_warning_variance_all_na` if that intersection is empty; `surveycore_warning_variance_insufficient_n` if size ≤ 1. |
+  | `na_handling = "pairwise"`, per-variable `n`s differ | Each row uses its own variable's complete-case `n`. No extra warning about mismatched `n`s. |
+  | `survey_nonprob` with zero weights in the focal domain | Zero-weight rows excluded from `n` and from the weighted mean (matching `svyvar` survey.R line 703). Strictly positive non-zero weights contribute. Zero-weight rows cannot occur in `survey_taylor` / `survey_replicate` / `survey_twophase` designs — their validators enforce strictly positive weights. This edge case applies only to `survey_nonprob`. |
+  | `survey_twophase`: row is in Phase 1 but not in Phase 2 | Contributes 0 to influence; excluded from `n` and `W`. |
+  | `survey_replicate`: near-zero variance with tiny negative replicate residual | Use `max(0, v)` inside the `sqrt()` of the SE calculation to avoid `NaN` from floating-point underflow in an otherwise-zero variance. |
+  | CI bounds fall below 0 (variance near 0 with wide SE) | **Not clamped.** `ci_low` may be negative. **Builder must document this explicitly in the roxygen `@details` section** of `get_variance()`: CIs use the normal-Wald approximation on the SE of the variance estimate; when the true variance is near zero with wide SE, `ci_low` can be negative; bounds are not clamped; users may clamp at `0` if desired; this matches `survey::svyvar()`. |
+  | `design` is a `survey_collection`: all surveys lack the variable | Dispatch collapses to `surveycore_error_collection_all_skipped`. |
+  | `design` is a `survey_collection`: per-survey `.meta` differs | `surveycore_warning_collection_meta_divergence` fires; top-level `.meta` reflects the first survey; per-survey metadata preserved under `.meta$per_survey`. |
+
+## Quality gates
+
+- `get_variance()` is numerically equivalent to `survey::svyvar()` on a single numeric variable for Taylor, replicate, and twophase designs within the project's standard tolerances (point and SE).
+- `get_variance()` returns a strictly positive `variance` for every non-degenerate non-constant variable with `n ≥ 2`; `0` for constants with `n ≥ 2`; `NaN` otherwise — never `NA_real_`.
+- `variance` column is the estimand; `var` column (when opted in) is the variance-of-the-estimate. The two are distinct columns with distinct meanings; neither overwrites the other.
+- Dispatch covers the five listed design classes and errors for any other class via the existing `.check_unsupported_class()` path.
+- `test_invariants(design)` holds for every constructor used in the test harness.
+- All output columns carry a `label` attribute.
+- The `.meta` of the result has the family-standard nested shape: `group` (possibly empty), `x` (one entry per focal variable), and echoes of `conf_level`, `name_style`, `min_cell_n`, `na_handling`, and `design_class`. **No `function_name` or `variable` keys** — those are intentionally omitted to match `get_means()` / `get_freqs()`.
+- Name-style `"broom"` renames `variance` → `estimate` (column and label updated consistently).
+- The two new warning classes `surveycore_warning_variance_all_na` and `surveycore_warning_variance_insufficient_n` are defined in `plans/error-messages.md` and are fired exactly once per variable-edge-case occurrence.
+- `survey.lonely.psu` behavior is inherited from the variance engine — no extra cli messages are emitted by `get_variance()` itself.
+- The roxygen `@details` block for `get_variance()` includes an explicit note that `ci_low` may be negative when the point estimate is near zero (builder requirement, per the CI edge-case row above).
+- `R CMD check --as-cran` passes with 0 errors, 0 warnings, ≤2 pre-approved notes.
+
+## Pipeline split
+
+**recommended** — A new exported numerical estimator that crosses every design type, adds two new warning classes, introduces a new `survey_variance` result class, mutates `analysis-meta.R`, and requires numerical parity tests against `survey::svyvar()` on three design paths. Single-PR implementation would exceed a reviewable surface area.
+
+Natural seam for the builder: split into two PRs.
+
+- **PR 1 — feature/get-variance-core**: Owns `R/analysis-variance.R`, `R/analysis-variance-helpers.R` (the single `.variance_cell()` wrapper + `.score_variance()`), the `analysis-meta.R` refactor to `FAMILY_META_KEYS`, the `survey_variance` print method, and the broom adapter including the `variance → estimate` entry in `.apply_name_style()`. Implements Taylor and replicate dispatch paths inside `.variance_cell()` via delegation to `.taylor_mean_cell()` / `.replicate_mean_cell()`. Ships the full public API (the `na_handling` argument, the multi-variable iteration, result assembly, `.meta` shape, column labels) and numerical parity tests against `svyvar()` for `survey_taylor` and `survey_replicate` designs.
+- **PR 2 — feature/get-variance-twophase-nonprob-collection**: **Does NOT re-author any helper from PR 1.** Only extends `.variance_cell()` to cover `survey_twophase` and `survey_nonprob` (delegating to the existing twophase/nonprob mean cell helpers) and adds `survey_collection` dispatch wiring (which is mostly free via `.dispatch_over_collection()`). Adds twophase and nonprob numerical parity tests plus collection-dispatch edge-case coverage (`C5`–`C11`). If a shared helper needs to change between PR 1 and PR 2, the change lands in PR 1 and is consumed (not copied) by PR 2.

--- a/plans/test-spec-get-variance.md
+++ b/plans/test-spec-get-variance.md
@@ -1,0 +1,157 @@
+# Test-spec — get-variance
+
+## Reference oracle
+
+- `survey::svyvar()` — authoritative oracle for point and SE values across
+  `survey_taylor`, `survey_replicate`, and `survey_twophase` numerical
+  parity tests.
+- `survey::svymean()` applied to the derived score
+  `z_i = (y_i - ȳ)^2 * n / (n-1)` — used only as a secondary confirmation
+  oracle that the point estimate reduces to a weighted mean of the Kish-scaled
+  centred-squared, and as the SRS comparator used in the `deff` parity check.
+- `survey::svydesign(ids = ~1, weights = ~w)` for the `survey_nonprob` parity
+  tests (nonprob-with-weights is treated as a one-stage SRS-with-weights
+  design for oracle purposes).
+- `survey` package version: whichever the project's `DESCRIPTION`
+  Suggests pins (≥ 4.2-1 at time of writing; do not hard-code).
+- Tests that compare against `survey::svyvar()` must wrap the oracle call
+  in `skip_if_not_installed("survey")` at the block level.
+
+## Datasets
+
+| Dataset | Purpose |
+|---|---|
+| `nhanes_2017` (project data) | Stratified clustered Taylor-design parity tests against `survey::svyvar()` with `ridageyr` and `bpxsy1` as focal numeric variables. |
+| `acs_pums_wy` (project data) | Replicate-weight (BRR) parity tests against `survey::svyvar()` on the replicate design path. |
+| `make_survey_data(n = 500, seed = 42, design = "twophase")` | Synthetic twophase design for numerical parity on the twophase path (Phase 1 rows vs Phase 2 rows), and for invariant checks. |
+| `make_survey_data(n = 400, seed = 11, design = "taylor")` | Synthetic Taylor design for edge-case tests (all-NA variable, single-obs variable, constant variable, small-cell warnings, single-level grouping, zero-weight rows) where exact control of values is easier than with real data. |
+| `make_survey_data(n = 400, seed = 11, design = "taylor", with_labels = TRUE)` | Metadata / label propagation, `label_values`, `label_vars`, `.meta` nested-shape tests, and column-level `label` attribute checks. |
+| `make_survey_data(n = 300, seed = 99, design = "replicate", type = "BRR")` | Synthetic replicate design for replicate-path edge cases (tiny-negative replicate residual on near-constant variable) and for dispatch tests separate from the ACS parity check. |
+| Inline `data.frame` with explicit NA patterns | Edge-case tests for `na.rm = FALSE`, `na_handling = "pairwise"` vs `"listwise"` differing `n`, and empty domain after group filtering. |
+| A two-survey `survey_collection` built from `make_survey_data()` twice with different seeds, one survey missing a focal variable | `survey_collection` dispatch: happy path, `.on_missing = "skip"`, `.on_missing = "error"`, `.id` collision, meta divergence. |
+
+## Per-function test plan
+
+### `get_variance()`
+
+#### Happy path
+
+| Scenario | Dataset | Oracle | Tolerance |
+|---|---|---|---|
+| Single numeric variable, Taylor design, no group — point estimate | `nhanes_2017` wrapped as `survey_taylor` with `ids = sdmvpsu`, `strata = sdmvstra`, `weights = wtint2yr`, `nest = TRUE` | `survey::svyvar(~ridageyr, design, na.rm = TRUE)` coefficient | point `1e-10` |
+| Single numeric variable, Taylor design, no group — SE | Same as above | `survey::SE(survey::svyvar(~ridageyr, design, na.rm = TRUE))` | SE `1e-8` |
+| Single numeric variable, Taylor design — default CI | Same | Manual: `coef ± qnorm(0.975) * SE` computed from oracle | CI `1e-6` |
+| Multi-variable input, Taylor design, pairwise | `nhanes_2017` with `c(ridageyr, bpxsy1)` | Per-variable `svyvar(~ridageyr, ...)` and `svyvar(~bpxsy1, ...)` — separate calls, each with its own `na.rm = TRUE` (to match pairwise) | point `1e-10`, SE `1e-8` |
+| Multi-variable input, Taylor design, listwise | Same input, `na_handling = "listwise"` | `survey::svyvar(~ridageyr + bpxsy1, design, na.rm = TRUE)` diagonal only | point `1e-10`, SE `1e-8` |
+| Replicate (BRR) parity — point and SE | `acs_pums_wy` wrapped as `survey_replicate` | `survey::svyvar(~focal, design, na.rm = TRUE)` | point `1e-10`, SE `1e-8` |
+| Twophase parity — point and SE | Synthetic twophase | `survey::svyvar(~focal, design, na.rm = TRUE)` on `survey::twophase()` design built from the same data | point `1e-10`, SE `1e-8` |
+| Nonprob parity — point and SE | Synthetic nonprob (weights only, no ids/strata) | `survey::svyvar(~focal, svydesign(ids = ~1, weights = ~w, data))` | point `1e-10`, SE `1e-8` |
+| Grouped estimate, Taylor, `group_by()` active | Synthetic labelled | `survey::svyby(~focal, ~g, design, survey::svyvar, na.rm = TRUE)` | point `1e-10`, SE `1e-8` |
+| Grouped estimate via `group =` argument | Synthetic labelled | Same as above | point `1e-10`, SE `1e-8` |
+| Constant variable returns `variance = 0`, `se = 0` | Inline `data.frame` with y = rep(5, n) | No oracle; check exact `0`s | exact equality |
+| `name_style = "broom"` renames `variance → estimate`, `se → std.error`, `ci_low → conf.low`, `ci_high → conf.high` | Any happy-path dataset | Column-name assertion | — |
+| `n_weighted = TRUE` appends `n_weighted` column equal to `sum(w[in_domain & !is.na(y) & w > 0])` | Synthetic labelled | Manually computed weighted sum | `1e-10` |
+| Column-level `label` attributes present on every output column | Synthetic labelled | `attr(col, "label")` not `NULL` and matches expected string | — |
+| `.meta` structure: top-level keys are exactly `group`, `x`, `design_class`, `conf_level`, `name_style`, `min_cell_n`, `na_handling` (no `function_name` or `variable` keys — family parity with `get_means()` / `get_freqs()`) | Synthetic labelled | Structural assertion: `expect_identical(sort(names(meta(result))), sort(c("group", "x", "design_class", "conf_level", "name_style", "min_cell_n", "na_handling")))` | — |
+| `.meta$x` has one entry per focal variable with `variable_label`, `question_preface`, `value_labels` sub-keys | Synthetic labelled | Structural assertion | — |
+| `.meta$group` empty when no group, populated when group active | Synthetic labelled | Structural assertion | — |
+| `label_vars = TRUE` substitutes variable label for `name` column value; `label_vars = FALSE` keeps raw name | Synthetic labelled | String equality | — |
+| `decimals = 3` rounds all numeric output columns to 3 decimals | Any happy path | Column equality to manually rounded oracle output | exact equality after rounding |
+| `deff` column equals `var(V_hat) / var_srs(score)` where `score = (y - ȳ)^2 * n/(n-1)` | Synthetic labelled, Taylor | Manual computation using SRS variance of score via `survey::svymean((y-mean)^2 * n/(n-1), srs_design)` | `1e-8` |
+| `survey_collection` dispatch happy path | Two-survey collection, both surveys contain focal var | Per-survey `get_variance()` on each, row-bound, with `.survey` id column equal to survey name | point `1e-10`, SE `1e-8` |
+
+#### Error paths
+
+| Condition | Error class | Assertion pattern |
+|---|---|---|
+| `design` is not a recognized survey class | `surveycore_error_unsupported_class` | Dual pattern (`expect_error(class=)` + `expect_snapshot(error = TRUE)`) |
+| `x` resolves to 0 columns | `surveycore_error_wrong_variable_count` | Dual |
+| A selected `x` column is non-numeric (factor) | `surveycore_error_non_numeric_variable` | Dual |
+| A selected `x` column is non-numeric (character) | `surveycore_error_non_numeric_variable` | Dual |
+| `variance` contains a value not in the valid set (e.g. `"foo"`) | `surveycore_error_invalid_variance_arg` | Dual |
+| `conf_level = 0` | `surveycore_error_invalid_conf_level` | Dual |
+| `conf_level = 1` | `surveycore_error_invalid_conf_level` | Dual |
+| `conf_level = NA` | `surveycore_error_invalid_conf_level` | Dual |
+| `decimals = -1` | `surveycore_error_invalid_decimals` | Dual |
+| `decimals = 1.5` | `surveycore_error_invalid_decimals` | Dual |
+| `name_style = "foo"` | `surveycore_error_invalid_name_style` | Dual |
+| `na.rm = NA` | `surveycore_error_na_rm_not_logical` | Dual |
+| `na.rm = 1` | `surveycore_error_na_rm_not_logical` | Dual |
+| `na_handling = "foo"` | `match.arg()` error (class-free check) | `expect_error()` only (no snapshot, consistent with row 18 precedent) |
+| Collection: requested variable missing, `.on_missing = "error"` | `surveycore_error_collection_missing_var` | Dual |
+| Collection: all surveys skipped | `surveycore_error_collection_all_skipped` | Dual |
+| Collection: `.id` collides with a produced column name (`"name"`, `"variance"`, etc.) | `surveycore_error_collection_id_collision` | Dual |
+| Collection: `.id = ""` | `surveycore_error_collection_invalid_id` | Dual |
+| Collection: `.id = c("a", "b")` | `surveycore_error_collection_invalid_id` | Dual |
+| Per-survey collection path with variable not in design | `surveycore_error_variable_not_found` | Dual |
+
+#### Warnings
+
+| Condition | Warning class | Assertion pattern |
+|---|---|---|
+| `n < min_cell_n` for at least one row | `surveycore_warning_small_cell` | `expect_warning(class = ...)` |
+| Grouping variable has a single observed level in the active domain | `surveycore_warning_single_level` | `expect_warning(class = ...)` |
+| `variance = "cv"` requested and at least one row has `variance = 0` (constant) | `surveycore_warning_cv_undefined` | `expect_warning(class = ...)` |
+| Focal variable all-NA in the active domain with `na.rm = TRUE` | `surveycore_warning_variance_all_na` | `expect_warning(class = ...)` + result has `variance = NaN`, `n = 0` |
+| Focal variable has exactly 1 non-NA row in the active domain | `surveycore_warning_variance_insufficient_n` | `expect_warning(class = ...)` + result has `variance = NaN`, `n = 1` |
+| Focal variable has 0 non-NA rows under `na_handling = "listwise"` (intersection empty) | `surveycore_warning_variance_all_na` | `expect_warning(class = ...)` |
+| Collection: surveys skipped with `.on_missing = "skip"` | `surveycore_message_collection_skipped_surveys` | `expect_message(class = ...)` |
+| Collection: per-survey `.meta` diverges for same variable | `surveycore_warning_collection_meta_divergence` | `expect_warning(class = ...)` |
+| Collection: duplicate survey names auto-repaired | `surveycore_warning_collection_duplicate_name_repaired` | `expect_warning(class = ...)` |
+
+#### Edge cases (from spec)
+
+| Edge case | Behavior asserted | Assertion pattern |
+|---|---|---|
+| Empty `x` selection | Error (see above) | Dual error |
+| All-NA focal variable with `na.rm = TRUE` | `variance = NaN`, all uncertainty cols `NaN`, `n = 0L`; `surveycore_warning_variance_all_na` fires once | `expect_warning` + structural |
+| Single non-NA observation | `variance = NaN`, uncertainty cols `NaN`, `n = 1L`; `surveycore_warning_variance_insufficient_n` fires | `expect_warning` + structural |
+| Constant (zero-variance) variable, `n ≥ 2` | `variance = 0`, `se = 0`, `ci_low = ci_high = 0`, `moe = 0`, `deff = 0`; `cv = NA` with `surveycore_warning_cv_undefined` fired (only when `"cv"` requested); no variance-specific warning | Exact-equality structural + warning assertion |
+| `na.rm = FALSE`, focal variable contains some NAs | `variance = NaN`, `se = NaN`; `n` reflects all in-domain rows; no variance-specific warning | Structural |
+| Grouping variable with a single observed level | Single output row per focal variable; `surveycore_warning_single_level` fires | `expect_warning` + `nrow` assertion |
+| `na_handling = "listwise"` with some rows NA in one variable | All output rows share the same `n`; each `n` equals the intersection complete-case count | Structural |
+| `na_handling = "pairwise"` with rows NA in different variables | Per-variable `n` differs across rows; no shared-`n` constraint | Structural |
+| Zero-weight rows in a `survey_nonprob` design | Zero-weight rows excluded from `n`; parity with oracle where zero-weight rows are pre-filtered | Parity `1e-10` / `1e-8` |
+| Twophase: Phase 1-only rows contribute zero influence | Parity with `survey::svyvar()` on the `survey::twophase()`-wrapped design | Parity `1e-10` / `1e-8` |
+| Replicate path: near-constant variable with tiny negative replicate residual | `se` returned as `0` (not `NaN`); no `sqrt(-eps)` warning | Exact equality + no extra warning |
+| CI below zero for variance near 0 with wide SE | `ci_low` returned as-is (may be negative); not clamped | Structural; documented behavior |
+| `survey_collection`: all surveys missing variable → `surveycore_error_collection_all_skipped` | Error | Dual |
+| `survey_collection`: per-survey `.meta` divergence | Warning fires; `meta(result)$per_survey` present | Structural + warning |
+
+#### Invariants
+
+- `test_invariants(design)` is the **first** assertion of every test that constructs a survey design via `as_survey()`, `as_survey_rep()`, `as_survey_twophase()`, or `as_survey_srs()`. This rule applies to every happy-path, edge-case, warning-path, and collection-path test that creates a design inline. Collection tests additionally assert `test_invariants()` on each component survey.
+- For every successful call, the result must satisfy:
+  - Inherits `c("survey_variance", "survey_result", "tbl_df")`.
+  - Contains a `variance` column that is numeric (not `NA_real_` when the cell is defined; `NaN` when undefined).
+  - Contains a `name` column of length = number of focal variables × number of active group combinations (or just number of focal variables when no grouping active).
+  - Every output column has a non-`NULL` `label` attribute.
+  - `names(meta(result)$x)` equals the resolved variable names.
+  - `meta(result)$na_handling %in% c("pairwise", "listwise")` matches the argument.
+  - `meta(result)$design_class` matches the design class (one of `"survey_taylor"`, `"survey_replicate"`, `"survey_twophase"`, `"survey_nonprob"`, `"survey_collection"`).
+  - `meta(result)` does **not** contain `function_name` or `variable` keys (family parity).
+  - No column named `var` exists unless `"var"` was passed in `variance`.
+  - No column named `estimate` / `std.error` / `conf.low` / `conf.high` exists unless `name_style = "broom"`.
+
+## Tolerances
+
+- Point estimates: `1e-10`
+- SE / variance of the estimate: `1e-8`
+- CI bounds: `1e-6`
+- `deff` parity: `1e-8` (treated as an SE-like derived quantity)
+- `n_weighted`: `1e-10` (sum of floats; tighter than SE)
+- Rounding tests (`decimals`): exact equality after `round()`
+- Constant-variable tests: exact equality to `0`
+
+No deviations from the project defaults.
+
+## Profile gates
+
+- [ ] devtools::document() clean
+- [ ] devtools::test() all pass
+- [ ] devtools::run_examples() all pass
+- [ ] R CMD check --as-cran (0 err, 0 warn, notes reviewed)
+- [ ] pkgcheck PASS
+- [ ] pkgdown::build_site() clean
+- [ ] covr::package_coverage() ≥ 95% (target 98%)
+- [ ] CRAN cookbook scan clean (see r-package-profile.md)


### PR DESCRIPTION
## Summary
- Adds `spec`, `test-spec`, `implementation-plan`, and `comprehension` docs for the upcoming `get_variance()` feature
- Adds two new warning classes (V-1 `surveycore_warning_variance_all_na`, V-2 `surveycore_warning_variance_insufficient_n`) to the canonical error table

## Test plan
- [ ] Docs-only PR; no code changes, no CI required beyond markdown rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)