### PR TITLE
feat(analysis): add show_favorability and alpha to get_diffs()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,16 +4,24 @@
 
 * `set_higher_is()` and `extract_higher_is()` store and retrieve a
   direction-of-improvement attribute (`"better"` or `"worse"`) for survey
-  variables. The attribute is used by `get_diffs()` (upcoming
-  `show_favorability` argument) to classify differences as favorable or
-  backlash. Supports all three calling conventions (named `...` args, named
-  vector, `variable =` + `direction =`), data frames, and tidy-select.
+  variables. The attribute is used by `get_diffs(show_favorability = TRUE)`
+  to classify differences as favorable or backlash. Supports all three
+  calling conventions (named `...` args, named vector,
+  `variable =` + `direction =`), data frames, and tidy-select.
 
 * `set_reverse_coded()` and `extract_reverse_coded()` store and retrieve a
   reverse-coded flag for survey variables. Supports tidy-select `...` (bare
   names and selection helpers) and the `variable =` character-vector
   interface. Setting `reverse_coded = FALSE` removes the flag. Works on both
   survey design objects and plain data frames.
+
+* `get_diffs()` gains `alpha` and `show_favorability` arguments.
+  `show_favorability = TRUE` appends `favorable` and `backlash` logical
+  columns to the result. A difference is classified as favorable when it is
+  statistically significant (`p < alpha`, default `0.05`) and in the
+  direction indicated by `higher_is` metadata set via `set_higher_is()`.
+  When no `higher_is` metadata is set, both columns are all `FALSE`. The
+  adjusted p-value (when `pval_adj` is supplied) is used for classification.
 
 # surveycore 0.8.4
 

--- a/R/analysis-diffs.R
+++ b/R/analysis-diffs.R
@@ -52,6 +52,16 @@
 #'   `"ci"`. Controls which uncertainty columns appear. Default `"ci"`.
 #' @param conf_level Numeric(1) in (0, 1). Confidence level. Default
 #'   `0.95`.
+#' @param alpha Numeric(1) strictly between 0 and 1. Significance threshold
+#'   used when `show_favorability = TRUE` to classify whether a difference
+#'   is statistically significant. Uses strict `<` (p < alpha). Default
+#'   `0.05`.
+#' @param show_favorability Logical. If `TRUE`, appends two logical columns
+#'   to the result: `favorable` (the difference is statistically significant
+#'   and in the direction indicated by `higher_is` metadata on `x`) and
+#'   `backlash` (significant but in the opposite direction). Requires
+#'   `higher_is` metadata set on `x` via [set_higher_is()]; if not set,
+#'   both columns are all `FALSE`. Default `FALSE`.
 #' @param min_cell_n Integer(1). Minimum unweighted cell size before
 #'   `surveycore_warning_small_cell` fires. Default `30L`.
 #' @param n_weighted Logical. If `TRUE`, includes an `n_weighted` column
@@ -123,8 +133,9 @@
 #'   Columns (in order): group columns (when active), treatment variable,
 #'   `estimate`, `pct_change` (optional), `mean` (optional), `n`,
 #'   `n_weighted` (optional), `se` (optional), `ci_low` (optional),
-#'   `ci_high` (optional), `p_value`, `stars`. Use [meta()] to access
-#'   design type, family, reference level, and other metadata.
+#'   `ci_high` (optional), `p_value`, `stars`, `favorable` (optional),
+#'   `backlash` (optional). Use [meta()] to access design type, family,
+#'   reference level, and other metadata.
 #'
 #' @examples
 #' library(marginaleffects)
