### PR TITLE
chore(release): bump version to 0.8.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: surveycore
 Title: Core Survey Analysis Infrastructure
-Version: 0.8.1.9000
+Version: 0.8.1
 Authors@R: c(
     person(
         "Jacob", "Dennen",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: surveycore
 Title: Core Survey Analysis Infrastructure
-Version: 0.8.0
+Version: 0.8.0.9000
 Authors@R:
     person(
         "Jacob", "Dennen", 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,18 +1,23 @@
 Package: surveycore
 Title: Core Survey Analysis Infrastructure
-Version: 0.8.0.9000
-Authors@R:
+Version: 0.8.1.9000
+Authors@R: c(
     person(
-        "Jacob", "Dennen", 
-        email = "jdenn0514@gmail.com", 
+        "Jacob", "Dennen",
+        email = "jdenn0514@gmail.com",
         role = c("aut", "cre", "cph"),
         comment = c(ORCID = "0000-0003-3006-7364")
-    )
+    ),
+    person(
+        "Thomas", "Lumley",
+        role = c("ctb", "cph"),
+        comment = "Author of variance estimation code vendored from the 'survey' package"
+    ))
 Description: Provides 'S7'-based infrastructure for survey analysis including
     design objects, metadata preservation, and variance estimation. Forms the
     foundation of the surveyverse ecosystem. Supports Taylor series, replicate
     weight, and two-phase designs with a 'tidyselect' interface for intuitive
-    design specification. Automatic preservation of 'haven'-style variable and
+    design specification. Automatically preserves 'haven'-style variable and
     value labels throughout all operations.
 License: GPL (>= 3)
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# surveycore (development version)
+
+## CRAN preparation
+
+* Added Thomas Lumley to `Authors@R` as `[ctb, cph]` for the variance
+  estimation code vendored from the `survey` package (R/variance-taylor.R,
+  R/variance-replicate.R, R/variance-twophase.R,
+  R/variance-vendored-saddlepoint.R). Vendoring is documented in
+  `VENDORED.md`.
+* Reworded the closing sentence of the package `Description` for grammatical
+  completeness ("Automatically preserves..." instead of "Automatic
+  preservation of...").
+* Bumped `inst/CITATION` to track the upcoming release version.
+
 # surveycore 0.8.0
 
 ## Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# surveycore (development version)
+# surveycore 0.8.1
 
 ## CRAN preparation
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@
   completeness ("Automatically preserves..." instead of "Automatic
   preservation of...").
 * Bumped `inst/CITATION` to track the upcoming release version.
+* Removed the `\url{}` wrapper around `electionstudies.org` in the
+  `anes_2024` data documentation. The URL is preserved as plain prose; the
+  ANES homepage 403's automated requests, which previously triggered a
+  `urlchecker::url_check()` failure under `R CMD check --as-cran`.
 
 # surveycore 0.8.0
 

--- a/R/data.R
+++ b/R/data.R
@@ -270,7 +270,7 @@
 #'
 #' @source
 #' American National Election Studies. 2024 Time Series Study.
-#' \url{https://electionstudies.org} (free account required to download raw
+#' Available at electionstudies.org (free account required to download raw
 #' data; the processed `.rda` is included in the package).
 #' Prepared by `data-raw/prepare-anes-2024.R`.
 #'

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,22 +2,11 @@
 
 Local macOS (arm64, R 4.5 release): 0 errors | 0 warnings | 0 notes.
 
-win-builder R-devel: 1 NOTE, containing only the standard "New submission"
+win-builder R-devel: 1 NOTE, containing the standard "New submission"
 flag and a possibly-misspelled-word flag on "surveyverse" in the Description
 field. "surveyverse" is the ecosystem name for the family of packages this
 package is the foundation of (https://github.com/JDenn0514/surveycore and
 related repositories); it is spelled correctly.
-
-## URL notes
-
-`urlchecker::url_check()` reports one URL with a 403 response:
-
-- `https://electionstudies.org` in `man/anes_2024.Rd`
-
-This is the American National Election Studies homepage. The 403 is returned
-for automated requests only — the site restricts bot/checker access. The URL
-is correct and accessible to human users. This is the canonical citation URL
-for the ANES data.
 
 ## Package size
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -4,7 +4,7 @@ bibentry(
   author  = person("Jacob", "Dennen",
                    comment = c(ORCID = "0000-0003-3006-7364")),
   year    = "2026",
-  note    = "R package version 0.6.2",
+  note    = "R package version 0.8.1",
   url     = "https://github.com/JDenn0514/surveycore"
 )
 

--- a/man/anes_2024.Rd
+++ b/man/anes_2024.Rd
@@ -49,7 +49,7 @@ Republican, \code{2} = neither, \code{3} = closer to Democrat.}
 }
 \source{
 American National Election Studies. 2024 Time Series Study.
-\url{https://electionstudies.org} (free account required to download raw
+Available at electionstudies.org (free account required to download raw
 data; the processed \code{.rda} is included in the package).
 Prepared by \verb{data-raw/prepare-anes-2024.R}.
 }


### PR DESCRIPTION
## Release: v0.8.1

## What's in this release

### CRAN preparation

* Added Thomas Lumley to `Authors@R` as `[ctb, cph]` for the variance
  estimation code vendored from the `survey` package (R/variance-taylor.R,
  R/variance-replicate.R, R/variance-twophase.R,
  R/variance-vendored-saddlepoint.R). Vendoring is documented in
  `VENDORED.md`.
* Reworded the closing sentence of the package `Description` for grammatical
  completeness ("Automatically preserves..." instead of "Automatic
  preservation of...").
* Bumped `inst/CITATION` to track the upcoming release version.
* Removed the `\url{}` wrapper around `electionstudies.org` in the
  `anes_2024` data documentation. The URL is preserved as plain prose; the
  ANES homepage 403's automated requests, which previously triggered a
  `urlchecker::url_check()` failure under `R CMD check --as-cran`.

## Release checklist

- [x] All planned feature PRs are merged to `develop`
- [x] NEWS.md updated
- [x] DESCRIPTION version bumped: `0.8.1.9000` → `0.8.1`
- [x] `devtools::check()` passes: 0 errors, 0 warnings, 0 notes
- [ ] After merge: tag `v0.8.1` on main
- [ ] After tagging: bump `develop` to `0.8.1.9000`