### PR TITLE
feat(print): update survey_nonprob print method for bootstrap repweights

### DIFF
--- a/R/methods-print.R
+++ b/R/methods-print.R
@@ -495,9 +495,22 @@ S7::method(print, survey_nonprob) <- function(
 
   # ── Header ────────────────────────────────────────────────────────────────
   cli::cli_h1("Survey Design")
-  cli::cli_text(
-    "{.cls survey_nonprob} (non-probability) [experimental]"
-  )
+  if (!is.null(x@variables$repweights)) {
+    R_count <- length(x@variables$repweights)
+    cli::cli_text(
+      paste0(
+        "{.cls survey_nonprob} (non-probability, BOOTSTRAP, ",
+        "{R_count} replicates) [experimental]"
+      )
+    )
+  } else {
+    cli::cli_text(
+      "{.cls survey_nonprob} (non-probability) [experimental]"
+    )
+    cli::cli_bullets(
+      c("*" = "Variance: SRS approximation (no bootstrap replicate weights)")
+    )
+  }
   cli::cli_text("Sample size: {.val {nrow(x@data)}}")
   .print_domain_info(x)
 
@@ -516,6 +529,16 @@ S7::method(print, survey_nonprob) <- function(
     cli::cli_h2("Design specification")
 
     cli::cli_bullets(c("*" = "Weights: {.field {wts_var}}"))
+
+    if (!is.null(x@variables$repweights)) {
+      R_count <- length(x@variables$repweights)
+      rep_cols <- paste(x@variables$repweights, collapse = ", ")
+      cli::cli_bullets(c(
+        "*" = "Replicate weights: {R_count} columns ({.field {rep_cols}})"
+      ))
+      cli::cli_bullets(c("*" = "Type: {.val {x@variables$type}}"))
+      cli::cli_bullets(c("*" = "Scale: {.val {x@variables$scale}}"))
+    }
 
     cal_label <- if (!is.null(x@calibration)) "stored" else "none stored"
     cli::cli_bullets(c("*" = "Calibration provenance: {cal_label}"))

--- a/changelog/nonprob-bootstrap/pr-3-print.md
+++ b/changelog/nonprob-bootstrap/pr-3-print.md
@@ -1,0 +1,28 @@
+# feat(print): update survey_nonprob print method for bootstrap repweights
+
+**Date**: 2026-05-19
+**Branch**: feature/nonprob-bootstrap-print
+**Plan**: nonprob-bootstrap-variance (PR 3)
+
+## Changes
+
+- Update `print.survey_nonprob` header line: when `@variables$repweights`
+  is non-`NULL`, display `<survey_nonprob> (non-probability, BOOTSTRAP,
+  N replicates) [experimental]`; otherwise display
+  `<survey_nonprob> (non-probability) [experimental]` followed by a
+  bullet noting the SRS variance approximation.
+- Add replicate weight detail bullets in the `design_info` block (shown
+  when `design_info = TRUE`): replicate count + column names, type, and
+  scale.
+
+## Files Modified
+
+- `R/methods-print.R` — conditional header for `survey_nonprob` with/
+  without repweights; add replicate detail bullets in `design_info` block.
+- `tests/testthat/test-methods-print.R` — add three snapshot tests:
+  `survey_nonprob` with repweights, without repweights, and with
+  repweights + `design_info = TRUE`.
+- `tests/testthat/_snaps/methods-print.md` — three new snapshots;
+  existing nonprob-without-repweights snapshots updated with SRS bullet.
+- `tests/testthat/_snaps/constructors.md` — updated snapshots from PR 3
+  print changes propagating through constructor error output.

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -265,6 +265,7 @@
       
       -- Survey Design ---------------------------------------------------------------
       <survey_nonprob> (non-probability) [experimental]
+      * Variance: SRS approximation (no bootstrap replicate weights)
       Sample size: 10
       
     Output
@@ -290,6 +291,7 @@
       
       -- Survey Design ---------------------------------------------------------------
       <survey_nonprob> (non-probability) [experimental]
+      * Variance: SRS approximation (no bootstrap replicate weights)
       Sample size: 10
       Weighted N: 10
       
@@ -336,6 +338,7 @@
       
       -- Survey Design ---------------------------------------------------------------
       <survey_nonprob> (non-probability) [experimental]
+      * Variance: SRS approximation (no bootstrap replicate weights)
       Sample size: 10
       
       
@@ -369,6 +372,7 @@
       
       -- Survey Design ---------------------------------------------------------------
       <survey_nonprob> (non-probability) [experimental]
+      * Variance: SRS approximation (no bootstrap replicate weights)
       Sample size: 10
       Weighted N: 10
       
@@ -402,6 +406,7 @@
       
       -- Survey Design ---------------------------------------------------------------
       <survey_nonprob> (non-probability) [experimental]
+      * Variance: SRS approximation (no bootstrap replicate weights)
       Sample size: 10
       
       

--- a/tests/testthat/_snaps/methods-print.md
+++ b/tests/testthat/_snaps/methods-print.md
@@ -444,6 +444,7 @@
       
       -- Survey Design ---------------------------------------------------------------
       <survey_nonprob> (non-probability) [experimental]
+      * Variance: SRS approximation (no bootstrap replicate weights)
       Sample size: 30
       
     Output
@@ -470,6 +471,7 @@
       
       -- Survey Design ---------------------------------------------------------------
       <survey_nonprob> (non-probability) [experimental]
+      * Variance: SRS approximation (no bootstrap replicate weights)
       Sample size: 30
       Domain: 30 of 30 rows
       
@@ -600,4 +602,99 @@
       id: ".survey"
       if_missing_var: "error"
       "only": survey_taylor, 50 rows, 8 variables
+
+# print.survey_nonprob() shows BOOTSTRAP class line with repweights
+
+    Code
+      print(d)
+    Message
+      
+      -- Survey Design ---------------------------------------------------------------
+      <survey_nonprob> (non-probability, BOOTSTRAP, 10 replicates) [experimental]
+      Sample size: 100
+      
+    Output
+      # A tibble: 100 x 18
+         psu   strata      fpc    wt    y1      y2    y3 group repwt_1 repwt_2 repwt_3
+         <chr> <chr>     <dbl> <dbl> <dbl>   <dbl> <int> <chr>   <dbl>   <dbl>   <dbl>
+       1 psu_1 stratum_1   298 13.2   61.2 -0.466      0 B      39.0    11.3      5.73
+       2 psu_2 stratum_1   298 16.5   64.4 -0.269      0 C      21.4     5.87    27.5 
+       3 psu_2 stratum_1   298 10.6   39.0 -0.391      0 A      49.0     0.334    4.36
+       4 psu_3 stratum_1   298 12.7   48.8  1.35       1 B       1.73   34.2     14.0 
+       5 psu_4 stratum_1   298 12.6   62.0 -0.0228     0 A       2.13   16.7      8.91
+       6 psu_4 stratum_1   298  9.19  45.3  0.244      0 B       0.766   2.32     3.94
+       7 psu_4 stratum_1   298 15.0   49.5 -0.942      1 A      34.6    60.8     25.4 
+       8 psu_5 stratum_1   298 15.5   49.1 -0.729      0 B       8.21    5.74     5.39
+       9 psu_5 stratum_1   298 13.9   41.1  0.998      1 C       7.15   44.6     25.4 
+      10 psu_5 stratum_1   298 17.3   45.6  1.26       1 B       1.61    0.395    8.04
+      # i 90 more rows
+      # i 7 more variables: repwt_4 <dbl>, repwt_5 <dbl>, repwt_6 <dbl>,
+      #   repwt_7 <dbl>, repwt_8 <dbl>, repwt_9 <dbl>, repwt_10 <dbl>
+
+# print.survey_nonprob() shows SRS approximation note without repweights
+
+    Code
+      print(d)
+    Message
+      
+      -- Survey Design ---------------------------------------------------------------
+      <survey_nonprob> (non-probability) [experimental]
+      * Variance: SRS approximation (no bootstrap replicate weights)
+      Sample size: 50
+      
+    Output
+      # A tibble: 50 x 2
+              y    wt
+          <dbl> <dbl>
+       1 -0.415 1.38 
+       2  1.98  0.808
+       3  0.460 0.715
+       4 -1.13  1.45 
+       5 -1.78  2.36 
+       6 -0.393 1.09 
+       7 -0.767 1.41 
+       8 -0.380 1.82 
+       9  0.370 1.33 
+      10 -0.625 0.631
+      # i 40 more rows
+
+# print.survey_nonprob() with repweights and design_info = TRUE shows replicate bullets
+
+    Code
+      print(d, design_info = TRUE)
+    Message
+      
+      -- Survey Design ---------------------------------------------------------------
+      <survey_nonprob> (non-probability, BOOTSTRAP, 10 replicates) [experimental]
+      Sample size: 100
+      
+      
+      -- Design specification --
+      
+      * Weights: wt
+      * Replicate weights: 10 columns (repwt_1, repwt_2, repwt_3, repwt_4, repwt_5,
+        repwt_6, repwt_7, repwt_8, repwt_9, repwt_10)
+      * Type: "bootstrap"
+      * Scale: 0.1
+      * Calibration provenance: none stored
+      
+      Design variables: wt
+      
+    Output
+      # A tibble: 100 x 18
+         psu   strata      fpc    wt    y1      y2    y3 group repwt_1 repwt_2 repwt_3
+         <chr> <chr>     <dbl> <dbl> <dbl>   <dbl> <int> <chr>   <dbl>   <dbl>   <dbl>
+       1 psu_1 stratum_1   298 13.2   61.2 -0.466      0 B      39.0    11.3      5.73
+       2 psu_2 stratum_1   298 16.5   64.4 -0.269      0 C      21.4     5.87    27.5 
+       3 psu_2 stratum_1   298 10.6   39.0 -0.391      0 A      49.0     0.334    4.36
+       4 psu_3 stratum_1   298 12.7   48.8  1.35       1 B       1.73   34.2     14.0 
+       5 psu_4 stratum_1   298 12.6   62.0 -0.0228     0 A       2.13   16.7      8.91
+       6 psu_4 stratum_1   298  9.19  45.3  0.244      0 B       0.766   2.32     3.94
+       7 psu_4 stratum_1   298 15.0   49.5 -0.942      1 A      34.6    60.8     25.4 
+       8 psu_5 stratum_1   298 15.5   49.1 -0.729      0 B       8.21    5.74     5.39
+       9 psu_5 stratum_1   298 13.9   41.1  0.998      1 C       7.15   44.6     25.4 
+      10 psu_5 stratum_1   298 17.3   45.6  1.26       1 B       1.61    0.395    8.04
+      # i 90 more rows
+      # i 7 more variables: repwt_4 <dbl>, repwt_5 <dbl>, repwt_6 <dbl>,
+      #   repwt_7 <dbl>, repwt_8 <dbl>, repwt_9 <dbl>, repwt_10 <dbl>
 

--- a/tests/testthat/test-methods-print.R
+++ b/tests/testthat/test-methods-print.R
@@ -729,3 +729,38 @@ test_that("print.survey_collection snapshot: length-1 pluralisation", {
   coll <- as_survey_collection(only = d)
   expect_snapshot(print(coll))
 })
+
+
+# ── NEW: survey_nonprob with repweights ──────────────────────────────────────
+
+test_that("print.survey_nonprob() shows BOOTSTRAP class line with repweights", {
+  withr::local_options(list(width = 80L, cli.width = 80L))
+  set.seed(42L)
+  df <- make_survey_data(n = 100L, seed = 42L)
+  # Add 10 repweight columns
+  R <- 10L
+  for (r in seq_len(R)) {
+    df[[paste0("repwt_", r)]] <- pmax(0.1, df$wt * rexp(nrow(df)))
+  }
+  d <- as_survey_nonprob(df, weights = wt, repweights = starts_with("repwt_"))
+  expect_snapshot(print(d))
+})
+
+test_that("print.survey_nonprob() shows SRS approximation note without repweights", {
+  withr::local_options(list(width = 80L, cli.width = 80L))
+  df <- data.frame(y = rnorm(50L), wt = runif(50L, 0.5, 2.5))
+  d <- as_survey_nonprob(df, weights = wt)
+  expect_snapshot(print(d))
+})
+
+test_that("print.survey_nonprob() with repweights and design_info = TRUE shows replicate bullets", {
+  withr::local_options(list(width = 80L, cli.width = 80L))
+  set.seed(42L)
+  df <- make_survey_data(n = 100L, seed = 42L)
+  R <- 10L
+  for (r in seq_len(R)) {
+    df[[paste0("repwt_", r)]] <- pmax(0.1, df$wt * rexp(nrow(df)))
+  }
+  d <- as_survey_nonprob(df, weights = wt, repweights = starts_with("repwt_"))
+  expect_snapshot(print(d, design_info = TRUE))
+})


### PR DESCRIPTION
## What

Updates `print.survey_nonprob` to display a BOOTSTRAP header and replicate
weight details when `@variables$repweights` is populated, and adds an SRS
approximation note when no repweights are present.

## Checklist

- [x] Tests written and passing (`devtools::test()`)
- [x] R CMD check: 0 errors, 0 warnings (`devtools::check()`)
- [x] Roxygen docs updated and `devtools::document()` run
- [ ] `plans/error-messages.md` updated (if new errors/warnings added)
- [ ] `VENDORED.md` updated (if variance code vendored in this PR)
- [x] PR title is a valid Conventional Commit (`feat(scope): description`)
- [x] PR targets `develop`, not `main`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)