@@ -160,6 +171,8 @@ get_diffs <- function(
   scale = c("ame", "link"),
   variance = "ci",
   conf_level = 0.95,
+  alpha = 0.05,
+  show_favorability = FALSE,
   min_cell_n = 30L,
   n_weighted = FALSE,
   decimals = NULL,
@@ -192,6 +205,26 @@ get_diffs <- function(
     na.rm = na.rm,
     valid_variance = c("se", "ci")
   )
+
+  # ── Step 1b: Validate alpha ───────────────────────────────────────────────
+  if (
+    !is.numeric(alpha) ||
+      length(alpha) != 1L ||
+      is.na(alpha) ||
+      !is.finite(alpha) ||
+      alpha <= 0 ||
+      alpha >= 1
+  ) {
+    cli::cli_abort(
+      c(
+        "x" = paste0(
+          "{.arg alpha} must be a single numeric value strictly between ",
+          "0 and 1. Got {.val {alpha}}."
+        )
+      ),
+      class = "surveycore_error_alpha_invalid"
+    )
+  }
 
   # ── Step 2: Validate design class ─────────────────────────────────────────
   .check_unsupported_class(design, "get_diffs")
@@ -446,6 +479,39 @@ get_diffs <- function(
 
   # ── Step 20: Attach .meta ────────────────────────────────────────────────
   x_meta <- .extract_var_meta(design, x_name)
+
+  # ── Step 20a: Favorability columns ───────────────────────────────────────
+  if (isTRUE(show_favorability)) {
+    higher_is_val <- x_meta$higher_is
+    pval_col <- if ("p_value" %in% names(result)) "p_value" else "p.value"
+    p_vals <- result[[pval_col]]
+    sig <- !is.na(p_vals) & p_vals < alpha
+
+    favorable <- logical(nrow(result))
+    backlash  <- logical(nrow(result))
+
+    if (!is.null(higher_is_val)) {
+      est <- result$estimate
+      if (higher_is_val == "better") {
+        favorable[sig] <- est[sig] > 0
+        backlash[sig]  <- est[sig] < 0
+      } else if (higher_is_val == "worse") {
+        favorable[sig] <- est[sig] < 0
+        backlash[sig]  <- est[sig] > 0
+      }
+    }
+
+    attr(favorable, "label") <- "Favorable"
+    attr(backlash,  "label") <- "Backlash"
+
+    saved_meta  <- attr(result, ".meta")
+    saved_class <- class(result)
+    result$favorable <- favorable
+    result$backlash  <- backlash
+    attr(result, ".meta") <- saved_meta
+    class(result) <- saved_class
+  }
+
   treats_meta <- .extract_var_meta(design, treats_name)
   treats_meta$name <- treats_name
   treats_meta$ref_level <- ref_level

--- a/changelog/feature-diffs-favorability.md
+++ b/changelog/feature-diffs-favorability.md
@@ -1,0 +1,31 @@
+# feat(analysis): add `show_favorability` and `alpha` arguments to `get_diffs()`
+
+**Date**: 2026-05-11
+**Branch**: feature/diffs-favorability
+**Phase**: Post-Phase 2 (PR 3 of variable-direction plan)
+
+## Changes
+
+- Add `show_favorability` argument to `get_diffs()` — when `TRUE`, appends
+  `favorable` and `backlash` logical columns classifying whether each
+  treatment–reference difference is statistically significant and in the
+  expected direction per `higher_is` metadata; both columns are all `FALSE`
+  when no `higher_is` metadata is set
+- Add `alpha` argument to `get_diffs()` — significance threshold (default
+  `0.05`) used for classifying differences; validated to be a single numeric
+  value strictly between 0 and 1
+- Add `surveycore_error_alpha_invalid` error class for invalid `alpha` input
+- Update NEWS.md to reflect the new arguments
+- Update `plans/error-messages.md` with the new error class row
+
+## Files Modified
+
+- `R/analysis-diffs.R` — add `alpha` and `show_favorability` params, alpha
+  validation, and favorability-column construction step (Step 20a)
+- `man/get_diffs.Rd` — updated roxygen2 docs for new params and return value
+- `tests/testthat/test-analysis-diffs.R` — new test section (PR 3) covering
+  all `alpha_invalid` error paths and `show_favorability` happy paths
+- `tests/testthat/_snaps/analysis-diffs.md` — new snapshots for alpha error
+  messages
+- `plans/error-messages.md` — new `surveycore_error_alpha_invalid` row
+- `NEWS.md` — entry for `get_diffs(alpha, show_favorability)`

--- a/man/get_diffs.Rd
+++ b/man/get_diffs.Rd
@@ -17,6 +17,8 @@ get_diffs(
   scale = c("ame", "link"),
   variance = "ci",
   conf_level = 0.95,
+  alpha = 0.05,
+  show_favorability = FALSE,
   min_cell_n = 30L,
   n_weighted = FALSE,
   decimals = NULL,
@@ -79,6 +81,18 @@ For Gaussian/identity models, both are identical. Case-sensitive.}
 \item{conf_level}{Numeric(1) in (0, 1). Confidence level. Default
 \code{0.95}.}
 
+\item{alpha}{Numeric(1) strictly between 0 and 1. Significance threshold
+used when \code{show_favorability = TRUE} to classify whether a difference
+is statistically significant. Uses strict \code{<} (p < alpha). Default
+\code{0.05}.}
+
+\item{show_favorability}{Logical. If \code{TRUE}, appends two logical columns
+to the result: \code{favorable} (the difference is statistically significant
+and in the direction indicated by \code{higher_is} metadata on \code{x}) and
+\code{backlash} (significant but in the opposite direction). Requires
+\code{higher_is} metadata set on \code{x} via \code{\link[=set_higher_is]{set_higher_is()}}; if not set,
+both columns are all \code{FALSE}. Default \code{FALSE}.}
+
 \item{min_cell_n}{Integer(1). Minimum unweighted cell size before
 \code{surveycore_warning_small_cell} fires. Default \code{30L}.}
 
@@ -121,8 +135,9 @@ A \code{survey_diffs} tibble (also inheriting \code{survey_result}).
 Columns (in order): group columns (when active), treatment variable,
 \code{estimate}, \code{pct_change} (optional), \code{mean} (optional), \code{n},
 \code{n_weighted} (optional), \code{se} (optional), \code{ci_low} (optional),
-\code{ci_high} (optional), \code{p_value}, \code{stars}. Use \code{\link[=meta]{meta()}} to access
-design type, family, reference level, and other metadata.
+\code{ci_high} (optional), \code{p_value}, \code{stars}, \code{favorable} (optional),
+\code{backlash} (optional). Use \code{\link[=meta]{meta()}} to access design type, family,
+reference level, and other metadata.
 }
 \description{
 Estimates treatment effects (differences from a reference group) via

--- a/plans/decisions-variable-direction.md
+++ b/plans/decisions-variable-direction.md
@@ -1,0 +1,224 @@
+# Decisions Log — surveycore variable-direction
+
+This file records planning decisions made during variable-direction.
+Each entry corresponds to one planning session.
+
+---
+
+## 2026-05-07 — Stage 4 Code Review Resolution
+
+### Context
+
+Resolving 12 issues (1 blocking, 8 required, 3 suggestions) from the Stage 3
+adversarial review of `plans/spec-variable-direction.md`.
+
+### Questions & Decisions
+
+**Q: The console output example had rows 1 and 4 transposed for `favorable`/`backlash` under `higher_is = "worse"`. Fix the example or fix the table?**
+- Options considered:
+  - **Fix the example:** Table is internally consistent with the footnote; example was wrong.
+  - **Fix the table:** Would reverse intended semantics.
+- **Decision:** Fix the example (row 1: FALSE TRUE; row 4: TRUE FALSE).
+- **Rationale:** The logic table and footnote are correct: negative diff on a "worse" variable is favorable.
+
+---
+
+**Q: The `get_diffs()` `direction` argument name collides with `set_higher_is()`'s `direction` argument (different semantics). What should the `get_diffs()` toggle be called?**
+- Options considered:
+  - **`direction = FALSE`:** Existing proposal; collides with setter's `direction` which means `"better"`/`"worse"`.
+  - **`favorability = FALSE`:** Names the concept.
+  - **`show_favorability = FALSE`:** Follows the existing `show_*` pattern in `get_diffs()` (`show_means`, `show_pct_change`).
+  - **Character `show_impact` with values `"favorability"/"backlash"/"both"`:** User proposed; rejected because `favorable`/`backlash` are always computed together (no value in selective visibility) and character defaults are awkward vs. boolean.
+- **Decision:** `show_favorability = FALSE` — follows `show_*` naming pattern, unambiguous, no collision.
+- **Rationale:** Consistent with `show_means` and `show_pct_change` already in the signature. Boolean is appropriate since the feature is binary (both columns always appear together).
+
+---
+
+**Q: Convention 3 for `set_higher_is()` — should scalar `direction = "worse"` be recycled to match `variable` length, or require exact match?**
+- Options considered:
+  - **Option A (scalar recycles):** `direction = "worse"` with 2 variables applies "worse" to both. Natural for setting many variables to the same direction.
+  - **Option B (exact match required):** Consistent with `set_var_label()` and all other setters using `.parse_setter_input()`, which errors with `surveycore_error_setter_mismatched_lengths` on length mismatch.
+- **Decision:** Option B — exact match required; reuse existing `surveycore_error_setter_mismatched_lengths`.
+- **Rationale:** `set_higher_is()` uses `.parse_setter_input()` which already enforces exact length match. Deviating would create inconsistency across all setters.
+
+---
+
+**Q: Convention 2 for `set_higher_is()` — spec showed `list(...)` but detection rule uses named character vector. Fix example?**
+- Options considered:
+  - **Correct to `c(anxiety = "worse", agreement = "better")`:** Matches `.parse_setter_input()` `content_type = "scalar"` detection (named character vector, not named list).
+  - **Keep `list(...)`:** Wrong; would not be detected as Convention 2.
+- **Decision:** Correct to `c(...)` and document the detection rule.
+- **Rationale:** `.parse_setter_input()` with `content_type = "scalar"` matches named character vectors; named lists are the `content_type = "vector"` path used by `set_val_labels()`.
+
+---
+
+**Q: Should the spec reference existing variable-name resolution helpers to prevent DRY violations?**
+- Options considered:
+  - **Reference existing patterns:** Name `.parse_setter_input()`, `set_sata()` pattern, `extract_var_label()` pattern in Section II.
+  - **Leave to implementer:** Patterns are in the codebase and discoverable.
+- **Decision:** Add explicit implementation notes to Section II.
+- **Rationale:** User preference; reduces guesswork and ensures each function follows the right pattern.
+
+### Outcome
+
+Spec v0.2 approved. All 12 issues resolved: 1 blocking (example fixed), 8 required
+(error table entries added, test plan expanded, `show_favorability` rename, length mismatch
+behavior documented), 3 suggestions (implementation notes, Convention 2 corrected, grouped test added).
+
+---
+
+## 2026-05-07 — Stage 4 Code Review Resolution (Pass 2)
+
+### Context
+
+Resolving 4 remaining issues (0 blocking, 3 required, 1 suggestion) from the
+Pass 2 adversarial review of `plans/spec-variable-direction.md`.
+
+### Questions & Decisions
+
+**Q: Convention 2 was spec'd for `set_higher_is()` but had no test in the PR 1 test plan. Add a test or remove Convention 2?**
+- Options considered:
+  - **Add happy-path test:** One test line; `.parse_setter_input()` already handles Convention 2 and is tested.
+  - **Remove Convention 2:** Simplifies the API; Conventions 1 and 3 cover all real use cases.
+- **Decision:** Add the test (Option A).
+- **Rationale:** Convention 2 is already documented and the backend is tested; removing it would be a needless breaking change before the feature ships.
+
+---
+
+**Q: `favorable`/`backlash` column `label` attributes are specified but not tested. Add assertions?**
+- Options considered:
+  - **Add `expect_identical(attr(..., "label"), ...)` to the happy-path test:** Consistent with how all other output column labels are tested.
+  - **Do nothing:** Risk of silent regression.
+- **Decision:** Add label attribute assertions to the `show_favorability = TRUE` happy-path test (Option A).
+- **Rationale:** The spec explicitly defines these attributes; one assertion per column costs nothing.
+
+---
+
+**Q: `alpha = NA`, `alpha = Inf`, and `alpha = c(0.05, 0.1)` are explicitly named as invalid in the spec but absent from the error-path test plan. Add them?**
+- Options considered:
+  - **Add all three:** Closes all explicitly-named invalid cases; cli `{.val}` renders NA/vectors acceptably.
+  - **Add only NA and Inf:** Non-scalar is implied by "single numeric value."
+- **Decision:** Add all three (Option A).
+- **Rationale:** All are realistic user mistakes and the cost is three test lines.
+
+---
+
+**Q: `.meta$higher_is` test description said "is populated" — ambiguous. Should the test assert the actual value?**
+- Options considered:
+  - **Assert the actual value `"worse"`:** Consistent with all existing `.meta` tests which use `expect_identical()` with exact values.
+  - **Keep "is populated":** Non-NULL check is the intent.
+- **Decision:** Assert actual value (Option A).
+- **Rationale:** Matches the pattern established by all existing `.meta` assertions in test-analysis-diffs.R.
+
+### Outcome
+
+Spec v0.3 approved. All 4 Pass 2 issues resolved: 3 required (Convention 2 test added,
+label attribute assertions added, alpha=NA/Inf/vector test cases added) and 1 suggestion
+(`.meta` test sharpened to assert actual value). No scope changes — test plan only.
+
+---
+
+## 2026-05-07 — Stage 4 Code Review Resolution (Passes 3 & 4)
+
+### Context
+
+Resolving 4 remaining issues (0 blocking, 3 required, 1 suggestion) carried over from
+Pass 3 and Pass 4 adversarial reviews of `plans/spec-variable-direction.md`.
+
+### Questions & Decisions
+
+**Q: §I scope table still listed `direction` for PR 3 instead of the renamed `show_favorability`. Fix or leave?**
+- Options considered:
+  - **Fix the table:** Trivial one-word change; a reviewer scanning only the table would see the wrong argument name.
+  - **Do nothing:** Body is correct; table is vestigial.
+- **Decision:** Fix the table (Option A).
+- **Rationale:** Consistency — a stale name in a public-facing table is a documentation bug.
+
+---
+
+**Q: `surveycore_error_setter_mixed_dots` is referenced in the Convention 2 description for `set_higher_is()` but was absent from the error table and test plan. Add it?**
+- Options considered:
+  - **Add to error table (marked existing) + add test block:** Reachable error via documented input; belongs in the table.
+  - **Note as delegated to `.parse_setter_input()`; no test needed:** Leaves an untested reachable error path.
+- **Decision:** Add to table and test plan (Option A).
+- **Rationale:** Convention 2 is a documented calling convention; the error that fires on malformed Convention 2 input must be testable.
+
+---
+
+**Q: `show_favorability = TRUE` produces a 9-column `survey_diffs` layout not covered by any print snapshot. Add one?**
+- Options considered:
+  - **Add `expect_snapshot(print(result))`:** Category 13 requirement per testing-standards.md; §V example defines expected output.
+  - **Rely on value assertions only:** Formatting regressions go undetected.
+- **Decision:** Add print snapshot to the `show_favorability = TRUE` happy-path test block (Option A).
+- **Rationale:** Non-negotiable per testing-standards.md; cost is zero since the expected output is already shown in §V.
+
+---
+
+**Q: `direction = NA_character_` is a realistic mistake for `set_higher_is()` but absent from the `direction_invalid` test block. Add it?**
+- Options considered:
+  - **Add `NA_character_` test:** Verifies CLI `{.val}` rendering with NA; consistent with Pass 2 `alpha = NA` precedent (that was REQUIRED).
+  - **Accept `"neutral"` as sufficient:** Same code path; NA rendering is slightly different but rarely diverges.
+- **Decision:** Add `NA_character_` to the `direction_invalid` test block (Option A).
+- **Rationale:** Establishes consistency with Pass 2 decision; CLI formatting with NA values has a known edge case worth confirming.
+
+### Outcome
+
+Spec v0.4 approved. All 4 issues resolved: 1 vestigial name in §I scope table corrected,
+`surveycore_error_setter_mixed_dots` added to error table and test plan, print snapshot
+requirement added for `show_favorability = TRUE`, and `NA_character_` test case added to
+`direction_invalid` error block. No scope changes — table and test plan only.
+
+---
+
+## 2026-05-08 — Stage 3 Plan Review Resolution (8 issues)
+
+### Context
+
+Resolving all 8 open issues from plan review passes 1–3 of `plans/impl-variable-direction.md`
+before handing off to `/r-implement`.
+
+### Questions & Decisions
+
+**Q: Issue 2 — Convention 3 `direction_invalid` untested. Does Convention 2 also need a test for this error?**
+- Options considered:
+  - **Convention 2 test needed:** Adds coverage for a distinct calling form.
+  - **Convention 2 shares the per-pair loop path with Convention 1:** The existing Convention 1 test covers the loop. Only Convention 3's pre-check is a distinct path.
+- **Decision:** Add only the Convention 3 test. Convention 2 does not need a separate `direction_invalid` test.
+- **Rationale:** Convention 2 direction values pass through the same per-pair loop as Convention 1. The pre-check fires only for Convention 3 scalar inputs.
+
+---
+
+**Q: Issue 3 — After Issue 2 adds the Convention 3 test, what is the correct error-path block count for PR 1?**
+- Options considered:
+  - **8 blocks:** Original count before Issue 2 addition.
+  - **9 blocks:** Original 8 + the new Convention 3 `direction_invalid` test.
+- **Decision:** 9 error-path blocks for PR 1 (5 unique classes; `not_survey_or_df` and `ambiguous_input` tested separately for setter and extractor; `direction_invalid` tested for Convention 1 and Convention 3).
+- **Rationale:** Issue 2's new test is an addition to the plan, so acceptance criteria must reflect the final required count.
+
+---
+
+**Q: Issue 5 — Favorability block reads `attr(result, ".meta")$x[[x_name]]$higher_is` but `.meta` is not yet attached at the intended insertion point. Fix by changing the read or tightening the insertion point?**
+- Options considered:
+  - **Use `x_meta$higher_is`:** Local variable available before insertion point; eliminates ordering constraint entirely.
+  - **Tighten insertion-point wording:** Still depends on implementer reading carefully.
+- **Decision:** Use `x_meta$higher_is` (local variable, not `attr(result, ".meta")`).
+- **Rationale:** Removes the silent wrong-answer bug with zero trade-off. `x_meta` is assigned at line 448 and does not constrain exact insertion position.
+
+---
+
+**Q: Issue 8 — `direction` pre-check uses `&&` which only checks the first element of vector inputs. Fix by restricting to scalar or removing?**
+- Options considered:
+  - **Restrict pre-check to `length(direction) == 1L`:** Scalars caught early; vectors always validated per-element in the loop. Consistent.
+  - **Remove pre-check entirely:** Fully consistent; slightly more code executed for scalar errors.
+- **Decision:** Restrict pre-check to scalar with `length(direction) == 1L`.
+- **Rationale:** One word scopes the pre-check to the scalar Convention 3 case it was designed for, without removing the early-exit optimization.
+
+### Outcome
+
+All 8 issues resolved. Coverage criteria added to all three PRs; Convention 3 `direction_invalid`
+test added (PR 1 now 9 error-path blocks); acceptance criteria count corrected; Convention 3
+happy-path test added to PR 2; favorability block switched to `x_meta$higher_is`; spec file
+line 61 corrected (`show_favorability`); NEWS.md added to all three PRs' file lists and acceptance
+criteria; pre-check restricted to scalar direction. Plan is approved and ready for `/r-implement`.
+
+---

--- a/plans/error-messages.md
+++ b/plans/error-messages.md
@@ -270,6 +270,12 @@ against the messages defined here.
 | RC-2 | `set_reverse_coded()` | Neither `...` nor `variable` provided (or `variable = character(0)`) | ERROR | `surveycore_error_reverse_coded_no_vars` | `"x" = "{.fn set_reverse_coded} requires at least one variable name."` |
 | RC-3 | `set_reverse_coded()` | `reverse_coded` is not `TRUE` or `FALSE` (e.g., `NA`, non-logical) | ERROR | `surveycore_error_reverse_coded_not_logical` | `"x" = "{.arg reverse_coded} must be {.code TRUE} or {.code FALSE}."` |
 
+### diffs favorability rows (PR 3 — 2026-05-11)
+
+| # | Function | Condition | Level | Error Class | cli Message Template |
+|---|----------|-----------|-------|-------------|----------------------|
+| FA-1 | `get_diffs()` | `alpha` not a single numeric value strictly between 0 and 1 | ERROR | `surveycore_error_alpha_invalid` | `"{.arg alpha} must be a single numeric value strictly between 0 and 1. Got {.val {alpha}}."` |
+
 ### pool_pvals rows (2026-04-29)
 
 | # | Function | Condition | Level | Error Class | cli Message Template |
@@ -336,7 +342,7 @@ Which test files cover which error table rows:
 | `test-glm-methods.R` | 76 |
 | `test-glm-clean.R` | 75, 84 |
 | `test-metadata-infer.R` | 78, 79, 80 |
-| `test-analysis-diffs.R` | 43 (reused), 45/45a/45b/46 (reused), 49 (reused), 64 (reused), 81 (reused), 92–100 (new) |
+| `test-analysis-diffs.R` | 43 (reused), 45/45a/45b/46 (reused), 49 (reused), 64 (reused), 81 (reused), 92–100 (new), FA-1 (new) |
 | `test-analysis-diffs-helpers.R` | .stars_pval() and .apply_name_style(exclude) tests |
 | `test-glm-anova.R` | A-1 (reused row 75), A-2..A-5, A-7..A-20 (new); 45b, 46 (reused via `.validate_decimals_namestyle()`) |
 | `test-survey-collection.R` | C1, C2, C2a, C3, C4, C8, C15 |

--- a/plans/impl-variable-direction.md
+++ b/plans/impl-variable-direction.md
@@ -1,0 +1,634 @@
+---
+Version: 1.0
+Date: 2026-05-07
+Spec: plans/spec-variable-direction.md (v0.3)
+Status: Draft
+---
+
+# Implementation Plan — Variable Direction Attributes
+
+## Overview
+
+This plan delivers three sequential PRs from `plans/spec-variable-direction.md` (v0.3).
+PR 1 adds `higher_is` to `survey_metadata` plus its setter/extractor and updates
+`.extract_var_meta()`. PR 2 adds `reverse_coded` to `survey_metadata` plus its
+setter/extractor (infrastructure only — no consumer in this plan). PR 3 extends
+`get_diffs()` with `alpha` and `show_favorability` arguments that produce
+`favorable`/`backlash` columns by reading `higher_is` from `.meta`. PR 3 must
+not open until PR 1 is fully merged to `develop`.
+
+## PR Map
+
+- [x] PR 1: `feature/higher-is` — `higher_is` property, `set_higher_is()`, `extract_higher_is()`, `.extract_var_meta()` update
+- [x] PR 2: `feature/reverse-coded` — `reverse_coded` property, `set_reverse_coded()`, `extract_reverse_coded()`
+- [x] PR 3: `feature/diffs-favorability` — `get_diffs()` `alpha` + `show_favorability` args, `favorable`/`backlash` columns
+
+---
+
+## PR 1: `higher_is` attribute
+
+**Branch:** `feature/higher-is`
+**Depends on:** none
+
+### Files (TDD order — tests first)
+
+- `plans/error-messages.md` — add PR 1 error/warning classes before any code is written
+- `tests/testthat/test-metadata-system.R` — write all PR 1 test blocks (failing)
+- `R/core-classes.R` — add `higher_is` property to `survey_metadata`
+- `R/core-metadata.R` — implement `set_higher_is()` and `extract_higher_is()`
+- `R/analysis-helpers.R` — update `.extract_var_meta()` to include `higher_is`
+- `NEWS.md` — add entry for `set_higher_is()` and `extract_higher_is()`
+
+### Step-by-step (TDD)
+
+**Step 1: Add error classes to `plans/error-messages.md`**
+
+Add rows for all PR 1 classes before writing any code. Classes to add:
+- `surveycore_error_direction_invalid` — `direction` not `"better"`, `"worse"`, or `NULL`
+- `surveycore_error_higher_is_ambiguous_input` — both `...` and `variable` supplied (shared by setter and extractor)
+- `surveycore_error_higher_is_no_vars` — no variable names provided to setter
+Follow the existing table format. Reference `surveycore_warning_var_not_found` (already exists — reused, not added).
+
+**Step 2: Write failing tests in `tests/testthat/test-metadata-system.R`**
+
+Add a clearly labelled "PR 1 — higher_is" section. Write all blocks in the spec VI §PR1
+test plan. Each `test_that()` block should fail at this point (functions don't exist yet).
+
+Happy-path blocks:
+- Convention 1: `set_higher_is(d, anxiety = "worse")` stores `"worse"` under `anxiety`
+- Convention 1 multi-var: `set_higher_is(d, anxiety = "worse", agreement = "better")` stores both
+- Convention 2: `set_higher_is(d, c(anxiety = "worse", agreement = "better"))` stores both
+- Convention 3 scalar: `set_higher_is(d, variable = "anxiety", direction = "worse")`
+- Convention 3 vector: `set_higher_is(d, variable = c("anxiety", "worry"), direction = c("worse", "worse"))`
+- Unset: `set_higher_is(d, anxiety = NULL)` removes the entry
+- Data frame: `set_higher_is(df, anxiety = "worse")` stores attr on column
+- `extract_higher_is(d, anxiety)` returns `c(anxiety = "worse")`
+- `extract_higher_is(d, c(anxiety, agreement))` returns both
+- `extract_higher_is(d)` returns all variables; unset → `NA_character_`
+- `extract_higher_is(d, variable = "anxiety")` returns `c(anxiety = "worse")`
+
+Error-path blocks (one block each, dual pattern: `expect_error(class=)` + `expect_snapshot(error=TRUE)`):
+- `not_survey_or_df` (setter): `set_higher_is(list(), anxiety = "worse")`
+- `not_survey_or_df` (extractor): `extract_higher_is(list(), anxiety)`
+- `direction_invalid` (Convention 1): `set_higher_is(d, anxiety = "neutral")` — exercises per-pair loop validation
+- `direction_invalid` (Convention 3): `set_higher_is(d, variable = "anxiety", direction = "neutral")` — exercises pre-check validation path
+- `higher_is_ambiguous_input` (setter): `set_higher_is(d, anxiety = "worse", variable = "anxiety")`
+- `higher_is_ambiguous_input` (extractor): `extract_higher_is(d, anxiety, variable = "anxiety")`
+- `higher_is_no_vars`: `set_higher_is(d)`
+- `var_not_found` (setter, warning): `set_higher_is(d, nonexistent = "worse")` — expect_warning + snapshot
+- `var_not_found` (extractor, warning + return shape): `extract_higher_is(d, variable = "nonexistent")` — expect_warning + verify return is `character(0)` with no names
+
+Edge-case blocks:
+- Overwrite: set `"worse"` then set `"better"` — verify last write wins
+- No `higher_is` set on any variable — `extract_higher_is(d)` returns all `NA_character_`
+- `.extract_var_meta()` includes `higher_is` key: call `.extract_var_meta(d, "anxiety")` directly after `set_higher_is(d, anxiety = "worse")` — verify `result$higher_is == "worse"`
+
+**Step 3: Confirm all new test blocks fail (red)**
+
+Run `devtools::test(filter = "metadata-system")`. Every new block must fail. If any pass, the test is wrong.
+
+**Step 4: Add `higher_is` property to `survey_metadata` in `R/core-classes.R`**
+
+After the `sata` property definition, insert:
+
+```r
+higher_is = S7::new_property(
+  S7::class_list,
+  default = quote(list())
+),
+```
+
+Each entry maps a variable name to `"better"` or `"worse"`. Absent keys mean unset.
+Update the `survey_metadata` roxygen `@param` section to document `higher_is`.
+
+**Step 5: Implement `set_higher_is()` in `R/core-metadata.R`**
+
+Pattern: `.parse_setter_input()` with `content_type = "scalar"` — exactly the same
+structure as `set_var_label()`. Key specifics:
+
+- `content_arg_name = "direction"`; `fn_name = "set_higher_is"`
+- Validate `direction` before calling `.parse_setter_input()`: any direction value not in `c("better", "worse")` and not `NULL` fires `surveycore_error_direction_invalid`. Apply this check per-value in the map returned by `.parse_setter_input()`.
+- For survey objects: `x@metadata@higher_is[[v]] <- value` (or `<- NULL` to remove)
+- For data frames: `attr(x[[v]], "higher_is") <- value` (or `<- NULL`)
+- Returns `invisible(x)`
+
+Note: `.parse_setter_input()` already handles the ambiguous-input and empty-input errors
+using `surveycore_error_setter_ambiguous` and `surveycore_error_setter_empty`. The spec
+defines `surveycore_error_higher_is_ambiguous_input` and `surveycore_error_higher_is_no_vars`
+as distinct classes for this function. **Do not** reuse the generic setter classes here —
+pass `class = "surveycore_error_higher_is_ambiguous_input"` etc. directly in the error
+calls inside `set_higher_is()` before calling `.parse_setter_input()`, matching the
+`set_sata()` pattern (which also checks ambiguity/no-vars before delegating).
+
+Actually, re-reading `.parse_setter_input()` vs. `set_sata()`: `.parse_setter_input()` does
+its own ambiguity/empty checks internally. `set_sata()` does its own checks inline.
+`set_higher_is()` must use `.parse_setter_input()` (spec §III). To get the right error
+classes, the simplest approach: let `.parse_setter_input()` run — it fires
+`surveycore_error_setter_ambiguous` / `surveycore_error_setter_empty`. BUT the spec defines
+distinct higher_is error classes. Resolution: do the ambiguous/no-vars checks inline in
+`set_higher_is()` (before calling `.parse_setter_input()` or instead of it for those paths),
+then call `.parse_setter_input()` only for the Convention 1/2/3 content parsing. This matches
+the approach used throughout the existing setters where per-function classes are needed.
+
+Concrete structure:
+```
+set_higher_is <- function(x, ..., variable = NULL, direction = NULL) {
+  call <- rlang::caller_env()
+  .check_is_survey_or_df(x, call = call)
+
+  dots <- rlang::list2(...)
+  dots_used <- length(dots) > 0L
+  var_used <- !is.null(variable)
+
+  # ambiguous-input check (fires surveycore_error_higher_is_ambiguous_input)
+  if (dots_used && var_used) { ... }
+
+  # no-vars check (fires surveycore_error_higher_is_no_vars)
+  if (!dots_used && !var_used) { ... }
+
+  # direction validation (fires surveycore_error_direction_invalid) — only when
+  # direction is a scalar and not one of c("better", "worse"); vectors are
+  # validated per-element in the loop below
+  if (length(direction) == 1L && !is.null(direction) && !direction %in% c("better", "worse")) { ... }
+
+  # Parse using .parse_setter_input() for Convention 1/2/3 routing
+  pairs <- .parse_setter_input(
+    dots = dots,
+    variable = variable,
+    content = direction,
+    content_arg_name = "direction",
+    content_type = "scalar",
+    fn_name = "set_higher_is",
+    call = call
+  )
+
+  # Apply each pair
+  all_cols <- .get_data_cols(x)
+  for (v in names(pairs)) {
+    if (!v %in% all_cols) {
+      cli::cli_warn(..., class = "surveycore_warning_var_not_found")
+      next
+    }
+    val <- pairs[[v]]
+    if (!is.null(val) && !val %in% c("better", "worse")) {
+      cli::cli_abort(..., class = "surveycore_error_direction_invalid")
+    }
+    if (S7::S7_inherits(x, survey_base)) {
+      x@metadata@higher_is[[v]] <- val  # NULL removes the entry
+    } else {
+      attr(x[[v]], "higher_is") <- val
+    }
+  }
+  invisible(x)
+}
+```
+
+**Step 6: Implement `extract_higher_is()` in `R/core-metadata.R`**
+
+Pattern: inline `extract_var_label()` approach.
+
+```
+extract_higher_is <- function(x, ..., variable = NULL) {
+  call <- rlang::caller_env()
+  .check_is_survey_or_df(x, call = call)
+
+  dots_used <- ...length() > 0L
+  var_used <- !is.null(variable)
+
+  if (dots_used && var_used) {
+    cli::cli_abort(..., class = "surveycore_error_higher_is_ambiguous_input")
+  }
+
+  all_cols <- .get_data_cols(x)
+
+  if (dots_used) {
+    var_names <- names(tidyselect::eval_select(
+      rlang::expr(c(...)),
+      data = .get_data_for_select(x)
+    ))
+  } else if (var_used) {
+    missing <- setdiff(variable, all_cols)
+    if (length(missing) > 0L) {
+      cli::cli_warn(..., class = "surveycore_warning_var_not_found")
+    }
+    var_names <- intersect(variable, all_cols)
+  } else {
+    var_names <- all_cols
+  }
+
+  out <- vapply(var_names, function(v) {
+    if (S7::S7_inherits(x, survey_base)) {
+      x@metadata@higher_is[[v]] %||% NA_character_
+    } else {
+      attr(x[[v]], "higher_is", exact = TRUE) %||% NA_character_
+    }
+  }, character(1L))
+
+  out
+}
+```
+
+The return value is a named character vector. Unset variables return `NA_character_`.
+When `var_names` is length 0 (all specified names were missing), returns `character(0)`
+(named, zero-length) — `vapply` over zero-length input produces this automatically.
+
+**Step 7: Update `.extract_var_meta()` in `R/analysis-helpers.R`**
+
+Add `higher_is` to the return list. Reads from `design@metadata@higher_is[[var_name]]`
+with `NULL` fallback (when absent, returns `NULL`):
+
+```r
+higher_is <- design@metadata@higher_is[[var_name]] %||% NULL
+
+list(
+  variable_label  = variable_label,
+  question_preface = question_preface,
+  value_labels    = value_labels,
+  sata            = sata,
+  higher_is       = higher_is
+)
+```
+
+Note: for data frames, `higher_is` will always be `NULL` here since `.extract_var_meta()`
+only accepts survey design objects. The `higher_is` attribute on data frame columns is
+accessible only through `extract_higher_is()`.
+
+Update the function's roxygen `@return` documentation to include `higher_is`.
+
+**Step 8: Confirm all new test blocks pass (green)**
+
+Run `devtools::test(filter = "metadata-system")`. All new blocks must pass. Also run
+`devtools::test(filter = "analysis-diffs")` to verify no regressions in `.extract_var_meta()`.
+
+**Step 9: Run `devtools::document()` and `devtools::check()`**
+
+Confirm 0 errors, 0 warnings, ≤2 pre-approved notes.
+
+### Acceptance criteria
+
+- [ ] All new tests confirmed failing (red) before implementation began
+- [ ] `devtools::check()` 0 errors, 0 warnings, ≤2 pre-approved notes
+- [ ] `devtools::document()` run; NAMESPACE and man/ in sync
+- [ ] All PR 1 error classes added to `plans/error-messages.md` before code was written
+- [ ] 98%+ line coverage on new code; overall package coverage ≥ 95% (verified with `covr::package_coverage()`)
+- [ ] Happy paths: all three calling conventions work; data frame path works
+- [ ] Error paths: all 9 error-path blocks written (5 unique classes; `not_survey_or_df` and `ambiguous_input` tested separately for setter and extractor; `direction_invalid` tested for both Convention 1 and Convention 3)
+- [ ] Edge cases: overwrite, all-NA extract, `.extract_var_meta()` includes `higher_is`
+- [ ] No existing test regressions in `test-metadata-system.R` or analysis test files
+- [ ] `NEWS.md` entry written under the appropriate version heading
+- [ ] Snapshot tests reviewed via `testthat::snapshot_review()` before PR opened
+
+### Notes
+
+- `set_higher_is()` uses `.parse_setter_input()` for Convention 1/2/3 input routing
+  but does its own ambiguous/no-vars checks inline with higher_is-specific error classes
+  (same structure as `set_sata()`). Do not let `.parse_setter_input()` fire its generic
+  `surveycore_error_setter_ambiguous` / `surveycore_error_setter_empty` classes for this function.
+- Convention 3 length mismatch (`direction` and `variable` lengths differ and neither is scalar-to-be-recycled) is handled by `.parse_setter_input()` via `surveycore_error_setter_mismatched_lengths` (existing class) — no new class needed.
+- `.extract_var_meta()` update is free for all analysis functions: every `get_*()` that calls `.extract_var_meta()` will automatically carry `higher_is` in `.meta` from PR 1 onward.
+- The `%||%` operator is defined in `R/utils.R` — no new import needed.
+
+---
+
+## PR 2: `reverse_coded` attribute
+
+**Branch:** `feature/reverse-coded`
+**Depends on:** PR 1 merged to `develop` (recommended, though not strictly required — no code dependency between PRs 1 and 2)
+
+### Files (TDD order)
+
+- `plans/error-messages.md` — add PR 2 error/warning classes before any code is written
+- `tests/testthat/test-metadata-system.R` — write all PR 2 test blocks (failing)
+- `R/core-classes.R` — add `reverse_coded` property to `survey_metadata`
+- `R/core-metadata.R` — implement `set_reverse_coded()` and `extract_reverse_coded()`
+- `NEWS.md` — add entry for `set_reverse_coded()` and `extract_reverse_coded()`
+
+### Step-by-step (TDD)
+
+**Step 1: Add error classes to `plans/error-messages.md`**
+
+Add rows for PR 2 classes:
+- `surveycore_error_reverse_coded_not_logical` — `reverse_coded` is not `TRUE` or `FALSE`
+- `surveycore_error_reverse_coded_ambiguous_input` — both `...` and `variable` supplied
+- `surveycore_error_reverse_coded_no_vars` — no variable names provided
+
+**Step 2: Write failing tests in `tests/testthat/test-metadata-system.R`**
+
+Add a "PR 2 — reverse_coded" section. All blocks fail at this point.
+
+Happy-path blocks:
+- `set_reverse_coded(d, anxiety)` stores `TRUE` for `anxiety`
+- `set_reverse_coded(d, anxiety, worry)` stores `TRUE` for both
+- `set_reverse_coded(d, anxiety, reverse_coded = FALSE)` removes the entry
+- Convention 3 (vector): `set_reverse_coded(d, variable = c("anxiety", "worry"))` — verifies both variables are flagged
+- Data frame: `set_reverse_coded(df, anxiety)` stores attr on column
+- `extract_reverse_coded(d, anxiety)` returns `c(anxiety = TRUE)`
+- `extract_reverse_coded(d)` returns all variables; unset → `FALSE`
+- `extract_reverse_coded(d, variable = "anxiety")` returns `c(anxiety = TRUE)`
+
+Error-path blocks (dual pattern):
+- `not_survey_or_df` (setter): `set_reverse_coded(list(), anxiety)`
+- `not_survey_or_df` (extractor): `extract_reverse_coded(list(), anxiety)`
+- `reverse_coded_not_logical`: `set_reverse_coded(d, anxiety, reverse_coded = NA)`
+- `reverse_coded_ambiguous_input` (setter): both `...` and `variable`
+- `reverse_coded_ambiguous_input` (extractor): both `...` and `variable`
+- `reverse_coded_no_vars`: `set_reverse_coded(d)`
+- `var_not_found` (setter, warning): unknown variable warns + result skipped
+- `var_not_found` (extractor, warning + return shape): `extract_reverse_coded(d, variable = "nonexistent")` warns + returns `logical(0)`
+
+Edge-case blocks:
+- Set then unset: `extract_reverse_coded()` returns `FALSE` after `reverse_coded = FALSE`
+
+**Step 3: Confirm all new test blocks fail (red)**
+
+Run `devtools::test(filter = "metadata-system")`. Only new PR 2 blocks should fail.
+
+**Step 4: Add `reverse_coded` property to `survey_metadata` in `R/core-classes.R`**
+
+After the `higher_is` property:
+
+```r
+reverse_coded = S7::new_property(
+  S7::class_list,
+  default = quote(list())
+),
+```
+
+Each entry maps a variable name to `TRUE`. Absent key = not reverse-coded. No stored `FALSE`.
+
+**Step 5: Implement `set_reverse_coded()` in `R/core-metadata.R`**
+
+Pattern: inline `set_sata()` pattern — manual ambiguity/no-vars checks, then
+`tidyselect::eval_select` for `...` or direct `variable` vector.
+
+```
+set_reverse_coded <- function(x, ..., variable = NULL, reverse_coded = TRUE) {
+  call <- rlang::caller_env()
+  .check_is_survey_or_df(x, call = call)
+
+  if (!is.logical(reverse_coded) || length(reverse_coded) != 1L || is.na(reverse_coded)) {
+    cli::cli_abort(
+      c("x" = "{.arg reverse_coded} must be {.code TRUE} or {.code FALSE}."),
+      class = "surveycore_error_reverse_coded_not_logical",
+      call = call
+    )
+  }
+
+  dots_used <- ...length() > 0L
+  var_used <- !is.null(variable)
+
+  if (dots_used && var_used) { ... class = "surveycore_error_reverse_coded_ambiguous_input" }
+  if (!dots_used && (!var_used || length(variable) == 0L)) { ... class = "surveycore_error_reverse_coded_no_vars" }
+
+  all_cols <- .get_data_cols(x)
+
+  if (dots_used) {
+    var_names <- names(tidyselect::eval_select(rlang::expr(c(...)), data = .get_data_for_select(x)))
+  } else {
+    missing <- setdiff(variable, all_cols)
+    if (length(missing) > 0L) cli::cli_warn(..., class = "surveycore_warning_var_not_found")
+    var_names <- intersect(variable, all_cols)
+  }
+
+  for (v in var_names) {
+    if (S7::S7_inherits(x, survey_base)) {
+      x@metadata@reverse_coded[[v]] <- if (isTRUE(reverse_coded)) TRUE else NULL
+    } else {
+      attr(x[[v]], "reverse_coded") <- if (isTRUE(reverse_coded)) TRUE else NULL
+    }
+  }
+  invisible(x)
+}
+```
+
+**Step 6: Implement `extract_reverse_coded()` in `R/core-metadata.R`**
+
+Same pattern as `extract_higher_is()`. Key differences:
+- Returns named logical vector (not character)
+- Unset variables return `FALSE` (not `NA_character_`)
+- Uses `x@metadata@reverse_coded[[v]]` (or `attr(x[[v]], "reverse_coded", exact = TRUE)`)
+- Absent entry → `isTRUE(NULL)` → `FALSE`
+
+```r
+out <- vapply(var_names, function(v) {
+  if (S7::S7_inherits(x, survey_base)) {
+    isTRUE(x@metadata@reverse_coded[[v]])
+  } else {
+    isTRUE(attr(x[[v]], "reverse_coded", exact = TRUE))
+  }
+}, logical(1L))
+```
+
+**Step 7: Confirm all PR 2 tests pass (green)**
+
+Run `devtools::test(filter = "metadata-system")`. All PR 2 blocks pass.
+
+**Step 8: Run `devtools::document()` and `devtools::check()`**
+
+### Acceptance criteria
+
+- [ ] All new tests confirmed failing (red) before implementation began
+- [ ] `devtools::check()` 0 errors, 0 warnings, ≤2 pre-approved notes
+- [ ] `devtools::document()` run; NAMESPACE and man/ in sync
+- [ ] All PR 2 error classes added to `plans/error-messages.md` before code was written
+- [ ] 98%+ line coverage on new code; overall package coverage ≥ 95% (verified with `covr::package_coverage()`)
+- [ ] Happy paths: Convention 1 (bare names), Convention 3 (variable=), data frame; extractor `FALSE` for unset variables
+- [ ] Error paths: all 8 error-path blocks written (5 unique classes; `not_survey_or_df` and `ambiguous_input` tested separately for setter and extractor)
+- [ ] Edge cases: set-then-unset returns `FALSE`; zero-length return is `logical(0)`
+- [ ] No PR 1 regressions
+- [ ] `NEWS.md` entry written under the appropriate version heading
+- [ ] Snapshot tests reviewed before PR opened
+
+### Notes
+
+- `set_reverse_coded()` does **not** support Convention 2 (named vector in `...`). It follows the `set_sata()` inline pattern: tidy-select `...` for bare names, `variable` for character vector — no `.parse_setter_input()`.
+- The absence-equals-`FALSE` semantics mirror `sata`: no stored `FALSE` in the list; removing the entry is done by setting to `NULL`.
+- `extract_reverse_coded()` has no `format` or `fill` arguments (unlike `extract_sata()`). It always returns a named logical vector.
+
+---
+
+## PR 3: `get_diffs()` favorability extensions
+
+**Branch:** `feature/diffs-favorability`
+**Depends on:** PR 1 fully merged to `develop` (`higher_is` must be in `survey_metadata`
+and `.extract_var_meta()` must return `higher_is`)
+
+**HARD GATE: Do not open this branch until PR 1 is merged.**
+
+### Files (TDD order)
+
+- `plans/error-messages.md` — add `surveycore_error_alpha_invalid`
+- `tests/testthat/test-analysis-diffs.R` — write all PR 3 test blocks (failing)
+- `R/analysis-diffs.R` — add `alpha`, `show_favorability` args; add favorability logic
+- `NEWS.md` — add entry for `get_diffs()` `alpha` and `show_favorability` arguments
+
+### Step-by-step (TDD)
+
+**Step 1: Add error class to `plans/error-messages.md`**
+
+Add one new row: `surveycore_error_alpha_invalid`.
+Message template: `"{.arg alpha} must be a single numeric value strictly between 0 and 1. Got {.val {alpha}}."`
+
+**Step 2: Write failing tests in `tests/testthat/test-analysis-diffs.R`**
+
+Add a "PR 3 — favorability" section. Use existing test design setup from the file.
+Set `higher_is` on the `x` variable via `set_higher_is()` before calling `get_diffs()`.
+
+Happy-path blocks:
+- `show_favorability = FALSE` (default): no `favorable`/`backlash` columns; `attr(result, ".meta")$x[[x_name]]$higher_is` equals `"worse"` (not just non-NULL — assert the value)
+- `show_favorability = TRUE` + `higher_is = "worse"` + negative significant diff: `favorable = TRUE`, `backlash = FALSE`; `attr(result$favorable, "label")` equals `"Favorable"`; `attr(result$backlash, "label")` equals `"Backlash"`
+- `show_favorability = TRUE` + `higher_is = "better"` + negative significant diff: `favorable = FALSE`, `backlash = TRUE`
+- `show_favorability = TRUE` + non-significant result: `favorable = FALSE`, `backlash = FALSE`
+- Custom `alpha = 0.01`: result with `p = 0.03` is not favorable/backlash (both `FALSE`)
+- `name_style = "broom"` + `show_favorability = TRUE`: `favorable`/`backlash` present; classification uses `p.value` column
+- `group` + `show_favorability = TRUE`: columns present; rows align correctly per group
+- `pval_adj` set + `show_favorability = TRUE`: classification uses adjusted p-value
+
+Error-path blocks (dual pattern):
+- `alpha_invalid`: `alpha = 1.5`
+- `alpha_invalid`: `alpha = 0`
+- `alpha_invalid`: `alpha = "0.05"`
+- `alpha_invalid`: `alpha = NA`
+- `alpha_invalid`: `alpha = Inf`
+- `alpha_invalid`: `alpha = c(0.05, 0.1)`
+
+Edge-case blocks:
+- `show_favorability = TRUE` with no `higher_is` set on `x`: both columns all `FALSE`; no warning
+- `p_value` exactly equal to `alpha`: not significant — both `FALSE` (strict `<`, not `<=`)
+
+**Step 3: Confirm all new test blocks fail (red)**
+
+Run `devtools::test(filter = "analysis-diffs")`. All new blocks fail.
+
+**Step 4: Add arguments to `get_diffs()` in `R/analysis-diffs.R`**
+
+Insert `alpha` and `show_favorability` after `conf_level` in the signature:
+
+```r
+conf_level = 0.95,
+alpha = 0.05,
+show_favorability = FALSE,
+min_cell_n = 30L,
+```
+
+Add `alpha` validation immediately after `.validate_shared_args()`:
+
+```r
+if (
+  !is.numeric(alpha) ||
+    length(alpha) != 1L ||
+    is.na(alpha) ||
+    !is.finite(alpha) ||
+    alpha <= 0 ||
+    alpha >= 1
+) {
+  cli::cli_abort(
+    c(
+      "x" = paste0(
+        "{.arg alpha} must be a single numeric value strictly between ",
+        "0 and 1. Got {.val {alpha}}."
+      )
+    ),
+    class = "surveycore_error_alpha_invalid"
+  )
+}
+```
+
+Update roxygen docs for `get_diffs()`:
+- Add `@param alpha` entry
+- Add `@param show_favorability` entry
+- Update `@return` to mention the optional `favorable`/`backlash` columns
+
+**Step 5: Implement favorability logic in `R/analysis-diffs.R`**
+
+Insert after `x_meta <- .extract_var_meta(design, x_name)` is assigned (after `.apply_name_style()`) and before `attr(result, ".meta") <- .build_meta(...)` is called. `x_meta` is the local variable holding the x-variable metadata; the block uses `x_meta$higher_is` directly, so it does not depend on `.meta` being attached to `result` yet:
+
+```r
+if (isTRUE(show_favorability)) {
+  # Read higher_is from x_meta (the local variable set just before .build_meta())
+  higher_is_val <- x_meta$higher_is
+
+  # Detect which p-value column name is present (surveycore or broom)
+  pval_col <- if ("p_value" %in% names(result)) "p_value" else "p.value"
+  p_vals <- result[[pval_col]]
+
+  sig <- !is.na(p_vals) & p_vals < alpha  # strict <
+
+  favorable <- logical(nrow(result))
+  backlash  <- logical(nrow(result))
+
+  if (!is.null(higher_is_val)) {
+    est <- result$estimate  # column name is "estimate" in get_diffs()
+    if (higher_is_val == "better") {
+      favorable[sig] <- est[sig] > 0
+      backlash[sig]  <- est[sig] < 0
+    } else if (higher_is_val == "worse") {
+      favorable[sig] <- est[sig] < 0
+      backlash[sig]  <- est[sig] > 0
+    }
+  }
+  # If higher_is_val is NULL, favorable/backlash remain all FALSE
+
+  attr(favorable, "label") <- "Favorable"
+  attr(backlash,  "label") <- "Backlash"
+
+  saved_meta  <- attr(result, ".meta")
+  saved_class <- class(result)
+  result$favorable <- favorable
+  result$backlash  <- backlash
+  attr(result, ".meta") <- saved_meta
+  class(result) <- saved_class
+}
+```
+
+Important ordering constraint: favorability uses the adjusted p-value (if `pval_adj` was
+applied) because the p-value column already contains the adjusted values by the time
+this block runs. This is correct per spec rule 4.
+
+**Step 6: Confirm all PR 3 tests pass (green)**
+
+Run `devtools::test(filter = "analysis-diffs")`. All new blocks pass. No regressions.
+
+**Step 7: Run `devtools::document()` and `devtools::check()`**
+
+### Acceptance criteria
+
+- [ ] All new tests confirmed failing (red) before implementation began
+- [ ] PR 1 is confirmed merged to `develop` before this branch opens
+- [ ] `devtools::check()` 0 errors, 0 warnings, ≤2 pre-approved notes
+- [ ] `devtools::document()` run; NAMESPACE and man/ in sync
+- [ ] `alpha_invalid` error class added to `plans/error-messages.md` before code written
+- [ ] Happy paths: `show_favorability = FALSE` (default, no columns), `"better"` direction, `"worse"` direction, non-significant → both `FALSE`
+- [ ] Column label attributes `"Favorable"` and `"Backlash"` asserted in happy-path test
+- [ ] `.meta$x[[x_name]]$higher_is` asserted to equal `"worse"` (not just non-NULL)
+- [ ] `name_style = "broom"` path tested: `favorable`/`backlash` present, classification uses `p.value`
+- [ ] `group` path tested: columns aligned across groups
+- [ ] `pval_adj` path tested: classification uses adjusted p-value
+- [ ] Error paths: all 6 `alpha_invalid` variants produce snapshot-matched messages
+- [ ] Edge cases: `higher_is` unset → both `FALSE`; `p == alpha` → both `FALSE`
+- [ ] No regressions in any existing `test-analysis-diffs.R` blocks
+- [ ] 98%+ line coverage on new code; overall package coverage ≥ 95% (verified with `covr::package_coverage()`)
+- [ ] `NEWS.md` entry written under the appropriate version heading
+- [ ] Snapshot tests reviewed before PR opened
+
+### Notes
+
+- Favorability block is inserted after `x_meta <- .extract_var_meta(design, x_name)` is assigned and after `.apply_name_style()` runs (so `p.value` vs. `p_value` detection works), but BEFORE `attr(result, ".meta") <- .build_meta(...)`. Using `x_meta$higher_is` (not `attr(result, ".meta")$x[[x_name]]$higher_is`) means the block has no ordering dependency on `.meta` being attached to `result`. Do not add `favorable`/`backlash` to the broom rename map — they are invariant.
+- `favorable` and `backlash` are appended to the result tibble last (after all other columns). Save and restore `.meta` and S3 class around the assignment to avoid attribute loss.
+- When `show_favorability = FALSE` (default), the `higher_is` value is still present in `.meta` (via PR 1's `.extract_var_meta()` update) — the test for this must assert the actual value, not just non-NULL.
+- The estimate column in `get_diffs()` output is named `"estimate"` — no need to handle multiple possible names.
+- `is.finite(alpha)` is `FALSE` for both `NA` and `Inf`, so a single `!is.finite(alpha)` check covers both. Use the combined validation shown above.
+
+---
+
+## Post-PR 3 checklist
+
+- [ ] All three PRs merged to `develop`
+- [ ] `develop` green on CI
+- [ ] Move `plans/spec-variable-direction.md`, `plans/spec-review-variable-direction.md`, `plans/decisions-variable-direction.md`, `plans/impl-variable-direction.md` to `archive/variable-direction/`
+- [ ] Update `CLAUDE.md` implementation status table
+
+> Review the PR map carefully — the scope of each PR is harder to change once
+> implementation starts. Confirm that no PR bundles functions that should be separate.
+> Run Stage 2 in a new session for an adversarial review of this plan before
+> handing off to `/r-implement`.

--- a/plans/plan-review-variable-direction.md
+++ b/plans/plan-review-variable-direction.md
@@ -1,0 +1,392 @@
+## Plan Review: variable-direction — Pass 1 (2026-05-07)
+
+### New Issues
+
+#### Section: PR Map
+
+No issues found. Three PRs are well-scoped: one per new metadata attribute plus
+one for the `get_diffs()` consumer. PR 3's hard gate on PR 1 is explicit and
+correct.
+
+---
+
+#### Section: PR 1 — `higher_is` attribute
+
+**Issue 1: 98%+ coverage criterion missing from all three PRs**
+Severity: REQUIRED
+Violates `testing-standards.md §2` ("98%+ line coverage is the project target;
+PRs that drop coverage below 95% are blocked by CI")
+
+None of the three PRs' acceptance criteria includes a line-coverage check. The
+acceptance criteria for PRs 1, 2, and 3 each list `devtools::check()` and
+snapshot review, but never state "98%+ line coverage on new code; overall
+package coverage ≥ 95%."
+
+Options:
+- **[A]** Add a coverage criterion to each of the three PRs' acceptance criteria:
+  `"98%+ line coverage on new code; overall package coverage ≥ 95% (verified
+  with covr::package_coverage())"` — Effort: low, Risk: low, Impact: ensures CI
+  gate is part of the PR definition of done
+- **[B]** Add a single global note at the top of the plan referencing the standard
+  — Effort: low, Risk: medium (easy to miss in the plan), Impact: same
+- **[C] Do nothing** — Coverage check is implicitly expected from
+  `testing-standards.md`, but the criterion is invisible in PR acceptance criteria
+  and easy to skip under time pressure.
+
+**Recommendation: A** — Each PR's acceptance criteria should be self-contained.
+Adding one line per PR is negligible effort and prevents the check being
+forgotten at ship time.
+
+---
+
+**Issue 2: Convention 3 `direction_invalid` path is untested**
+Severity: REQUIRED
+Violates `testing-standards.md §2` ("Every error class gets a test")
+
+The only `direction_invalid` test in the plan is:
+```
+set_higher_is(d, anxiety = "neutral")   # Convention 1 — named dot
+```
+This exercises the per-pair validation in the loop (after `.parse_setter_input()`
+returns). The pre-check block executed before `.parse_setter_input()` — which
+fires for Convention 3 scalar when `direction` is not NULL — is never exercised:
+
+```r
+# pre-check (fires for Convention 3 scalar only)
+if (!is.null(direction) && !direction %in% c("better", "worse")) { ... }
+```
+
+Without a test like `set_higher_is(d, variable = "anxiety", direction = "neutral")`,
+this block has zero coverage. If a future refactor breaks it, no test will
+catch the regression.
+
+Options:
+- **[A]** Add one happy-path/error-path test to Step 2: `set_higher_is(d,
+  variable = "anxiety", direction = "neutral")` — `expect_error(class = ...) +
+  expect_snapshot(error = TRUE)` — Effort: low, Risk: low, Impact: full coverage
+  of the pre-check path
+- **[B]** Remove the pre-check entirely and rely solely on the per-pair loop
+  check, then document in a code comment that Convention 3 direction validation
+  is handled in the loop — Effort: low, Risk: low, Impact: slightly simpler
+  implementation; removes the coverage gap by removing the uncovered code
+- **[C] Do nothing** — The correct error fires via the loop in all tested
+  cases; the pre-check code path is a latent coverage gap.
+
+**Recommendation: A** — Adding the Convention 3 test is the minimal-risk fix and
+also validates the end-to-end Convention 3 path for `direction_invalid`.
+
+---
+
+**Issue 3: Acceptance criteria say "5 error classes" — ambiguous against 8 test blocks**
+Severity: SUGGESTION
+Clarity concern
+
+PR 1 acceptance criteria: "Error paths: all 5 error classes produce
+snapshot-matched messages."
+PR 2 acceptance criteria: "Error paths: all 5 error classes produce
+snapshot-matched messages."
+
+Both PRs have 5 unique error classes but require 8 separate test blocks
+(setter and extractor each need blocks for `not_survey_or_df` and
+`ambiguous_input`). An implementer reading "5 error classes" might write only
+5 blocks and miss the per-function variants.
+
+Options:
+- **[A]** Change the criterion to: "Error paths: all 8 error-path blocks written
+  (5 unique classes; `not_survey_or_df` and `ambiguous_input` tested separately
+  for setter and extractor)" — Effort: trivial, Risk: none, Impact: unambiguous
+- **[B] Do nothing** — Step 2 lists all 8 blocks explicitly; the acceptance
+  criterion count is a summary only.
+
+**Recommendation: A** — The acceptance criteria are the PR-open gate. Clarity
+there matters.
+
+---
+
+#### Section: PR 2 — `reverse_coded` attribute
+
+**Issue 4: `set_reverse_coded()` Convention 3 setter happy path not tested**
+Severity: SUGGESTION
+Violates `testing-standards.md §2` (happy path coverage)
+
+The PR 2 test plan for `set_reverse_coded()` covers:
+- Convention 1: `set_reverse_coded(d, anxiety)` (single bare name) ✅
+- Convention 1 multi: `set_reverse_coded(d, anxiety, worry)` ✅
+- Convention 1 unset: `set_reverse_coded(d, anxiety, reverse_coded = FALSE)` ✅
+- Data frame: ✅
+
+But there is no happy-path test for:
+```r
+set_reverse_coded(d, variable = "anxiety")          # Convention 3 — scalar
+set_reverse_coded(d, variable = c("anxiety", "worry"))  # Convention 3 — vector
+```
+
+The extractor test plan includes `extract_reverse_coded(d, variable = "anxiety")`
+as a happy path. The setter has the same `variable` argument and should be
+symmetrically tested. This is the code path that exercises the
+`if (dots_used) { ... } else { ... }` branch when `dots_used = FALSE` and
+`var_used = TRUE`.
+
+Options:
+- **[A]** Add one happy-path block to Step 2: `set_reverse_coded(d, variable =
+  c("anxiety", "worry"))` — verifies both variables are flagged — Effort: low,
+  Risk: none, Impact: exercises the `variable` branch in the setter
+- **[B] Do nothing** — The ambiguous-input error test (setter, both `...` and
+  `variable`) implicitly confirms `variable` is a known argument; full coverage
+  of the `variable` branch is tested via the error path.
+
+**Recommendation: A** — A happy-path test for Convention 3 is cheap and makes
+the setter's coverage symmetric with the extractor.
+
+---
+
+#### Section: PR 3 — `get_diffs()` favorability extensions
+
+**Issue 5: Favorability block insertion point is under-specified; silent correctness bug if placed before Step 20**
+Severity: REQUIRED
+Implementation ambiguity that produces a silent wrong-answer bug
+
+The plan says:
+> "Insert after `.apply_name_style()` and `.apply_decimals()` are called,
+> before `return(result)`"
+
+The actual `get_diffs()` function has this sequence:
+- Step 18: `.apply_decimals()`
+- Step 19: `.apply_name_style()`
+- **Step 20:** `x_meta <- .extract_var_meta(design, x_name)` … `attr(result, ".meta") <- .build_meta(...)`
+- Step 21: column-level labels
+- Step 22: set class and return
+
+The favorability block reads:
+```r
+higher_is_val <- attr(result, ".meta")$x[[x_name]]$higher_is
+```
+
+If the block is inserted **between Step 19 and Step 20**, `attr(result, ".meta")`
+is `NULL`. In R, `NULL$x` = `NULL`, `NULL[[x_name]]` = `NULL`, so
+`higher_is_val` silently becomes `NULL` — meaning the favorability block would
+always produce all-`FALSE` results even when `higher_is` is set on the design.
+There is no error; it just silently never works.
+
+The save/restore pattern also captures the pre-Step-22 class
+(`c("tbl_df", "tbl", "data.frame")`), which is fine since Step 22 overwrites
+it. But the `.meta` issue is a silent correctness failure.
+
+Fix options:
+- **[A]** Change the plan to say "Insert after Step 20 (after
+  `attr(result, '.meta') <- .build_meta(...)` is executed)" — Effort: trivial,
+  Risk: none, Impact: removes ambiguity; implementer places block correctly
+- **[B]** Change the block to read `x_meta$higher_is` directly (using the local
+  variable set at Step 20 line 448) instead of `attr(result, ".meta")$x[[x_name]]$higher_is`
+  — Effort: trivial, Risk: none, Impact: block can be inserted anywhere after
+  Step 20's local variable is assigned; same value, no `.meta` dependency
+- **[C] Do nothing** — An attentive implementer reading the full function will
+  notice `.meta` isn't attached yet and adjust; an inattentive one ships a
+  silently broken feature.
+
+**Recommendation: B** — Using `x_meta$higher_is` is simpler and eliminates the
+ordering dependency entirely. Update the note in §Notes accordingly.
+
+---
+
+#### Section: Cross-cutting / Out of Scope
+
+**Issue 6: Spec §I scope table says "direction" where it should say "show_favorability"**
+Severity: SUGGESTION
+Spec inconsistency (plan itself is correct)
+
+The spec §I scope table entry for PR 3 reads:
+> "| 3 | `get_diffs()` extensions | `alpha`, `direction` arguments; … |"
+
+But throughout the spec body, the second new argument is `show_favorability`.
+There is no argument named `direction` added to `get_diffs()`. The plan
+correctly implements `show_favorability`. The scope table contains a stale name.
+
+This is a spec issue, not a plan issue, but if the spec is referenced by
+others during review it may cause confusion.
+
+Options:
+- **[A]** Correct the spec §I scope table to read "alpha, show_favorability
+  arguments" — Effort: trivial, Risk: none
+- **[B] Do nothing** — The plan is correct; the spec body is correct; the table
+  is vestigial.
+
+**Recommendation: A** — Update the spec table entry to avoid confusion during
+PR review.
+
+---
+
+**Issue 7: NEWS.md not mentioned in any PR's file list or acceptance criteria**
+Severity: SUGGESTION
+Release workflow gap
+
+None of the three PRs lists `NEWS.md` as a file to update, and none of the
+acceptance criteria include a changelog entry. PRs 1 and 2 each add two new
+exported functions (`set_higher_is`, `extract_higher_is`, `set_reverse_coded`,
+`extract_reverse_coded`). PR 3 adds two new arguments to an existing exported
+function. All three warrant `NEWS.md` entries.
+
+Options:
+- **[A]** Add `NEWS.md` to each PR's file list and add a criterion:
+  "NEWS.md entry written under the appropriate version heading" — Effort: low,
+  Risk: none, Impact: each PR is self-contained at ship time
+- **[B]** Add a single post-PR-3 checklist item to update NEWS.md once for
+  all three PRs — Effort: low, Risk: medium (easy to defer and forget)
+- **[C] Do nothing** — NEWS.md is updated during the release preparation
+  (`/merge-main` workflow).
+
+**Recommendation: A** — Each PR should be independently shippable; a reviewer
+checking the PR branch should see the NEWS.md entry alongside the code.
+
+---
+
+### Summary (Pass 1)
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 0 |
+| REQUIRED | 3 |
+| SUGGESTION | 4 |
+
+**Total issues:** 7
+
+**Overall assessment:** The plan is nearly implementation-ready. Issues 2 and 5
+are the most important: Issue 2 is a test coverage gap that leaves a code path
+unexercised, and Issue 5 is a silent wrong-answer bug if the favorability block
+is placed at the wrong position within `get_diffs()`. Both are quick to fix
+(one test block added, one line changed from `attr(result, ".meta")$x[[x_name]]$higher_is`
+to `x_meta$higher_is`). Resolve the three REQUIRED issues and the plan is ready
+to hand off to `/r-implement`.
+
+---
+
+## Plan Review: variable-direction — Pass 2 (2026-05-07)
+
+### Prior Issues (Pass 1)
+
+| # | Title | Status |
+|---|---|---|
+| 1 | 98%+ coverage criterion missing from all three PRs | ⚠️ Still open |
+| 2 | Convention 3 `direction_invalid` path is untested | ⚠️ Still open |
+| 3 | Acceptance criteria say "5 error classes" — ambiguous against 8 test blocks | ⚠️ Still open |
+| 4 | `set_reverse_coded()` Convention 3 setter happy path not tested | ⚠️ Still open |
+| 5 | Favorability block insertion point under-specified; silent correctness bug if misplaced | ⚠️ Still open |
+| 6 | Spec §I scope table says "direction" where it should say "show_favorability" | ⚠️ Still open |
+| 7 | NEWS.md not mentioned in any PR's file list or acceptance criteria | ⚠️ Still open |
+
+### New Issues
+
+#### Section: PR 1 — `set_higher_is()` implementation
+
+**Issue 8: Direction pre-check behavior is inconsistent for vector `direction` inputs**
+Severity: SUGGESTION
+Violates engineering-preferences.md §5 (explicit over clever).
+
+The plan's concrete structure for `set_higher_is()` includes a pre-check before calling `.parse_setter_input()`:
+
+```r
+if (!is.null(direction) && !direction %in% c("better", "worse")) { ... }
+```
+
+`&&` in R uses only the **first element** of each operand. For vector `direction` inputs this produces inconsistent behavior:
+- `direction = c("neutral", "worse")` → `TRUE && TRUE` → pre-check fires; error displays the whole vector as the bad value ✅
+- `direction = c("worse", "neutral")` → `TRUE && FALSE` → pre-check silently passes; error fires later from the per-pair loop, displaying only the invalid element ✅
+
+Both cases correctly raise `surveycore_error_direction_invalid`. However, the displayed invalid value differs based on which element is bad first — surprising for callers of Convention 3 with vector inputs.
+
+The pre-check was designed for scalar `direction` (Convention 3 scalar); applying it to vectors is an unintended side-effect of not restricting the length check.
+
+Options:
+- **[A]** Restrict pre-check to scalar: `if (length(direction) == 1L && !is.null(direction) && !direction %in% c("better", "worse"))` — Effort: trivial, Risk: none, Impact: consistent behavior; scalars caught early, vectors always validated per-element in loop, Maintenance: none
+- **[B]** Remove the pre-check entirely; rely solely on the per-pair loop check — Effort: trivial, Risk: none, Impact: fully consistent; slightly more code executed for scalar errors, Maintenance: none
+- **[C] Do nothing** — Functional correctness preserved; inconsistent error message display for vector inputs
+
+**Recommendation: A** — One-word addition scopes the pre-check to the case it was designed for without affecting any currently-tested behavior.
+
+---
+
+#### Section: PR 3 — Favorability block placement (Issue 5 follow-up)
+
+Code confirmation: `get_diffs()` in `R/analysis-diffs.R` attaches `.meta` at **line 469** (`attr(result, ".meta") <- .build_meta(...)`) — which is **after** `.apply_name_style()` at line 445. `x_meta` (the local variable for the x-variable metadata) is assigned at line 448. The favorability block reads `attr(result, ".meta")$x[[x_name]]$higher_is`. If the block is placed between lines 445 and 469, `.meta` is `NULL`, `higher_is_val` is silently `NULL`, and all favorability results are `FALSE` regardless of what `higher_is` is set to — a silent wrong-answer bug with no error.
+
+The plan's current specification ("Insert after `.apply_name_style()` and `.apply_decimals()` are called, before `return(result)`") spans this dangerous window. The simplest fix remains switching to `x_meta$higher_is` (line 448 local variable), which eliminates the ordering dependency.
+
+---
+
+### Summary (Pass 2)
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 0 |
+| REQUIRED | 0 new (Issues 1, 2, 5 from Pass 1 still unresolved) |
+| SUGGESTION | 1 new (Issue 8) |
+
+**Total new issues:** 1
+
+**Open issues requiring resolution before implementation:** Issues 1, 2, and 5 (REQUIRED from Pass 1). Issues 3, 4, 6, 7 (SUGGESTION from Pass 1) and Issue 8 (SUGGESTION, new) can be resolved during implementation or in Stage 4 at the author's discretion.
+
+---
+
+## Plan Review: variable-direction — Pass 3 (2026-05-07)
+
+### Prior Issues (Passes 1–2)
+
+| # | Title | Status |
+|---|---|---|
+| 1 | 98%+ coverage criterion missing from all three PRs | ⚠️ Still open |
+| 2 | Convention 3 `direction_invalid` path is untested | ⚠️ Still open |
+| 3 | Acceptance criteria say "5 error classes" — ambiguous against 8 test blocks | ⚠️ Still open |
+| 4 | `set_reverse_coded()` Convention 3 setter happy path not tested | ⚠️ Still open |
+| 5 | Favorability block insertion point under-specified; silent correctness bug if misplaced | ⚠️ Still open |
+| 6 | Spec §I scope table says "direction" where it should say "show_favorability" | ⚠️ Still open |
+| 7 | NEWS.md not mentioned in any PR's file list or acceptance criteria | ⚠️ Still open |
+| 8 | Direction pre-check inconsistent for vector `direction` inputs | ⚠️ Still open |
+
+### Code Verification — Issue 5 (Authoritative)
+
+Direct inspection of `R/analysis-diffs.R` confirms the exact execution order:
+
+```
+Line 438:  result <- .apply_decimals(result, decimals)
+Line 445:  result <- .apply_name_style(result, name_style, ...)
+Line 448:  x_meta <- .extract_var_meta(design, x_name)   ← x_meta local var set here
+Line 469:  attr(result, ".meta") <- .build_meta(...)      ← .meta attached here
+Line 472:  stopifnot(all(DIFFS_META_KEYS %in% names(meta_args)))
+Lines 498–513:  column-label loop
+Lines 515–522:  class(result) <- c("survey_diffs", ...)
+Line 523:  result                                          ← implicit return
+```
+
+The plan says to insert the favorability block "after `.apply_name_style()` and `.apply_decimals()` are called, before `return(result)`" — which spans the range lines 445–522. The dangerous sub-range is **445–468**: `.meta` is `NULL` there, so `attr(result, ".meta")$x[[x_name]]$higher_is` silently returns `NULL` and all favorability results are `FALSE`. Safe range is **469–522**.
+
+The fix from Pass 2 is confirmed correct: switching to `x_meta$higher_is` (available from line 448 onward) eliminates the ordering constraint entirely. The plan must adopt this fix before implementation.
+
+Also verified: `.parse_setter_input()` (line 72 comment) explicitly documents "NULL values signal deletion" — confirming that Convention 1 unsetting (`set_higher_is(d, anxiety = NULL)`) flows correctly through `.parse_setter_input()` without needing special-case handling.
+
+### New Issues
+
+#### Section: All PRs
+
+No new BLOCKING or REQUIRED issues found in Pass 3. All five lenses were re-applied:
+
+- **Lens 1 (Granularity):** PR scope is clean. Three PRs, one coherent unit each. No bundling or splitting needed.
+- **Lens 2 (Dependency ordering):** PR 1 independent, PR 2 recommended-sequential (merge conflict risk in `core-classes.R` if concurrent), PR 3 hard-gated on PR 1. All dependencies accurate.
+- **Lens 3 (Acceptance criteria):** Issues 1, 3, 7 remain the open gaps (coverage, error-block count ambiguity, NEWS.md).
+- **Lens 4 (Spec coverage):** Issue 2 remains the only coverage gap (Convention 3 `direction_invalid` test path). No scope creep found. No spec behaviors missing from the plan.
+- **Lens 5 (File completeness):** All R source, test, and error-messages files listed correctly. Issue 7 (NEWS.md) remains the only missing file.
+
+---
+
+### Summary (Pass 3)
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 0 |
+| REQUIRED | 0 new |
+| SUGGESTION | 0 new |
+
+**Total new issues:** 0
+
+**Open issues requiring resolution before implementation:** Issues 1, 2, and 5 (REQUIRED from Pass 1). All three are quick fixes: add one coverage line to each PR's acceptance criteria (Issue 1), add one test block for Convention 3 `direction_invalid` (Issue 2), and change `attr(result, ".meta")$x[[x_name]]$higher_is` to `x_meta$higher_is` in PR 3 Step 5 (Issue 5). Issues 3, 4, 6, 7, 8 (SUGGESTION) may be resolved during implementation at the author's discretion.
+
+**Overall assessment:** The plan is structurally sound with no new problems found after three adversarial passes. The three REQUIRED issues from Pass 1 are all trivial to fix (one line each). Resolve them and this plan is ready to hand off to `/r-implement`.

--- a/plans/spec-review-variable-direction.md
+++ b/plans/spec-review-variable-direction.md
@@ -1,0 +1,518 @@
+## Spec Review: variable-direction — Pass 1 (2026-05-06)
+
+### New Issues
+
+#### Section: V. PR 3 — `get_diffs()` extensions
+
+---
+
+**Issue 1: Console output example contradicts the favorability logic table**
+Severity: BLOCKING
+Violates engineering-preferences.md §5 (explicit over clever); internal spec inconsistency.
+
+The favorability logic table (Section V) and the console output example directly contradict each other for rows 1 and 4.
+
+Logic table rules (for `higher_is = "worse"`):
+- Positive estimate + significant → `favorable = FALSE`, `backlash = TRUE`
+- Negative estimate + significant → `favorable = TRUE`, `backlash = FALSE`
+
+The example (annotated as `x = anxiety, higher_is = "worse"`):
+
+| Row | estimate | p_value | favorable (example) | backlash (example) | Per table |
+|-----|----------|---------|---------------------|--------------------|-----------|
+| 1   | +0.300   | 0.003   | TRUE                | FALSE              | favorable=FALSE, backlash=TRUE ❌ |
+| 2   | -0.200   | 0.048   | TRUE                | FALSE              | favorable=TRUE, backlash=FALSE ✅ |
+| 3   | +0.100   | 0.340   | FALSE               | FALSE              | ✅ |
+| 4   | -0.100   | 0.021   | FALSE               | TRUE               | favorable=TRUE, backlash=FALSE ❌ |
+
+Rows 1 and 4 have their `favorable` and `backlash` columns transposed in the example. An implementer following the example would produce the opposite classification from the one described in the table. The table is internally consistent with the footnote ("negative diff on a 'worse' variable is favorable"); the example is wrong.
+
+Options:
+- **[A]** Fix the example to match the table: row 1 → `FALSE TRUE`; row 4 → `TRUE FALSE`. — Effort: low, Risk: low, Impact: removes blocking ambiguity, Maintenance: none
+- **[B]** Fix the table to match the example — Effort: low, Risk: high (the table logic is correct; this would reverse the intended semantics), Impact: wrong output
+- **[C] Do nothing** — implementer guesses; 50% chance of incorrect output
+
+**Recommendation: A** — The logic table is correct and consistent with the footnote. Correct the example.
+
+---
+
+**Issue 2: `direction` parameter name collision across the PR series**
+Severity: REQUIRED
+Violates API Coherence (Lens 6) — same parameter name, opposite semantics in sister functions.
+
+The spec introduces `direction` with two unrelated meanings:
+
+- `set_higher_is(x, ..., variable = NULL, direction = NULL)` — `direction` is a character value: `"better"` or `"worse"`. It represents the semantic direction of a variable.
+- `get_diffs(..., direction = FALSE)` — `direction` is a boolean switch: `TRUE` means "add `favorable`/`backlash` columns." It is not a direction value.
+
+A user who reads `set_higher_is()` first will expect `direction` in `get_diffs()` to mean a direction value (e.g., `direction = "worse"`), or to override the stored `higher_is` attribute. Instead, `direction = TRUE` means "enable the direction-based classification feature." This is the kind of API confusion that survives all tests but causes workflow errors.
+
+The `get_diffs()` argument would be clearer as `show_direction`, `add_direction`, `classify`, or `favorability`.
+
+Options:
+- **[A]** Rename the `get_diffs()` argument. Candidates: `favorability = FALSE` (most self-documenting), `show_direction = FALSE` (mirrors column-name intent), `classify = FALSE` (compact). — Effort: low (spec edit only), Risk: low, Impact: eliminates naming collision before any code ships, Maintenance: none
+- **[B]** Keep the name but add a usage note in both functions' docs warning about the overloading — Effort: low, Risk: medium (users still see two `direction` params), Impact: partial mitigation
+- **[C] Do nothing** — collision ships; confusing at best, silent errors possible in workflows that use both
+
+**Recommendation: A** — `favorability = FALSE` is the clearest choice: it names the output concept (favorability classification) rather than the mechanism.
+
+---
+
+#### Section: III. PR 1 — `set_higher_is()` / `extract_higher_is()`
+
+---
+
+**Issue 3: `extract_higher_is()` error table missing ambiguous-input error class**
+Severity: REQUIRED
+Violates testing-standards.md §2 (every error table entry covered by a test).
+
+Behavior rule 2 for `extract_higher_is()` states: "Cannot supply both `...` and `variable`." This is enforced behavior, but no error class is listed in the error table for the extractor. The setter (`set_higher_is()`) defines `surveycore_error_higher_is_ambiguous_input` for this case, but the extractor's error table only lists:
+- `surveycore_error_not_survey_or_df`
+- `surveycore_warning_var_not_found`
+
+An error class is needed for the extractor's ambiguous-input case, and a corresponding test in the PR 1 test plan. The same gap exists for `extract_reverse_coded()` (Section IV, Issue 7 below).
+
+Options:
+- **[A]** Add `surveycore_error_higher_is_ambiguous_input` (same class as the setter) to the `extract_higher_is()` error table, and add a test block. — Effort: low, Risk: low, Impact: complete error coverage
+- **[B]** Define a separate extractor-specific class `surveycore_error_higher_is_extract_ambiguous_input` — Effort: low, Risk: low, Impact: finer-grained distinction, more classes to maintain
+- **[C] Do nothing** — behavior rule is stated but untestable; error message has no class=, violating code-style.md §3
+
+**Recommendation: A** — Reuse the setter's class for the same ambiguous-input condition; fewer classes, consistent semantics.
+
+---
+
+**Issue 4: Convention 3 — vector length mismatch between `variable` and `direction` is unspecified**
+Severity: REQUIRED
+Violates contract completeness (Lens 3) and engineering-preferences.md §4 (handle edge cases).
+
+The spec shows Convention 3 with vectorized usage:
+```r
+set_higher_is(x, variable = c("anxiety", "worry"), direction = c("worse", "worse"))
+```
+
+But it does not specify what happens when lengths differ:
+```r
+set_higher_is(x, variable = c("anxiety", "worry"), direction = "worse")
+# recycle? error? silently apply to first only?
+
+set_higher_is(x, variable = c("anxiety", "worry"), direction = c("worse", "better", "worse"))
+# error? truncate?
+```
+
+R's default recycling would silently use `"worse"` for both — which may be convenient — but no explicit decision is documented. Implementers and callers need to know whether recycling is intentional or an error.
+
+Options:
+- **[A]** State that scalar `direction` is recycled to match `variable` length; `direction` length > 1 and != `length(variable)` is `surveycore_error_direction_invalid` (or a new length-mismatch class). — Effort: low, Risk: low, Impact: natural behavior with explicit boundary
+- **[B]** Require `direction` length to exactly match `variable` length or be scalar; length mismatch → error — Effort: low, Risk: low
+- **[C] Do nothing** — recycling is implicit; a user passing `direction = c("worse", "better")` with three variables gets surprising silent behavior
+
+**Recommendation: A** — Scalar recycling is the most useful behavior and matches R conventions; explicit error for non-scalar, non-matching length.
+
+---
+
+**Issue 5: Missing test — `extract_higher_is()` and `extract_reverse_coded()` with `surveycore_error_not_survey_or_df`**
+Severity: REQUIRED
+Violates testing-standards.md §2 — every row in the error table covered by a test.
+
+Both extractor error tables list `surveycore_error_not_survey_or_df`, but neither function's test plan in Section VI includes a test block for this error. The setter test plans do include this case. The extractor test plans for PR 1 only list:
+- `direction_invalid` (setter)
+- `higher_is_ambiguous_input` (setter)
+- `higher_is_no_vars` (setter)
+- `var_not_found` (setter + extractor)
+
+No extractor-specific error path tests are listed for `not_survey_or_df`.
+
+Options:
+- **[A]** Add two test blocks to PR 1 test plan: `extract_higher_is(list(), anxiety)` → `surveycore_error_not_survey_or_df` with snapshot; `extract_reverse_coded(list(), anxiety)` → same. — Effort: low, Risk: none, Impact: completes error coverage
+- **[B] Do nothing** — missing tests; error class is implemented but untested
+
+**Recommendation: A** — required for test completeness.
+
+---
+
+#### Section: IV. PR 2 — `reverse_coded` attribute
+
+---
+
+**Issue 6: `extract_reverse_coded()` error table missing ambiguous-input error class (mirrors Issue 3)**
+Severity: REQUIRED
+
+Same gap as Issue 3. Behavior rule 2 for `extract_reverse_coded()` states "Cannot supply both `...` and `variable`," but the error table has no class for this case. `set_reverse_coded()` defines `surveycore_error_reverse_coded_ambiguous_input`, but the extractor's error table only lists `not_survey_or_df` and `var_not_found`.
+
+Options:
+- **[A]** Add `surveycore_error_reverse_coded_ambiguous_input` to `extract_reverse_coded()` error table and a test block. — Effort: low
+- **[B]** Separate extractor-specific class — see Issue 3 discussion
+- **[C] Do nothing** — same consequence as Issue 3
+
+**Recommendation: A**
+
+---
+
+#### Section: V. PR 3 — `get_diffs()` extensions (continued)
+
+---
+
+**Issue 7: `name_style = "broom"` behavior for `favorable`/`backlash` columns is unspecified**
+Severity: REQUIRED
+Violates contract completeness (Lens 3).
+
+`get_diffs()` supports `name_style = "broom"` which renames output columns (`p_value` → `p.value`, `ci_low` → `conf.low`, etc.). The spec introduces `favorable` and `backlash` as new output columns but does not specify their names under `name_style = "broom"`.
+
+Options:
+- **[A]** Declare that `favorable` and `backlash` are unaffected by `name_style` (they have no broom equivalents); document this explicitly. — Effort: low, Risk: low
+- **[B]** Define broom equivalents (e.g., same names — `favorable`, `backlash` — since these are already lower-case snake-case). — Effort: low
+- **[C] Do nothing** — implementer decides; inconsistent behavior possible
+
+**Recommendation: A** — The simplest correct answer: these are surveycore-native columns with no broom analogue; names are invariant across `name_style`.
+
+---
+
+**Issue 8: Missing test — `direction = TRUE` with `name_style = "broom"` (p.value column)**
+Severity: REQUIRED
+Violates testing-standards.md §2 (error paths / variant coverage).
+
+The spec states: "The p-value column used is `p_value` (surveycore name style) or `p.value` (broom name style) — whichever is present after `name_style` is applied." This is a conditional code path (check for `p_value` first, fall back to `p.value`). No test in the PR 3 test plan exercises the `name_style = "broom"` code path for favorability classification. Without this test, the broom branch is untested and could be broken silently.
+
+Options:
+- **[A]** Add a test: `get_diffs(d, x, treats, direction = TRUE, name_style = "broom")` — verify `favorable`/`backlash` columns are present and correctly classified using `p.value`. — Effort: low, Risk: none
+- **[B] Do nothing** — broom code path untested; regression risk high
+
+**Recommendation: A**
+
+---
+
+#### Section: VI. Testing
+
+---
+
+**Issue 9: Missing test — `extract_higher_is()` and `extract_reverse_coded()` returning `character(0)` / `logical(0)` when `variable` argument names don't match any column**
+Severity: REQUIRED
+Violates contract completeness (the zero-length return case is specified but not tested).
+
+The spec states: "If no variables match, returns a zero-length named `character(0)`" for `extract_higher_is()`. This case occurs when `variable = "nonexistent"` is passed and the warning fires (skipping), leaving an empty result. The test plan tests the warning but not the structure of the return value in that case. An implementer could return `NULL` or an unnamed vector and no test would catch it.
+
+Options:
+- **[A]** Add assertion to the `var_not_found` warning test: after the warning fires, verify the return value is `character(0)` (named, length 0) for `extract_higher_is()` and `logical(0)` (named) for `extract_reverse_coded()`. — Effort: low
+- **[B] Do nothing** — return value shape for zero-match case is untested
+
+**Recommendation: A**
+
+---
+
+#### Cross-cutting
+
+---
+
+**Issue 10: No shared variable-name resolution helper specified (DRY gap across all four functions)**
+Severity: SUGGESTION
+Violates engineering-preferences.md §1 (DRY — flag repetition aggressively).
+
+All four functions (`set_higher_is()`, `extract_higher_is()`, `set_reverse_coded()`, `extract_reverse_coded()`) must parse variable names from either tidy-select `...` or `variable = character`. This is the same logic in each. The spec does not mention a shared helper for this resolution — implementers will write it four times, or extract it informally.
+
+The existing metadata system likely already has `.resolve_tidy_select()` or a similar helper for the `extract_var_label()` / `set_var_label()` family. If so, that helper should be referenced. If not, a new shared helper should be specified.
+
+Options:
+- **[A]** Reference the existing resolution helper (name it in the spec) or declare a new internal helper (e.g., `.resolve_var_names(x, dots, variable)`) and specify that all four functions use it. — Effort: low, Risk: low, Impact: DRY-compliant, consistent behavior
+- **[B]** Leave as-is, trusting the implementer to extract naturally — Effort: none for spec, Risk: medium (four separate implementations that may diverge)
+- **[C] Do nothing**
+
+**Recommendation: A** — At minimum, name the existing helper if one exists; if not, add a shared-helper specification.
+
+---
+
+**Issue 11: Convention 2 for `set_higher_is()` — parsing complexity not specified**
+Severity: SUGGESTION
+Violates contract completeness (Lens 3) for an unusual code path.
+
+Convention 2 for `set_higher_is()` passes a named list as the sole argument to `...`:
+```r
+set_higher_is(x, list(anxiety = "worse", agreement = "better"))
+```
+This requires the function to detect: `...` length == 1 AND the element is an unnamed list with named entries. The spec does not describe this detection logic, what happens if the list is unnamed (`list("worse", "better")`), or whether this path reuses an existing helper from `set_variable_labels()`.
+
+`set_reverse_coded()` explicitly does NOT support Convention 2 (it follows `set_sata()`). The asymmetry is not called out.
+
+Options:
+- **[A]** Add a sentence specifying the Convention 2 detection rule (e.g., "if `...` contains exactly one unnamed list with named elements, treat as named pairs"), note the asymmetry with `set_reverse_coded()`, and reference any existing helper. — Effort: low
+- **[B]** Remove Convention 2 from the spec for `set_higher_is()` — Conventions 1 and 3 already cover all use cases — Effort: low, simplifies implementation
+- **[C] Do nothing** — implementer infers parsing logic
+
+**Recommendation: A** — Convention 2 is a valid convenience; just specify the detection rule so it's unambiguous.
+
+---
+
+**Issue 12: Missing test — `direction = TRUE` with `group` argument in `get_diffs()`**
+Severity: SUGGESTION
+Applies testing-standards.md Lens 2 category 3 (grouped analysis).
+
+The PR 3 test plan does not include a test for `direction = TRUE` combined with `group`. Since `favorable`/`backlash` are appended row-by-row from the p-value column, they should work transparently with grouping — but this is unverified. Group output multiplies rows, and the column-append logic should apply identically. A test would confirm no off-by-one or row-alignment bug.
+
+Options:
+- **[A]** Add one happy-path test: `get_diffs(d, x, treats, group = g, direction = TRUE)` — verify `favorable`/`backlash` columns appear and rows align correctly per group. — Effort: low
+- **[B] Do nothing** — grouped behavior is probably correct but unconfirmed
+
+**Recommendation: A** — Low effort, closes an obvious gap.
+
+---
+
+## Summary (Pass 1)
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 1 |
+| REQUIRED | 8 |
+| SUGGESTION | 3 |
+
+**Total issues:** 12
+
+**Overall assessment:** The spec is close to implementable — the architecture is sound and the metadata property design is solid — but a factual error in the PR 3 console example (rows 1 and 4 have transposed `favorable`/`backlash` values) must be fixed before any code is written. Seven of the eight REQUIRED issues are small test-plan or contract gaps that can be resolved in Stage 4 with minimal spec edits.
+
+---
+
+## Spec Review: variable-direction — Pass 2 (2026-05-07)
+
+### Prior Issues (Pass 1)
+
+| # | Title | Status |
+|---|---|---|
+| 1 | Console output example contradicts the favorability logic table | ✅ Resolved |
+| 2 | `direction` parameter name collision across the PR series | ✅ Resolved — renamed to `show_favorability` |
+| 3 | `extract_higher_is()` error table missing ambiguous-input error class | ✅ Resolved |
+| 4 | Convention 3 — vector length mismatch between `variable` and `direction` is unspecified | ✅ Resolved |
+| 5 | Missing test — `extract_higher_is()` and `extract_reverse_coded()` with `surveycore_error_not_survey_or_df` | ✅ Resolved |
+| 6 | `extract_reverse_coded()` error table missing ambiguous-input error class | ✅ Resolved |
+| 7 | `name_style = "broom"` behavior for `favorable`/`backlash` columns is unspecified | ✅ Resolved |
+| 8 | Missing test — `direction = TRUE` with `name_style = "broom"` | ✅ Resolved |
+| 9 | Missing test — `extract_higher_is()` and `extract_reverse_coded()` returning `character(0)` / `logical(0)` | ✅ Resolved |
+| 10 | No shared variable-name resolution helper specified (DRY gap across all four functions) | ✅ Resolved |
+| 11 | Convention 2 for `set_higher_is()` — parsing complexity not specified | ✅ Resolved |
+| 12 | Missing test — `direction = TRUE` with `group` argument in `get_diffs()` | ✅ Resolved |
+
+### New Issues
+
+#### Section: VI. Testing — PR 1 test plan
+
+**Issue 1: Convention 2 has no test in the PR 1 test plan**
+Severity: REQUIRED
+Violates testing-standards.md §2 — every supported calling convention must be exercised.
+
+The spec explicitly declares Convention 2 as a supported calling convention for `set_higher_is()`:
+```r
+set_higher_is(x, c(anxiety = "worse", agreement = "better"))
+```
+And specifies a distinct detection rule (handled by `.parse_setter_input()`: exactly one unnamed element that is a named character vector). This is a real, documented code path. The PR 1 happy-path test plan covers Convention 1 and Convention 3 but contains no test for Convention 2. An implementer who misdetects Convention 2 inputs would have no failing test to catch the bug.
+
+Options:
+- **[A]** Add one happy-path test for Convention 2: `set_higher_is(x, c(anxiety = "worse", agreement = "better"))` stores both values correctly. — Effort: low, Risk: none, Impact: closes untested code path, Maintenance: none
+- **[B]** Remove Convention 2 from the spec entirely (Conventions 1 and 3 already cover all use cases) — Effort: low, Risk: low (breaks a documented feature before it ships), Impact: simpler API
+- **[C] Do nothing** — Convention 2 ships untested; detection bugs are undetectable
+
+**Recommendation: A** — Convention 2 is already spec'd; one test line closes the gap.
+
+---
+
+#### Section: VI. Testing — PR 3 test plan
+
+**Issue 2: Column `label` attributes on `favorable`/`backlash` not tested**
+Severity: REQUIRED
+Violates testing-standards.md §2 — all specified output properties must be covered by a test.
+
+The spec explicitly specifies in the output contract:
+```
+attr(result$favorable, "label") <- "Favorable"
+attr(result$backlash, "label") <- "Backlash"
+```
+The PR 3 test plan has no assertion verifying these attribute values. If an implementer forgets to set them (or sets wrong strings), no test would catch it. Every other `get_*()` column label attribute is tested via the existing test suite; `favorable` and `backlash` should be no different.
+
+Options:
+- **[A]** Add an assertion in the `show_favorability = TRUE` happy-path test: `expect_identical(attr(result$favorable, "label"), "Favorable")` and `expect_identical(attr(result$backlash, "label"), "Backlash")`. — Effort: low, Risk: none, Impact: closes specified-but-untested output contract
+- **[B] Do nothing** — label attributes are specified but untested; regression risk present
+
+**Recommendation: A** — The spec explicitly defines these attributes; one assertion per column closes the gap.
+
+---
+
+**Issue 3: `alpha = NA` and `alpha = Inf` explicitly named as invalid but absent from the test plan**
+Severity: REQUIRED
+Violates testing-standards.md §2 — every row in the error table covered by a test; behavior-rule-1 names specific invalid values.
+
+Behavior rule 1 explicitly lists the invalid values for `alpha`: `NA`, `Inf`, `0`, `1`, and non-numeric. The test plan covers three of them (`alpha = 1.5`, `alpha = 0`, `alpha = "0.05"`) but omits:
+- `alpha = NA` — explicitly listed in rule 1; `is.finite(NA)` is `FALSE` so this must be caught, but whether the error class fires correctly on `NA` input to `cli_abort()` formatting (specifically `{.val {alpha}}` with an NA value) needs testing
+- `alpha = Inf` — explicitly listed in rule 1; `is.finite(Inf)` is `FALSE`, so the same validation path handles it — but it's named in the spec and absent from the test plan
+- `alpha = c(0.05, 0.1)` — implied by "single" in "single numeric value"; non-scalar input is a realistic mistake and the `{.val {alpha}}` formatting with a vector should be verified
+
+Options:
+- **[A]** Add three test blocks (or expand the existing `alpha_invalid` block): `alpha = NA`, `alpha = Inf`, `alpha = c(0.05, 0.1)`. — Effort: low, Risk: none, Impact: closes three named invalid cases; confirms `cli_abort()` message renders correctly for each
+- **[B]** Add only `alpha = NA` and `alpha = Inf` (the two explicitly named); treat non-scalar as implied by "single" — Effort: low, Risk: low
+- **[C] Do nothing** — three named invalid inputs are untested; the message-rendering behavior for NA/vector is unverified
+
+**Recommendation: A** — All three are realistic user mistakes; the cost is three lines.
+
+---
+
+#### Section: VI. Testing — PR 3, `.meta` contract
+
+**Issue 4: `.meta$higher_is` test says "is populated" rather than asserting the actual value**
+Severity: SUGGESTION
+Violates engineering-preferences.md §5 (explicit over clever).
+
+The PR 3 happy-path test says:
+> `show_favorability = FALSE` (default): no `favorable`/`backlash` columns in result; `.meta$x[[x_name]]$higher_is` is populated
+
+"Is populated" is ambiguous — an implementer could write `expect_true(!is.null(...))` and pass. The test should assert the actual value, e.g.:
+```r
+expect_identical(attr(result, ".meta")$x[[x_name]]$higher_is, "worse")
+```
+This confirms the value flows through `.extract_var_meta()` correctly, not just that the key exists.
+
+Options:
+- **[A]** Change the test description to assert the actual value: `...higher_is` equals `"worse"` (using the "worse" variable from the test setup). — Effort: low
+- **[B]** Keep "is populated" — a non-NULL check is the intent — Effort: none, Risk: low
+- **[C] Do nothing** — current language is ambiguous but functional
+
+**Recommendation: A** — One word change to the test spec; forces a stronger assertion without any implementation cost.
+
+---
+
+## Summary (Pass 2)
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 0 |
+| REQUIRED | 3 |
+| SUGGESTION | 1 |
+
+**Total new issues:** 4
+
+**Overall assessment:** All 12 Pass 1 issues are resolved — the spec is substantially improved. The remaining gaps are confined to the test plan: Convention 2 is untested, column label attributes are unverified, and three explicitly-named invalid `alpha` values are absent from the error-path tests. None are blockers; all require only small additions to the Section VI test plan. The spec is ready to implement after resolving these three REQUIRED items.
+
+---
+
+## Spec Review: variable-direction — Pass 3 (2026-05-07)
+
+### Prior Issues (Pass 2)
+
+| # | Title | Status |
+|---|---|---|
+| 1 | Convention 2 has no test in the PR 1 test plan | ✅ Resolved |
+| 2 | Column `label` attributes on `favorable`/`backlash` not tested | ✅ Resolved |
+| 3 | `alpha = NA` and `alpha = Inf` explicitly named as invalid but absent from the test plan | ✅ Resolved |
+| 4 | `.meta$higher_is` test says "is populated" rather than asserting the actual value | ✅ Resolved |
+
+### New Issues
+
+#### Section: I. Scope
+
+**Issue 1: §I scope table lists `direction` instead of `show_favorability` for PR 3**
+Severity: REQUIRED
+Internal spec inconsistency; originally surfaced in plan-review Pass 1 Issue 6 but not yet fixed in the spec.
+
+The scope table row for PR 3 reads:
+> `| 3 | \`get_diffs()\` extensions | \`alpha\`, \`direction\` arguments; \`favorable\`/\`backlash\` columns; \`.meta\` enrichment |`
+
+The argument was renamed to `show_favorability` when Pass 1 Issue 2 (spec-review) was resolved. The spec body (§V argument table, §VI test plan, §VII quality gates) consistently uses `show_favorability`. The scope table alone carries the stale name.
+
+Options:
+- **[A]** Change the scope table entry: `\`alpha\`, \`show_favorability\` arguments; ...` — Effort: trivial, Risk: none, Impact: scope table matches the body, Maintenance: none
+- **[B] Do nothing** — Spec body is correct; the table is vestigial and implementers reading the body won't be misled
+
+**Recommendation: A** — A reviewer scanning only the scope table would see the wrong argument name.
+
+---
+
+### Summary (Pass 3)
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 0 |
+| REQUIRED | 1 |
+| SUGGESTION | 0 |
+
+**Total new issues:** 1
+
+**Overall assessment:** The spec is in excellent shape. All four Pass 2 issues are resolved. One vestigial `direction` in the §I scope table is the only remaining fix. The outstanding work (coverage criterion, Convention 3 test gaps, favorability block placement) lives in the implementation plan, not the spec. After correcting the scope table entry, the spec is fully ready for `/r-implement`.
+
+---
+
+## Spec Review: variable-direction — Pass 4 (2026-05-07)
+
+### Prior Issues (Pass 3)
+
+| # | Title | Status |
+|---|---|---|
+| 1 | §I scope table lists `direction` instead of `show_favorability` | ⚠️ Still open — spec line 32 unchanged |
+
+### New Issues
+
+#### Section: III. PR 1 — `set_higher_is()`
+
+**Issue 1: `surveycore_error_setter_mixed_dots` referenced in Convention 2 description but absent from the error table**
+Severity: REQUIRED
+Violates contract completeness (Lens 3) and testing-standards.md §2 — every reachable error class must be in the table and tested.
+
+The spec states in the Convention 2 detection note:
+> "An unnamed list or a mixed named/unnamed `...` is not Convention 2 — it errors with `surveycore_error_setter_mixed_dots`."
+
+This error class is reachable via `set_higher_is()` but does not appear anywhere in its error table. The table lists five classes; `setter_mixed_dots` is not among them. It is also absent from every test block in the PR 1 test plan. An implementer reading the test plan has no guidance that this error path must be exercised.
+
+Whether this is an existing class (from `.parse_setter_input()`) or a new one, two changes are needed: (1) add it to the error table with "(existing class)" if it pre-exists, and (2) add a test block — e.g., `set_higher_is(x, list(anxiety = "worse"))` errors with `surveycore_error_setter_mixed_dots`.
+
+Options:
+- **[A]** Add `surveycore_error_setter_mixed_dots` to the `set_higher_is()` error table (mark existing if it is), and add a test block: `set_higher_is(x, list(anxiety = "worse"))` errors with that class. — Effort: low, Risk: none, Impact: complete error coverage, Maintenance: none
+- **[B]** Document that this class is delegated to `.parse_setter_input()` and therefore outside the `set_higher_is()` error contract — explicitly state no test is needed — Effort: low, Risk: low (but leaves an untested reachable error path)
+- **[C] Do nothing** — error fires in production with no test; class is not in the table
+
+**Recommendation: A** — The class is reachable via a documented input; it belongs in the table and must be tested.
+
+---
+
+#### Section: VI. Testing — PR 3 test plan
+
+**Issue 2: Print snapshot missing for `survey_diffs` with `show_favorability = TRUE`**
+Severity: REQUIRED
+Violates testing-standards.md Lens 2 category 13 — print snapshot required for every result class with a `print()` method.
+
+The spec's §V console output example shows a 9-column `survey_diffs` output:
+```
+# A <survey_diffs> [4 × 9]
+  treatment  estimate    se  ci_low ci_high p_value stars favorable backlash
+```
+This confirms `survey_diffs` has a print method and that `show_favorability = TRUE` produces a distinct column layout. The PR 3 test plan does not include a snapshot test for this output. The existing `test-analysis-diffs.R` snapshots test the baseline (without `favorable`/`backlash` columns); the new layout is tested only via column-presence and value assertions, not a print snapshot. Formatting bugs — wrong column width, missing `<lgl>` type header, alignment issues — would not be caught.
+
+Options:
+- **[A]** Add a `expect_snapshot(print(result))` call to the `show_favorability = TRUE` happy-path test block, using the design from the §V example. — Effort: low, Risk: none, Impact: closes the only unsnapshotted `survey_diffs` output variant, Maintenance: update snapshot intentionally if print format changes
+- **[B]** Rely on the existing column-value assertions; treat print format as implicit — Effort: none, Risk: medium (formatting regressions undetected)
+- **[C] Do nothing** — new print layout ships without a snapshot test
+
+**Recommendation: A** — Category 13 is non-negotiable per testing-standards.md; the example in §V already defines the expected output.
+
+---
+
+#### Section: VI. Testing — PR 1 test plan
+
+**Issue 3: `direction = NA` not tested for `set_higher_is()` direction_invalid error**
+Severity: SUGGESTION
+Consistent with Pass 2 Issue 3 (`alpha = NA` was REQUIRED there; same pattern here).
+
+Behavior rule 2 states `direction` must be `"better"`, `"worse"`, or `NULL` — "any other value is an error." The test plan exercises only `direction = "neutral"` for the `direction_invalid` class. `NA` is a realistic mistake (`direction = NA_character_` is easy to produce accidentally from a lookup that returns NA) and hits the same validation path. No test currently verifies that `surveycore_error_direction_invalid` fires — and that the `{.val {direction}}` CLI formatting renders correctly — for an NA input.
+
+Options:
+- **[A]** Add `set_higher_is(x, anxiety = NA_character_)` to the `direction_invalid` test block (or a separate block). — Effort: low, Risk: none, Impact: confirms NA renders correctly in the error message
+- **[B]** Accept the `"neutral"` test as sufficient; NA is the same code path — Effort: none, Risk: low (NA CLI rendering is slightly different than character)
+- **[C] Do nothing** — NA case untested; CLI formatting with NA unverified
+
+**Recommendation: A** — The `alpha = NA` precedent in Pass 2 was REQUIRED; direction NA is the same issue, just in a different argument. One test line.
+
+---
+
+## Summary (Pass 4)
+
+| Severity | Count |
+|---|---|
+| BLOCKING | 0 |
+| REQUIRED | 2 |
+| SUGGESTION | 1 |
+
+**Total new issues:** 3
+
+**Overall assessment:** The spec remains in excellent shape after 3 passes — all prior blocking and most required issues are resolved. The three new issues are confined to one contract gap (Convention 2 error class absent from the error table) and two test-plan gaps (print snapshot for the new column layout, NA direction input). Pass 3 Issue 1 (scope table stale name) is still unresolved. Resolve these four items and the spec is implementation-ready.

--- a/plans/spec-variable-direction.md
+++ b/plans/spec-variable-direction.md
@@ -1,0 +1,586 @@
+---
+Version: 0.4
+Date: 2026-05-07
+Status: Approved
+---
+
+# Spec: Variable Direction Attributes
+
+## Document Purpose
+
+This spec defines two new item-level metadata attributes for survey variables
+(`higher_is` and `reverse_coded`), the setters and extractors for each, and
+targeted extensions to `get_diffs()` that use `higher_is` to classify results
+as favorable or backlash. It is the authoritative source of truth for three
+sequential PRs.
+
+---
+
+## I. Scope
+
+### What this spec delivers
+
+| PR | Deliverable | Description |
+|----|-------------|-------------|
+| 1 | `higher_is` property on `survey_metadata` | New list property storing direction per variable |
+| 1 | `set_higher_is()` | Set direction attribute for one or more variables |
+| 1 | `extract_higher_is()` | Retrieve direction attribute for one or more variables |
+| 1 | `.extract_var_meta()` update | Include `higher_is` so it flows into all analysis `.meta` |
+| 2 | `reverse_coded` property on `survey_metadata` | New list property storing reverse-coding flag per variable |
+| 2 | `set_reverse_coded()` | Set reverse-coded flag for one or more variables |
+| 2 | `extract_reverse_coded()` | Retrieve reverse-coded flag for one or more variables |
+| 3 | `get_diffs()` extensions | `alpha`, `show_favorability` arguments; `favorable`/`backlash` columns; `.meta` enrichment |
+
+### What this spec does NOT deliver
+
+- `compute_scale()`, row-means, or row-sums functions — `reverse_coded` is
+  infrastructure only; there is no consumer yet
+- Changes to any `get_*()` function other than `get_diffs()`
+- Automatic scale scoring or reversal
+
+### Design/class support matrix
+
+PRs 1 and 2 (setters/extractors): `survey_taylor`, `survey_replicate`,
+`survey_twophase`, plain `data.frame`.
+
+PR 3 (`get_diffs()` extensions): all design types supported by the current
+`get_diffs()` implementation.
+
+---
+
+## II. Architecture
+
+### File changes
+
+```
+R/
+  core-classes.R          # Add higher_is and reverse_coded properties to survey_metadata
+  core-metadata.R         # Add set_higher_is(), extract_higher_is(),
+                          #     set_reverse_coded(), extract_reverse_coded()
+  analysis-helpers.R      # Update .extract_var_meta() to include higher_is
+  analysis-diffs.R        # Add alpha, show_favorability arguments; favorable/backlash logic
+
+tests/testthat/
+  test-metadata-system.R  # PR 1 and PR 2 tests (existing file)
+  test-analysis-diffs.R   # PR 3 tests (existing file)
+
+plans/
+  error-messages.md       # New error/warning classes for all three PRs
+```
+
+### Variable name resolution patterns
+
+All four functions resolve variable names from either tidy-select `...` or
+`variable = character`. Follow these existing patterns — do not write new
+resolution logic:
+
+| Function | Pattern to follow |
+|----------|-------------------|
+| `set_higher_is()` | `.parse_setter_input()` with `content_type = "scalar"` (same as `set_var_label()`) |
+| `set_reverse_coded()` | Inline `set_sata()` pattern: manual ambiguous-input check, then `tidyselect::eval_select` for `...` or direct `variable` vector |
+| `extract_higher_is()` | Inline `extract_var_label()` pattern: `tidyselect::eval_select(rlang::expr(c(...)), ...)` for `...`; `.get_data_cols(x)` when `...` is empty |
+| `extract_reverse_coded()` | Same as `extract_higher_is()` |
+
+---
+
+### Key shared helper
+
+`.extract_var_meta(design, var_name)` in `R/analysis-helpers.R` — updated in
+PR 1 to include `higher_is`. After PR 1, its return list will be:
+
+```r
+list(
+  variable_label  = character(1) or NULL,
+  question_preface = character(1) or NULL,
+  value_labels    = named vector or NULL,
+  sata            = logical(1),
+  higher_is       = "better" | "worse" | NULL
+)
+```
+
+This update is free — every analysis function that calls `.extract_var_meta()`
+will automatically carry `higher_is` in its `.meta` without further changes.
+
+---
+
+## III. PR 1 — `higher_is` attribute
+
+### `survey_metadata` property
+
+Add to `survey_metadata` in `R/core-classes.R`:
+
+```r
+higher_is = S7::new_property(
+  S7::class_list,
+  default = quote(list())
+)
+```
+
+Each entry maps a variable name (character key) to `"better"` or `"worse"`.
+Absent keys mean the attribute is unset for that variable.
+
+---
+
+### `set_higher_is()`
+
+**Signature:**
+```r
+set_higher_is(x, ..., variable = NULL, direction = NULL)
+```
+
+Follows the `set_var_label()` pattern. `direction` is the scalar content
+argument (parallel to `label` in `set_var_label()`).
+
+**Argument table:**
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `x` | survey design or `data.frame` | required | Object to modify |
+| `...` | named pairs | — | Variable-direction pairs, e.g. `anxiety = "worse"` |
+| `variable` | `character` | `NULL` | Variable name(s); use with `direction` |
+| `direction` | `character` or `NULL` | `NULL` | `"better"`, `"worse"`, or `NULL` to unset |
+
+**Calling conventions (three supported, matching `set_var_label()`):**
+
+Convention 1 — named `...` (recommended):
+```r
+set_higher_is(x, anxiety = "worse", agreement = "better")
+```
+
+Convention 2 — single named character vector in `...`:
+```r
+set_higher_is(x, c(anxiety = "worse", agreement = "better"))
+```
+Detection rule (handled by `.parse_setter_input()`): `...` contains exactly one
+unnamed element that is a named character vector with no empty names. An unnamed
+list or a mixed named/unnamed `...` is not Convention 2 — it errors with
+`surveycore_error_setter_mixed_dots`.
+
+Note: `set_reverse_coded()` does **not** support Convention 2 — it follows the
+`set_sata()` inline pattern, which only supports Conventions 1 and 3.
+
+Convention 3 — `variable` + `direction`:
+```r
+set_higher_is(x, variable = "anxiety", direction = "worse")
+set_higher_is(x, variable = c("anxiety", "worry"), direction = c("worse", "worse"))
+```
+
+**Unsetting (pass `NULL` as direction):**
+```r
+set_higher_is(x, anxiety = NULL)
+set_higher_is(x, variable = "anxiety", direction = NULL)
+```
+
+**Output contract:**
+- Returns `invisible(x)` — see `surveycore-conventions.md §2` (setter return)
+- For survey objects: writes to `x@metadata@higher_is[[var_name]]`
+- For data frames: writes to `attr(x[[var_name]], "higher_is")`
+- `NULL` direction removes the entry
+
+**Behavior rules:**
+1. Variable names not found in `x` are skipped with `surveycore_warning_var_not_found`
+2. `direction` must be `"better"`, `"worse"`, or `NULL`; any other value is an error
+3. Cannot supply both `...` and `variable` simultaneously
+4. At least one variable name must be provided
+5. In Convention 3, `direction` must be the same length as `variable`, or `NULL` (applies to all); length mismatch is `surveycore_error_setter_mismatched_lengths` (existing class from `.parse_setter_input()`)
+
+**Error table:**
+
+| Class | Trigger | Message template |
+|-------|---------|-----------------|
+| `surveycore_error_not_survey_or_df` | `x` is not a survey object or data frame | `"{.arg x} must be a survey design object or data frame."` |
+| `surveycore_error_direction_invalid` | `direction` is not `"better"`, `"worse"`, or `NULL` | `"{.arg direction} must be {.val \"better\"}, {.val \"worse\"}, or {.code NULL}. Got {.val {direction}}."` |
+| `surveycore_error_higher_is_ambiguous_input` | Both `...` and `variable` supplied | `"Provide variable names via {.arg ...} or {.arg variable}, not both."` |
+| `surveycore_error_higher_is_no_vars` | No variable names provided | `"{.fn set_higher_is} requires at least one variable name."` |
+| `surveycore_error_setter_mismatched_lengths` | `direction` and `variable` lengths differ (Convention 3) | (existing class; message from `.parse_setter_input()`) |
+| `surveycore_error_setter_mixed_dots` | `...` is an unnamed list or mixed named/unnamed (invalid Convention 2 input) | (existing class; message from `.parse_setter_input()`) |
+| `surveycore_warning_var_not_found` | Variable name not in `x` | `"Variable {.field {var_name}} not found in {.arg x} and was skipped."` (existing class) |
+
+---
+
+### `extract_higher_is()`
+
+**Signature:**
+```r
+extract_higher_is(x, ..., variable = NULL)
+```
+
+**Argument table:**
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `x` | survey design or `data.frame` | required | Object to query |
+| `...` | tidy-select | — | Variable names (bare); omit to return all variables |
+| `variable` | `character` | `NULL` | Variable name(s) as character; alternative to `...` |
+
+**Output contract:**
+- Returns a named `character` vector
+- Names are variable names; values are `"better"`, `"worse"`, or `NA_character_`
+  (unset variables return `NA_character_`, not `NULL`)
+- If no variables are specified (`...` empty, `variable = NULL`), returns all
+  variables in `x` (including those with `NA_character_`)
+- If no variables match, returns a zero-length named `character(0)`
+- For survey objects: reads from `x@metadata@higher_is`
+- For data frames: reads from `attr(x[[var]], "higher_is")`
+
+**Examples:**
+```r
+d <- set_higher_is(d, anxiety = "worse", agreement = "better")
+
+extract_higher_is(d, anxiety)
+#>   anxiety
+#> "worse"
+
+extract_higher_is(d, c(anxiety, agreement))
+#>    anxiety  agreement
+#>    "worse"  "better"
+
+extract_higher_is(d)  # all variables; unset → NA_character_
+#>    anxiety  agreement     income
+#>    "worse"  "better"         NA
+```
+
+**Behavior rules:**
+1. Variables with no `higher_is` set return `NA_character_` (not `NULL`)
+2. Cannot supply both `...` and `variable`
+3. Returns visible (not `invisible`)
+
+**Error table:**
+
+| Class | Trigger | Message template |
+|-------|---------|-----------------|
+| `surveycore_error_not_survey_or_df` | `x` is not a survey object or data frame | `"{.arg x} must be a survey design object or data frame."` |
+| `surveycore_error_higher_is_ambiguous_input` | Both `...` and `variable` supplied | `"Provide variable names via {.arg ...} or {.arg variable}, not both."` (same class as setter) |
+| `surveycore_warning_var_not_found` | Named variable not in `x` | `"Variable {.field {var_name}} not found in {.arg x} and was skipped."` (existing class) |
+
+---
+
+## IV. PR 2 — `reverse_coded` attribute
+
+### `survey_metadata` property
+
+Add to `survey_metadata` in `R/core-classes.R`:
+
+```r
+reverse_coded = S7::new_property(
+  S7::class_list,
+  default = quote(list())
+)
+```
+
+Each entry maps a variable name to `TRUE`. Absent keys mean the variable is
+not reverse-coded. There is no stored `FALSE` — absence equals `FALSE`.
+
+---
+
+### `set_reverse_coded()`
+
+`reverse_coded` is boolean — follows the `set_sata()` pattern. Variable names
+go in `...` or `variable`; the boolean value is a separate argument.
+
+**Signature:**
+```r
+set_reverse_coded(x, ..., variable = NULL, reverse_coded = TRUE)
+```
+
+**Argument table:**
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `x` | survey design or `data.frame` | required | Object to modify |
+| `...` | tidy-select | — | Variable names (bare) to flag |
+| `variable` | `character` | `NULL` | Variable name(s) as character; alternative to `...` |
+| `reverse_coded` | `logical(1)` | `TRUE` | `TRUE` to flag; `FALSE` to unset |
+
+**Calling conventions (matching `set_sata()`):**
+```r
+# Flag variables
+set_reverse_coded(x, anxiety, worry)
+
+# Unset
+set_reverse_coded(x, anxiety, reverse_coded = FALSE)
+
+# Via variable argument
+set_reverse_coded(x, variable = c("anxiety", "worry"))
+```
+
+**Output contract:**
+- Returns `invisible(x)`
+- When `reverse_coded = TRUE`: `x@metadata@reverse_coded[[var_name]] <- TRUE`
+- When `reverse_coded = FALSE`: removes the entry (sets to `NULL`)
+- For data frames: `attr(x[[var_name]], "reverse_coded") <- TRUE` or `NULL`
+
+**Behavior rules:**
+1. Variable names not found in `x` are skipped with `surveycore_warning_var_not_found`
+2. `reverse_coded` must be `TRUE` or `FALSE`; `NA` is an error
+3. Cannot supply both `...` and `variable`
+4. At least one variable name must be provided
+
+**Error table:**
+
+| Class | Trigger | Message template |
+|-------|---------|-----------------|
+| `surveycore_error_not_survey_or_df` | `x` is not a survey object or data frame | `"{.arg x} must be a survey design object or data frame."` |
+| `surveycore_error_reverse_coded_not_logical` | `reverse_coded` is not `TRUE` or `FALSE` | `"{.arg reverse_coded} must be {.code TRUE} or {.code FALSE}."` |
+| `surveycore_error_reverse_coded_ambiguous_input` | Both `...` and `variable` supplied | `"Provide variable names via {.arg ...} or {.arg variable}, not both."` |
+| `surveycore_error_reverse_coded_no_vars` | No variable names provided | `"{.fn set_reverse_coded} requires at least one variable name."` |
+| `surveycore_warning_var_not_found` | Variable name not in `x` | `"Variable {.field {var_name}} not found in {.arg x} and was skipped."` (existing class) |
+
+---
+
+### `extract_reverse_coded()`
+
+**Signature:**
+```r
+extract_reverse_coded(x, ..., variable = NULL)
+```
+
+**Argument table:**
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `x` | survey design or `data.frame` | required | Object to query |
+| `...` | tidy-select | — | Variable names (bare); omit to return all variables |
+| `variable` | `character` | `NULL` | Variable name(s) as character; alternative to `...` |
+
+**Output contract:**
+- Returns a named `logical` vector
+- Names are variable names; values are `TRUE` or `FALSE`
+- Variables with no `reverse_coded` flag return `FALSE` (boolean semantics;
+  contrast with `extract_higher_is()` which returns `NA_character_` for unset)
+- If no variables are specified, returns all variables in `x`
+- Returns visible
+
+**Examples:**
+```r
+d <- set_reverse_coded(d, anxiety, worry)
+
+extract_reverse_coded(d, anxiety)
+#>  anxiety
+#>     TRUE
+
+extract_reverse_coded(d)  # all variables; unset → FALSE
+#>    anxiety     worry    income
+#>       TRUE      TRUE     FALSE
+```
+
+**Behavior rules:**
+1. Variables with no flag return `FALSE`, not `NA`
+2. Cannot supply both `...` and `variable`
+
+**Error table:**
+
+| Class | Trigger | Message template |
+|-------|---------|-----------------|
+| `surveycore_error_not_survey_or_df` | `x` is not a survey object or data frame | `"{.arg x} must be a survey design object or data frame."` |
+| `surveycore_error_reverse_coded_ambiguous_input` | Both `...` and `variable` supplied | `"Provide variable names via {.arg ...} or {.arg variable}, not both."` (same class as setter) |
+| `surveycore_warning_var_not_found` | Named variable not in `x` | `"Variable {.field {var_name}} not found in {.arg x} and was skipped."` (existing class) |
+
+---
+
+## V. PR 3 — `get_diffs()` extensions
+
+PR 3 depends on PR 1 being merged. It must not be opened until `higher_is` is
+available on `survey_metadata` and in `.extract_var_meta()`.
+
+### New arguments
+
+Two new optional scalar arguments, placed after `conf_level` and before
+`min_cell_n` to group them with other inference-control parameters:
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `alpha` | `numeric(1)` | `0.05` | Significance threshold for `favorable`/`backlash` classification; must be in (0, 1) exclusive |
+| `show_favorability` | `logical(1)` | `FALSE` | If `TRUE`, add `favorable` and `backlash` columns to output |
+
+### Favorability logic
+
+`higher_is` is read from the design for the `x` variable (via `.meta` populated
+by `.extract_var_meta()`). The p-value column used is `p_value` (surveycore
+name style) or `p.value` (broom name style) — whichever is present after
+`name_style` is applied.
+
+| `higher_is` | `estimate` sign | `p < alpha`? | `favorable` | `backlash` |
+|-------------|-----------------|--------------|-------------|------------|
+| `"better"` | positive | yes | `TRUE` | `FALSE` |
+| `"better"` | negative | yes | `FALSE` | `TRUE` |
+| `"worse"` | negative | yes | `TRUE` | `FALSE` |
+| `"worse"` | positive | yes | `FALSE` | `TRUE` |
+| any | any | no (p ≥ alpha) | `FALSE` | `FALSE` |
+| `NULL` (unset) | any | any | `FALSE` | `FALSE` |
+
+Significance comparison is **strict**: `p < alpha`, not `p <= alpha`.
+
+### Output changes
+
+**New columns (when `show_favorability = TRUE`):**
+
+| Column | Type | Values | Description |
+|--------|------|--------|-------------|
+| `favorable` | `logical` | `TRUE`/`FALSE` | Significant movement in the good direction |
+| `backlash` | `logical` | `TRUE`/`FALSE` | Significant movement in the bad direction |
+
+Columns are appended after the last existing column. Column-level `label`
+attributes follow the same pattern as other columns:
+- `attr(result$favorable, "label") <- "Favorable"`
+- `attr(result$backlash, "label") <- "Backlash"`
+
+`favorable` and `backlash` are surveycore-native columns with no broom
+equivalent. Their names are invariant across `name_style` — they are always
+`favorable` and `backlash` regardless of whether `name_style = "surveycore"`
+or `name_style = "broom"` is used.
+
+**`.meta` enrichment (always, regardless of `show_favorability`):**
+
+PR 1's `.extract_var_meta()` update means `x_meta` in `get_diffs()` already
+includes `higher_is`. No additional `.meta` wiring is needed in PR 3 — the
+value is accessible at `attr(result, ".meta")$x[[x_name]]$higher_is`.
+
+**Console output example (with `show_favorability = TRUE`, `name_style = "surveycore"`):**
+
+```
+# A <survey_diffs> [4 × 9]
+  treatment  estimate    se  ci_low ci_high p_value stars favorable backlash
+  <chr>         <dbl> <dbl>   <dbl>   <dbl>   <dbl> <chr> <lgl>     <lgl>
+1 Message A     0.300 0.100   0.104   0.496   0.003  **    FALSE     TRUE
+2 Message B    -0.200 0.100  -0.396  -0.004   0.048  *     TRUE      FALSE
+3 Message C     0.100 0.100  -0.096   0.296   0.340        FALSE     FALSE
+4 Message D    -0.100 0.100  -0.296   0.004   0.021  *     TRUE      FALSE
+```
+
+*(`x = anxiety`, `higher_is = "worse"` — negative diff on a "worse" variable is favorable)*
+
+**Behavior rules:**
+1. `alpha` must be a single finite numeric in (0, 1) exclusive; `NA`, `Inf`,
+   `0`, `1`, or non-numeric values are an error
+2. `show_favorability = FALSE` (default): no `favorable`/`backlash` columns; `higher_is`
+   is still present in `.meta` via the PR 1 `.extract_var_meta()` update
+3. `show_favorability = TRUE` with `higher_is` unset on the `x` variable: both columns
+   all `FALSE`; no warning (the user set `show_favorability = TRUE` intentionally)
+4. `show_favorability = TRUE` does not affect `pval_adj` application — classification
+   uses the adjusted p-value if `pval_adj` is set
+
+**Error table (new errors only):**
+
+| Class | Trigger | Message template |
+|-------|---------|-----------------|
+| `surveycore_error_alpha_invalid` | `alpha` is not a single numeric in (0, 1) | `"{.arg alpha} must be a single numeric value strictly between 0 and 1. Got {.val {alpha}}."` |
+
+---
+
+## VI. Testing
+
+See `testing-standards.md` and `testing-surveycore.md` for general
+conventions. Only surveycore-specific additions are listed here.
+
+### PR 1 — `set_higher_is()` / `extract_higher_is()`
+
+File: `tests/testthat/test-metadata-system.R`
+
+**Happy paths:**
+- `set_higher_is(x, anxiety = "worse")` stores `"worse"` for `anxiety`
+- `set_higher_is(x, anxiety = "worse", agreement = "better")` stores both
+- Convention 2 (`set_higher_is(x, c(anxiety = "worse", agreement = "better"))`) stores both values correctly
+- Convention 3 (`variable = "anxiety", direction = "worse"`) stores correctly
+- `set_higher_is(x, anxiety = NULL)` removes the entry
+- Works on a plain `data.frame`; attribute stored on the column
+- `extract_higher_is(d, anxiety)` returns `c(anxiety = "worse")`
+- `extract_higher_is(d, c(anxiety, agreement))` returns both
+- `extract_higher_is(d)` returns all variables, `NA_character_` for unset
+
+**Error paths (one block per class):**
+- `not_survey_or_df` (setter): `set_higher_is(list(), anxiety = "worse")` errors with snapshot
+- `not_survey_or_df` (extractor): `extract_higher_is(list(), anxiety)` errors with snapshot
+- `direction_invalid`: `set_higher_is(x, anxiety = "neutral")` errors with snapshot; also `set_higher_is(x, anxiety = NA_character_)` errors with snapshot
+- `setter_mixed_dots`: `set_higher_is(x, list(anxiety = "worse"))` (unnamed list in `...`) errors with snapshot
+- `higher_is_ambiguous_input` (setter): both `...` and `variable` supplied to `set_higher_is()` errors with snapshot
+- `higher_is_ambiguous_input` (extractor): both `...` and `variable` supplied to `extract_higher_is()` errors with snapshot
+- `higher_is_no_vars`: no variable supplied errors with snapshot
+- `var_not_found`: unknown variable name warns with snapshot
+
+**Edge cases:**
+- Overwrite: `set_higher_is(x, anxiety = "worse")` then `set_higher_is(x, anxiety = "better")` — last write wins
+- `extract_higher_is()` with no `higher_is` set on any variable — returns all `NA_character_`
+- `.extract_var_meta()` includes `higher_is` after PR 1 — test directly that the
+  returned list has the `higher_is` key
+- `extract_higher_is(d, variable = "nonexistent")` — warns with `var_not_found` and returns named `character(0)`
+
+### PR 2 — `set_reverse_coded()` / `extract_reverse_coded()`
+
+File: `tests/testthat/test-metadata-system.R`
+
+**Happy paths:**
+- `set_reverse_coded(x, anxiety)` sets `TRUE` for `anxiety`
+- `set_reverse_coded(x, anxiety, reverse_coded = FALSE)` removes the entry
+- Works on a plain `data.frame`
+- `extract_reverse_coded(d, anxiety)` returns `c(anxiety = TRUE)`
+- `extract_reverse_coded(d)` returns all variables; unset → `FALSE`
+
+**Error paths (one block per class):**
+- `not_survey_or_df` (setter): `set_reverse_coded(list(), anxiety)` errors with snapshot
+- `not_survey_or_df` (extractor): `extract_reverse_coded(list(), anxiety)` errors with snapshot
+- `reverse_coded_not_logical`: `set_reverse_coded(x, anxiety, reverse_coded = NA)` errors with snapshot
+- `reverse_coded_ambiguous_input` (setter): both `...` and `variable` supplied to `set_reverse_coded()` errors with snapshot
+- `reverse_coded_ambiguous_input` (extractor): both `...` and `variable` supplied to `extract_reverse_coded()` errors with snapshot
+- `reverse_coded_no_vars`: no variables errors with snapshot
+- `var_not_found`: unknown variable warns with snapshot
+
+**Edge cases:**
+- Set then unset: `extract_reverse_coded()` returns `FALSE` after unsetting
+- `extract_reverse_coded(d, variable = "nonexistent")` — warns with `var_not_found` and returns named `logical(0)`
+
+### PR 3 — `get_diffs()` extensions
+
+File: `tests/testthat/test-analysis-diffs.R`
+
+**Happy paths:**
+- `show_favorability = FALSE` (default): no `favorable`/`backlash` columns in result;
+  `meta(result)$x[[x_name]]$higher_is` equals `"worse"` (when `higher_is = "worse"` was set on the `x` variable)
+- `show_favorability = TRUE` with `higher_is = "worse"` and negative significant diff:
+  `favorable = TRUE`, `backlash = FALSE`; `attr(result$favorable, "label")` equals `"Favorable"`;
+  `attr(result$backlash, "label")` equals `"Backlash"`; `expect_snapshot(print(result))` verifies column layout
+- `show_favorability = TRUE` with `higher_is = "better"` and negative significant diff:
+  `favorable = FALSE`, `backlash = TRUE`
+- `show_favorability = TRUE` with non-significant result: both `FALSE`
+- Custom `alpha = 0.01`: a result with `p = 0.03` is not favorable/backlash
+
+**Error paths:**
+- `alpha_invalid`: `get_diffs(..., alpha = 1.5)` errors with snapshot
+- `alpha_invalid`: `get_diffs(..., alpha = 0)` errors with snapshot
+- `alpha_invalid`: `get_diffs(..., alpha = "0.05")` errors with snapshot
+- `alpha_invalid`: `get_diffs(..., alpha = NA)` errors with snapshot
+- `alpha_invalid`: `get_diffs(..., alpha = Inf)` errors with snapshot
+- `alpha_invalid`: `get_diffs(..., alpha = c(0.05, 0.1))` errors with snapshot
+
+**Edge cases:**
+- `show_favorability = TRUE` with no `higher_is` set on `x`: both columns all `FALSE`
+- `p_value` exactly equal to `alpha`: not significant — both `FALSE` (strict `<`)
+- `pval_adj` set: `favorable`/`backlash` use the adjusted p-value, not raw
+- `show_favorability = TRUE` with `name_style = "broom"`: `favorable`/`backlash` columns present; classification uses `p.value` column
+- `show_favorability = TRUE` with `group`: `favorable`/`backlash` columns present; rows align correctly across groups
+
+---
+
+## VII. Quality Gates
+
+Before opening each PR:
+
+- [ ] `devtools::document()` run; `NAMESPACE` and `man/` files updated
+- [ ] `devtools::check()` passes: 0 errors, 0 warnings, ≤2 pre-approved notes
+- [ ] All new error classes in this spec added to `plans/error-messages.md`
+- [ ] 98%+ line coverage on new code; overall package coverage ≥ 95%
+- [ ] Snapshot tests for all new error/warning messages reviewed via
+  `testthat::snapshot_review()` before PR is opened
+- [ ] PR 3 is not opened until PR 1 is fully merged to `develop`
+
+---
+
+## VIII. Integration
+
+No external package contracts change. `higher_is` and `reverse_coded` are
+internal `survey_metadata` properties — downstream packages (surveytidy) do
+not read them. The `.meta$x$higher_is` field is a surveycore-internal contract
+for future reporting functions.
+
+`reverse_coded` has no consumer in this spec. It is infrastructure only.
+`compute_scale()` or equivalent functions are explicitly out of scope.

--- a/tests/testthat/_snaps/analysis-diffs.md
+++ b/tests/testthat/_snaps/analysis-diffs.md
@@ -84,3 +84,51 @@
       2 A          0.214  50.2    58  -3.29    3.72   0.898 ""   
       3 B         -0.543  49.4    77  -3.95    2.86   0.737 ""   
 
+# get_diffs() rejects alpha > 1
+
+    Code
+      get_diffs(d, dv, treats, alpha = 1.5)
+    Condition
+      Error in `get_diffs()`:
+      x `alpha` must be a single numeric value strictly between 0 and 1. Got 1.5.
+
+# get_diffs() rejects alpha = 0
+
+    Code
+      get_diffs(d, dv, treats, alpha = 0)
+    Condition
+      Error in `get_diffs()`:
+      x `alpha` must be a single numeric value strictly between 0 and 1. Got 0.
+
+# get_diffs() rejects alpha = '0.05' (character)
+
+    Code
+      get_diffs(d, dv, treats, alpha = "0.05")
+    Condition
+      Error in `get_diffs()`:
+      x `alpha` must be a single numeric value strictly between 0 and 1. Got "0.05".
+
+# get_diffs() rejects alpha = NA
+
+    Code
+      get_diffs(d, dv, treats, alpha = NA)
+    Condition
+      Error in `get_diffs()`:
+      x `alpha` must be a single numeric value strictly between 0 and 1. Got NA.
+
+# get_diffs() rejects alpha = Inf
+
+    Code
+      get_diffs(d, dv, treats, alpha = Inf)
+    Condition
+      Error in `get_diffs()`:
+      x `alpha` must be a single numeric value strictly between 0 and 1. Got Inf.
+
+# get_diffs() rejects alpha = c(0.05, 0.1) (length > 1)
+
+    Code
+      get_diffs(d, dv, treats, alpha = c(0.05, 0.1))
+    Condition
+      Error in `get_diffs()`:
+      x `alpha` must be a single numeric value strictly between 0 and 1. Got 0.05 and 0.1.
+

--- a/tests/testthat/test-analysis-diffs.R
+++ b/tests/testthat/test-analysis-diffs.R
@@ -643,3 +643,204 @@ test_that("get_diffs() na.rm = FALSE with NAs errors from survey_glm", {
     get_diffs(d, dv, treats, na.rm = FALSE)
   )
 })
+
+# ═══════════════════════════════════════════════════════════════════════════
+# PR 3 — favorability (show_favorability, alpha)
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Helper: two-group design with a large, clearly significant negative diff
+# (A mean ~30 vs Control mean ~60; p ≈ 0 → stable across seeds)
+.make_fav_design <- function(seed = 42L) {
+  df <- make_survey_data(n = 400L, n_psu = 40L, n_strata = 4L, seed = seed)
+  set.seed(seed + 1L)
+  n <- nrow(df)
+  # Explicit levels so "Control" is the reference (first level)
+  df$treats <- factor(
+    sample(c("Control", "A"), n, replace = TRUE),
+    levels = c("Control", "A")
+  )
+  # Control ~60, A ~30 → diff (A - Control) ≈ -30, p ≈ 0
+  df$dv <- ifelse(
+    df$treats == "Control",
+    rnorm(n, 60, 3),
+    rnorm(n, 30, 3)
+  )
+  df$gender <- factor(sample(c("M", "F"), n, replace = TRUE))
+  as_survey(df, ids = psu, weights = wt, strata = strata)
+}
+
+# ── Error paths: alpha_invalid ──────────────────────────────────────────────
+
+test_that("get_diffs() rejects alpha > 1", {
+  d <- .make_diffs_design()
+  expect_error(
+    get_diffs(d, dv, treats, alpha = 1.5),
+    class = "surveycore_error_alpha_invalid"
+  )
+  expect_snapshot(error = TRUE, get_diffs(d, dv, treats, alpha = 1.5))
+})
+
+test_that("get_diffs() rejects alpha = 0", {
+  d <- .make_diffs_design()
+  expect_error(
+    get_diffs(d, dv, treats, alpha = 0),
+    class = "surveycore_error_alpha_invalid"
+  )
+  expect_snapshot(error = TRUE, get_diffs(d, dv, treats, alpha = 0))
+})
+
+test_that("get_diffs() rejects alpha = '0.05' (character)", {
+  d <- .make_diffs_design()
+  expect_error(
+    get_diffs(d, dv, treats, alpha = "0.05"),
+    class = "surveycore_error_alpha_invalid"
+  )
+  expect_snapshot(error = TRUE, get_diffs(d, dv, treats, alpha = "0.05"))
+})
+
+test_that("get_diffs() rejects alpha = NA", {
+  d <- .make_diffs_design()
+  expect_error(
+    get_diffs(d, dv, treats, alpha = NA),
+    class = "surveycore_error_alpha_invalid"
+  )
+  expect_snapshot(error = TRUE, get_diffs(d, dv, treats, alpha = NA))
+})
+
+test_that("get_diffs() rejects alpha = Inf", {
+  d <- .make_diffs_design()
+  expect_error(
+    get_diffs(d, dv, treats, alpha = Inf),
+    class = "surveycore_error_alpha_invalid"
+  )
+  expect_snapshot(error = TRUE, get_diffs(d, dv, treats, alpha = Inf))
+})
+
+test_that("get_diffs() rejects alpha = c(0.05, 0.1) (length > 1)", {
+  d <- .make_diffs_design()
+  expect_error(
+    get_diffs(d, dv, treats, alpha = c(0.05, 0.1)),
+    class = "surveycore_error_alpha_invalid"
+  )
+  expect_snapshot(error = TRUE, get_diffs(d, dv, treats, alpha = c(0.05, 0.1)))
+})
+
+# ── Happy paths ──────────────────────────────────────────────────────────────
+
+test_that("get_diffs() show_favorability = FALSE: no favorable/backlash columns; higher_is in .meta", {
+  d <- .make_fav_design()
+  d <- set_higher_is(d, dv = "worse")
+  result <- get_diffs(d, dv, treats, show_favorability = FALSE)
+  expect_false("favorable" %in% names(result))
+  expect_false("backlash" %in% names(result))
+  expect_identical(attr(result, ".meta")$x[["dv"]]$higher_is, "worse")
+})
+
+test_that("get_diffs() show_favorability + higher_is='worse' + negative sig diff: favorable=TRUE, backlash=FALSE", {
+  d <- .make_fav_design()
+  d <- set_higher_is(d, dv = "worse")
+  result <- get_diffs(d, dv, treats, show_favorability = TRUE)
+  a_row <- result[result$treats == "A", ]
+  expect_true(a_row$favorable)
+  expect_false(a_row$backlash)
+  expect_identical(attr(result$favorable, "label"), "Favorable")
+  expect_identical(attr(result$backlash, "label"), "Backlash")
+})
+
+test_that("get_diffs() show_favorability + higher_is='better' + negative sig diff: favorable=FALSE, backlash=TRUE", {
+  d <- .make_fav_design()
+  d <- set_higher_is(d, dv = "better")
+  result <- get_diffs(d, dv, treats, show_favorability = TRUE)
+  a_row <- result[result$treats == "A", ]
+  expect_false(a_row$favorable)
+  expect_true(a_row$backlash)
+})
+
+test_that("get_diffs() show_favorability + non-significant result: both FALSE", {
+  # Random data with no treatment effect; p >> 0.01 for random diffs
+  d <- .make_diffs_design()
+  d <- set_higher_is(d, dv = "worse")
+  result <- get_diffs(d, dv, treats, show_favorability = TRUE, alpha = 0.01)
+  expect_true(all(!result$favorable))
+  expect_true(all(!result$backlash))
+})
+
+test_that("get_diffs() show_favorability: custom alpha = 0.001 keeps highly sig result favorable", {
+  d <- .make_fav_design()
+  d <- set_higher_is(d, dv = "worse")
+  # p ≈ 0 for the large effect, so favorable even at very small alpha
+  result <- get_diffs(d, dv, treats, show_favorability = TRUE, alpha = 0.001)
+  a_row <- result[result$treats == "A", ]
+  expect_true(a_row$favorable)
+})
+
+test_that("get_diffs() show_favorability + name_style='broom': favorable/backlash present, uses p.value", {
+  d <- .make_fav_design()
+  d <- set_higher_is(d, dv = "worse")
+  result <- get_diffs(d, dv, treats, show_favorability = TRUE, name_style = "broom")
+  expect_true("favorable" %in% names(result))
+  expect_true("backlash" %in% names(result))
+  expect_true("p.value" %in% names(result))
+  a_row <- result[result$treats == "A", ]
+  expect_true(a_row$favorable)
+  expect_false(a_row$backlash)
+})
+
+test_that("get_diffs() show_favorability + group: columns present, aligned per group", {
+  d <- .make_fav_design()
+  d <- set_higher_is(d, dv = "worse")
+  result <- get_diffs(d, dv, treats, group = gender, show_favorability = TRUE)
+  expect_true("favorable" %in% names(result))
+  expect_true("backlash" %in% names(result))
+  expect_true(is.logical(result$favorable))
+  expect_true(is.logical(result$backlash))
+  # Each group should have its own rows with correct alignment
+  expect_true("gender" %in% names(result))
+})
+
+test_that("get_diffs() show_favorability + pval_adj: classification uses adjusted p-value", {
+  d <- .make_fav_design()
+  d <- set_higher_is(d, dv = "worse")
+  result <- get_diffs(d, dv, treats, show_favorability = TRUE, pval_adj = "bonferroni")
+  expect_true("favorable" %in% names(result))
+  expect_true("backlash" %in% names(result))
+  a_row <- result[result$treats == "A", ]
+  # Large effect: even after Bonferroni adjustment, p ≈ 0 → still favorable
+  expect_true(a_row$favorable)
+  expect_false(a_row$backlash)
+})
+
+# ── Edge cases ────────────────────────────────────────────────────────────────
+
+test_that("get_diffs() show_favorability + no higher_is set: both columns all FALSE, no warning", {
+  d <- .make_fav_design()
+  # Deliberately do NOT call set_higher_is()
+  expect_no_warning(
+    result <- get_diffs(d, dv, treats, show_favorability = TRUE)
+  )
+  expect_true("favorable" %in% names(result))
+  expect_true("backlash" %in% names(result))
+  expect_true(all(!result$favorable))
+  expect_true(all(!result$backlash))
+})
+
+test_that("get_diffs() show_favorability: p_value == alpha → both FALSE (strict <)", {
+  d <- .make_diffs_design()
+  d <- set_higher_is(d, dv = "worse")
+  # Get the actual p-values for this fixed-seed dataset
+  baseline <- get_diffs(d, dv, treats)
+  # Exclude the reference row (p_value = NA) before finding min p
+  valid_pvals <- baseline$p_value[!is.na(baseline$p_value)]
+  min_p <- min(valid_pvals)
+  skip_if(min_p == 0 || !is.finite(min_p),
+          "p-value is exactly 0 or non-finite; boundary cannot be tested")
+  skip_if(min_p >= 1, "p-value >= 1; outside valid alpha range")
+  # With alpha == min_p: strict < means p is NOT < alpha → not significant
+  result <- get_diffs(d, dv, treats, show_favorability = TRUE, alpha = min_p)
+  # Find the row with p_value exactly equal to min_p (exclude NA rows)
+  obs_rows <- result[!is.na(result$p_value) & result$p_value == min_p, ]
+  if (nrow(obs_rows) > 0) {
+    expect_false(obs_rows$favorable[[1]])
+    expect_false(obs_rows$backlash[[1]])
+  }
+})


### PR DESCRIPTION
## What

Adds `show_favorability` and `alpha` arguments to `get_diffs()`. When `show_favorability = TRUE`, the result gains `favorable` and `backlash` logical columns that classify each treatment–reference difference as statistically significant and in the direction indicated by `higher_is` metadata (set via `set_higher_is()`). The `alpha` argument (default `0.05`) sets the significance threshold and is validated as a single finite numeric value strictly between 0 and 1.

## Checklist

- [x] Tests written and passing (`devtools::test()`)
- [x] R CMD check: 0 errors, 0 warnings (`devtools::check()`)
- [x] Roxygen docs updated and `devtools::document()` run
- [x] `plans/error-messages.md` updated (if new errors/warnings added)
- [ ] `VENDORED.md` updated (if variance code vendored in this PR) — N/A
- [x] PR title is a valid Conventional Commit (`feat(scope): description`)
- [x] PR targets `develop`, not `main`