### PR TITLE
chore(release): bump version to 0.8.2

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -28,3 +28,4 @@
 ^CODE_OF_CONDUCT\.md$
 ^doc$
 ^Meta$
+^CRAN-SUBMISSION$

--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,0 +1,3 @@
+Version: 0.8.1
+Date: 2026-04-27 20:33:57 UTC
+SHA: afd346ff5ed3323aef74383ed3809fe0da4c0e3d

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: surveycore
 Title: Core Survey Analysis Infrastructure
-Version: 0.8.1
+Version: 0.8.1.9000
 Authors@R: c(
     person(
         "Jacob", "Dennen",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: surveycore
 Title: Core Survey Analysis Infrastructure
-Version: 0.8.1.9000
+Version: 0.8.2
 Authors@R: c(
     person(
         "Jacob", "Dennen",
@@ -15,7 +15,7 @@ Authors@R: c(
     ))
 Description: Provides 'S7'-based infrastructure for survey analysis including
     design objects, metadata preservation, and variance estimation. Forms the
-    foundation of the surveyverse ecosystem. Supports Taylor series, replicate
+    foundation of the 'surveyverse' ecosystem. Supports Taylor series, replicate
     weight, and two-phase designs with a 'tidyselect' interface for intuitive
     design specification. Automatically preserves 'haven'-style variable and
     value labels throughout all operations.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+# surveycore 0.8.2
+
+## CRAN preparation
+
+* Resubmission addressing CRAN feedback on the 0.8.1 submission. Tagged
+  numerical oracle and integration test files (comparisons against
+  `survey`, `marginaleffects` integration, polychoric/polyserial MLE,
+  vendored saddlepoint parity, and two-phase variance parity) with
+  `skip_on_cran()`. Test runtime under `R CMD check --as-cran` drops
+  from ~11 minutes to under 1 minute. The skipped tests continue to
+  run on every push in CI and locally with `devtools::test()`.
+* Single-quoted `'surveyverse'` in `Description` to match the
+  convention used for other proper nouns (`'S7'`, `'tidyselect'`,
+  `'haven'`) and silence the spell-checker NOTE.
+
 # surveycore 0.8.1
 
 ## CRAN preparation

--- a/R/variance-vendored-saddlepoint.R
+++ b/R/variance-vendored-saddlepoint.R
@@ -19,7 +19,9 @@
 #
 # Modifications: helpers are dotted/internal (not exported); no dependency
 # on CompQuadForm; no Satterthwaite-only / integration branches (those are
-# intentionally out of scope for the vendored slice).
+# intentionally out of scope for the vendored slice); upstream's sapply()
+# calls are replaced with type-safe vapply(..., FUN.VALUE = numeric(1))
+# and .saddle()'s bare NA return is typed as NA_real_ to match.
 # ---------------------------------------------------------------------------
 
 # Saddlepoint root-finder (direct port of survey:::saddle).
@@ -32,7 +34,11 @@
   x <- x / d
   k0 <- function(zeta) -sum(log(1 - 2 * zeta * lambda)) / 2
   kprime0 <- function(zeta) {
-    sapply(zeta, function(zz) sum(lambda / (1 - 2 * zz * lambda)))
+    vapply(
+      zeta,
+      function(zz) sum(lambda / (1 - 2 * zz * lambda)),
+      numeric(1)
+    )
   }
   kpprime0 <- function(zeta) {
     2 * sum(lambda^2 / (1 - 2 * zeta * lambda)^2)
@@ -55,7 +61,7 @@
   w <- sign(hatzeta) * sqrt(2 * (hatzeta * x - k0(hatzeta)))
   v <- hatzeta * sqrt(kpprime0(hatzeta))
   if (abs(hatzeta) < 1e-04) {
-    NA
+    NA_real_
   } else {
     stats::pnorm(w + log(v / w) / w, lower.tail = FALSE)
   }
@@ -86,7 +92,7 @@
   # Saddlepoint: expand a by df to produce the per-chi-square-component
   # eigenvalue vector, then call .saddle() per x element.
   lambda <- rep(a, df)
-  sad <- sapply(x, .saddle, lambda = lambda)
+  sad <- vapply(x, .saddle, numeric(1), lambda = lambda)
   if (lower.tail) {
     sad <- 1 - sad
   }

--- a/changelog/chore-cran-resubmit-0.8.2.md
+++ b/changelog/chore-cran-resubmit-0.8.2.md
@@ -1,0 +1,50 @@
+# chore/cran-resubmit-0.8.2 — CRAN Resubmission Fixes
+
+**Branch:** `chore/cran-resubmit-0.8.2`
+**Date:** 2026-04-27
+
+## Summary
+
+Addresses CRAN feedback on the 0.8.1 submission. Two issues were flagged:
+test runtime exceeded 10 minutes (Uwe Ligges) and a "possibly misspelled
+words" NOTE for `surveyverse` in the `Description` field. After these
+changes `R CMD check --as-cran` runs in ~2 minutes (test step in 48
+seconds, down from ~11 minutes), and the spell-check NOTE no longer
+appears.
+
+## Changes
+
+### `tests/testthat/` (11 files, +1 line each)
+
+Added `skip_on_cran()` at the top level of each numerical-oracle and
+heavy-integration test file. testthat treats a top-level `skip()` as a
+file-level skip; these files continue to run on every push in CI and
+locally with `devtools::test()`.
+
+- `test-analysis-t-test-numerical.R`
+- `test-analysis-diffs-numerical.R`
+- `test-analysis-diffs-marginaleffects.R`
+- `test-glm-numerical.R`
+- `test-glm-anova-numerical.R`
+- `test-glm-marginaleffects.R`
+- `test-analysis-corr-latent.R`
+- `test-analysis-corr-latent-variance.R`
+- `test-analysis-variance-twophase-nonprob.R`
+- `test-variance-vendored-saddlepoint.R`
+- `test-variance-twophase.R`
+
+### `DESCRIPTION`
+
+- Bumped `Version` from `0.8.1.9000` to `0.8.2`.
+- Single-quoted `'surveyverse'` in `Description` to match the convention
+  already used for `'S7'`, `'tidyselect'`, and `'haven'`. This silences
+  the CRAN spell-check NOTE.
+
+### `NEWS.md`
+
+- Added `# surveycore 0.8.2` section documenting the resubmission.
+
+### `cran-comments.md`
+
+- Rewrote as a resubmission cover letter explaining how each of the two
+  issues from the 0.8.1 submission was addressed.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,27 +1,45 @@
+## Resubmission
+
+This is a resubmission of surveycore 0.8.1 as 0.8.2. The previous
+submission was flagged for two issues:
+
+1. **Test runtime exceeded 10 minutes** (Uwe Ligges, "Please reduce the
+   test timings"). Numerical oracle tests against the `survey` package,
+   `marginaleffects` integration tests, polychoric/polyserial MLE tests,
+   vendored saddlepoint parity tests, and two-phase variance parity tests
+   (11 test files in total) are now gated with `skip_on_cran()`. These
+   continue to run on every push in CI and locally during development.
+   Test runtime under `R CMD check --as-cran` is now ~50 seconds,
+   down from ~11 minutes.
+
+2. **"Possibly misspelled words" NOTE for `surveyverse`.** The word is
+   the proper name of the package ecosystem this package founds; it is
+   now single-quoted in `Description` to match the convention already
+   used for `'S7'`, `'tidyselect'`, and `'haven'`. The NOTE no longer
+   appears in the local check.
+
 ## R CMD check results
 
-Local macOS (arm64, R 4.5 release): 0 errors | 0 warnings | 0 notes.
+Local macOS (arm64, R 4.5.2): 0 errors | 0 warnings | 2 notes.
 
-win-builder R-devel: 1 NOTE, containing the standard "New submission"
-flag and a possibly-misspelled-word flag on "surveyverse" in the Description
-field. "surveyverse" is the ecosystem name for the family of packages this
-package is the foundation of (https://github.com/JDenn0514/surveycore and
-related repositories); it is spelled correctly.
+  * "New submission" (CRAN incoming feasibility) — expected for a
+    first-time submission and returned by win-builder as well.
+  * "Skipping checking HTML validation: 'tidy' doesn't look like recent
+    enough HTML Tidy." — local macOS toolchain issue; does not appear on
+    CRAN's check infrastructure.
 
 ## Package size
 
-Installed package size is approximately 6.4 MB (5.1 MB in the `data/`
-subdirectory). The package includes several bundled survey teaching datasets
-(ANES, NHANES, ACS PUMS, Pew Research) that are the primary examples for the
-package functionality.
+Source tarball is 5.8 MB; installed size is 6.4 MB, of which 5.1 MB is the
+`data/` subdirectory. The package bundles several survey teaching datasets
+(ANES, NHANES, ACS PUMS, Pew Research) that are the primary examples for
+the package functionality and are referenced throughout the documentation
+and tests. The data is already xz-compressed (`LazyDataCompression: xz`).
 
 ## Method references
 
-There are no published references describing the methods in this package beyond
-the standard survey sampling literature (e.g., Lohr 2022, "Sampling: Design and
-Analysis"). The variance estimation code is vendored from the 'survey' package
-(Thomas Lumley, GPL-2/GPL-3) with full attribution in `VENDORED.md`.
-
-## New submission
-
-This is a new submission.
+There are no published references describing the methods in this package
+beyond the standard survey sampling literature (e.g., Lohr 2022,
+"Sampling: Design and Analysis"). The variance estimation code is vendored
+from the 'survey' package (Thomas Lumley, GPL-2/GPL-3) with full
+attribution in `VENDORED.md`.

--- a/tests/testthat/test-analysis-corr-latent-variance.R
+++ b/tests/testthat/test-analysis-corr-latent-variance.R
@@ -11,6 +11,8 @@
 #   PC-14 (Taylor boundary wide CI).
 # Dispatcher-level re-raises: PC-2, PC-4, PC-5, PC-10, PC-11, PC-13.
 
+skip_on_cran()
+
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 # Create a small Taylor design with two ordinal variables.

--- a/tests/testthat/test-analysis-corr-latent.R
+++ b/tests/testthat/test-analysis-corr-latent.R
@@ -17,6 +17,8 @@
 # Error / warning classes exercised at the public-API layer:
 #   PC-1 .. PC-14 plus pre-existing Pearson classes (regression guard).
 
+skip_on_cran()
+
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 # Build a small unweighted Taylor design with two 4-level ordinal factors;

--- a/tests/testthat/test-analysis-diffs-marginaleffects.R
+++ b/tests/testthat/test-analysis-diffs-marginaleffects.R
@@ -3,6 +3,8 @@
 # Tests specific to the marginaleffects estimation path in get_diffs().
 # Validates avg_slopes() and avg_predictions() integration.
 
+skip_on_cran()
+
 # ── Shared test data ──────────────────────────────────────────────────────
 
 .make_me_data <- function(n = 300, seed = 42) {

--- a/tests/testthat/test-analysis-diffs-numerical.R
+++ b/tests/testthat/test-analysis-diffs-numerical.R
@@ -3,6 +3,8 @@
 # Numerical oracle tests for get_diffs() — comparing against
 # survey::svyglm + marginaleffects and manual computation.
 
+skip_on_cran()
+
 # ═══════════════════════════════════════════════════════════════════════════
 # 1. BIVARIATE OLS VS MANUAL COMPUTATION (clean path)
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/testthat/test-analysis-t-test-numerical.R
+++ b/tests/testthat/test-analysis-t-test-numerical.R
@@ -3,6 +3,8 @@
 # Numerical oracle tests: get_t_test() vs survey::svyttest()
 # All blocks guarded with skip_if_not_installed("survey")
 
+skip_on_cran()
+
 # ── Shared NHANES fixture ───────────────────────────────────────────────────
 
 .make_nhanes_designs <- function() {

--- a/tests/testthat/test-analysis-variance-twophase-nonprob.R
+++ b/tests/testthat/test-analysis-variance-twophase-nonprob.R
@@ -6,6 +6,8 @@
 #
 # Tolerances (from test-spec.md): point 1e-10, SE 1e-8.
 
+skip_on_cran()
+
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 .variance_tol_point <- 1e-10

--- a/tests/testthat/test-glm-anova-numerical.R
+++ b/tests/testthat/test-glm-anova-numerical.R
@@ -15,6 +15,8 @@
 # directly on fitted model objects with no environment re-evaluation. This
 # is the same oracle used by anova.svyglm per term.
 
+skip_on_cran()
+
 # ═══════════════════════════════════════════════════════════════════════════
 # 1. Taylor sequential — 4 combos
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/testthat/test-glm-marginaleffects.R
+++ b/tests/testthat/test-glm-marginaleffects.R
@@ -6,6 +6,8 @@
 # All 10 test items from spec §7.7. Every block gated with
 # skip_if_not_installed("marginaleffects").
 
+skip_on_cran()
+
 library(surveycore)
 
 # ── Shared test fixtures ───────────────────────────────────────────────────────

--- a/tests/testthat/test-glm-numerical.R
+++ b/tests/testthat/test-glm-numerical.R
@@ -11,6 +11,8 @@
 # Spec: plans/spec-phase-2.md §9.1
 # Handoff: plans/handoff-pr6-glm-numerical-tests.md
 
+skip_on_cran()
+
 # ===========================================================================
 # Section 1: Gaussian oracle — all 5 design classes
 # ===========================================================================

--- a/tests/testthat/test-variance-twophase.R
+++ b/tests/testthat/test-variance-twophase.R
@@ -2,6 +2,8 @@
 # Tests for the two-phase variance engine: .twophasevar(), .twophase_mean(),
 # .twophase_total(), .twophase_df(), and associated helpers.
 
+skip_on_cran()
+
 # ── Section 1: Engine unit tests (synthetic data) ─────────────────────────────
 
 test_that(".twophasevar() returns a finite non-negative scalar for valid input (approx)", {

--- a/tests/testthat/test-variance-vendored-saddlepoint.R
+++ b/tests/testthat/test-variance-vendored-saddlepoint.R
@@ -6,6 +6,8 @@
 # Satterthwaite fallback is out of scope here; the NA-regime parity test
 # targets the root-finder directly per the impl plan PR B task 3.
 
+skip_on_cran()
+
 # ---------------------------------------------------------------------------
 # .pchisqsum_sad() vs survey::pchisqsum(..., method = "saddlepoint")
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Release: v0.8.2

## What's in this release

### CRAN preparation

* Resubmission addressing CRAN feedback on the 0.8.1 submission. Tagged
  numerical oracle and integration test files (comparisons against
  `survey`, `marginaleffects` integration, polychoric/polyserial MLE,
  vendored saddlepoint parity, and two-phase variance parity) with
  `skip_on_cran()`. Test runtime under `R CMD check --as-cran` drops
  from ~11 minutes to under 1 minute. The skipped tests continue to
  run on every push in CI and locally with `devtools::test()`.
* Single-quoted `'surveyverse'` in `Description` to match the
  convention used for other proper nouns (`'S7'`, `'tidyselect'`,
  `'haven'`) and silence the spell-checker NOTE.
* Added `^CRAN-SUBMISSION$` to `.Rbuildignore` and committed the
  artifact for historical record.

## Release checklist

- [x] All planned feature PRs are merged to `develop`
- [x] NEWS.md updated with all `feat:` and `fix:` entries since last release
- [x] DESCRIPTION version bumped: `0.8.1.9000` → `0.8.2` (in PR #117)
- [x] `devtools::check()` passes: 0 errors, 0 warnings, 1 note (env-only)
- [ ] `devtools::check_win_devel()` passes (running in parallel from develop)
- [ ] After merge: tag `v0.8.2` on main
- [ ] After tagging: `devtools::submit_cran()` from main
- [ ] After CRAN accepts: bump `develop` to `0.8.2.9000`