### PR TITLE
feat(variance): calibration-adjusted variance for survey_taylor (means, totals, domain estimates)

### DIFF
--- a/R/analysis-means-helpers.R
+++ b/R/analysis-means-helpers.R
@@ -78,6 +78,9 @@
   lonely.psu <- getOption("survey.lonely.psu", "remove")
 
   infl_mat <- matrix(w * u / N_d, ncol = 1L, dimnames = list(NULL, y_col))
+  infl_mat <- .maybe_apply_calibration(infl_mat, design)
+  cal_df_reduction <- .get_calibration_df_reduction(design)
+
   v <- .svy_recvar(
     infl_mat,
     mats$clusters_mat,
@@ -88,6 +91,25 @@
 
   se <- sqrt(max(0, v[1L, 1L]))
 
+  # Calibration-adjusted degrees of freedom
+  df_design <- max(1L, .degf_taylor(data, vars))
+  df_final <- df_design - cal_df_reduction
+  if (df_final <= 0L) {
+    cli::cli_warn(
+      c(
+        "!" = paste0(
+          "Calibration reduces design df ({df_design}) to {df_final}."
+        ),
+        "i" = "CIs and p-values may be invalid.",
+        "v" = paste0(
+          "Reduce the number of calibration columns or use a larger design."
+        )
+      ),
+      class = "surveycore_warning_zero_df_after_calibration"
+    )
+    df_final <- max(1L, df_final)
+  }
+
   # SRS-equivalent SE for design effect computation
   y_domain <- y_all[domain > 0]
   se_srs <- if (n_d >= 2L) {
@@ -97,7 +119,14 @@
     0
   }
 
-  list(mean = ybar, se = se, se_srs = se_srs, n = n_d, n_weighted = N_d)
+  list(
+    mean = ybar,
+    se = se,
+    se_srs = se_srs,
+    n = n_d,
+    n_weighted = N_d,
+    df = df_final
+  )
 }
 
 
@@ -142,9 +171,11 @@
   R <- ncol(rep_mat)
   na_dropped <- sum(is.na(rep_p))
   na_frac <- na_dropped / R
-  if (isTRUE(
-    .nonprob_rep_na_warn(design, na_frac, na_dropped, R, vars$scale)
-  )) {
+  if (
+    isTRUE(
+      .nonprob_rep_na_warn(design, na_frac, na_dropped, R, vars$scale)
+    )
+  ) {
     return(list(
       mean = NA_real_,
       se = NA_real_,

--- a/R/analysis-means.R
+++ b/R/analysis-means.R
@@ -74,8 +74,13 @@
 #' metadata.
 #'
 #' @examples
-#' d <- as_survey(nhanes_2017, ids = sdmvpsu, weights = wtint2yr,
-#'                strata = sdmvstra, nest = TRUE)
+#' d <- as_survey(
+#'   nhanes_2017,
+#'   ids = sdmvpsu,
+#'   weights = wtint2yr,
+#'   strata = sdmvstra,
+#'   nest = TRUE
+#' )
 #' get_means(d, ridageyr)
 #'
 #' # With grouped estimate
@@ -83,7 +88,6 @@
 #'
 #' # AAPOR-compliant
 #' get_means(d, ridageyr, variance = c("ci", "moe"), n_weighted = TRUE)
-#'
 #' @family analysis
 #' @export
 get_means <- function(
@@ -200,6 +204,7 @@ get_means <- function(
   acc_sesrs <- numeric(0)
   acc_n <- integer(0)
   acc_nw <- numeric(0)
+  acc_df <- numeric(0)
   acc_grp_rows <- vector("list", 0L)
 
   small_cell_ns <- integer(0)
@@ -226,6 +231,7 @@ get_means <- function(
     acc_sesrs <- c(acc_sesrs, cell$se_srs)
     acc_n <- c(acc_n, cell$n)
     acc_nw <- c(acc_nw, cell$n_weighted)
+    acc_df <- c(acc_df, if (!is.null(cell$df)) cell$df else Inf)
 
     if (length(group_vars) > 0L) {
       acc_grp_rows <- c(acc_grp_rows, list(combo_row))
@@ -248,18 +254,29 @@ get_means <- function(
   }
 
   # ── Step 8: Build column vectors ────────────────────────────────────────────
+  # Use per-cell df from .taylor_mean_cell() when calibration is active;
+  # fall back to Inf (normal approximation) for non-Taylor or uncalibrated.
+  has_calibration <- S7::S7_inherits(design, survey_taylor) &&
+    !is.null(design@calibration) &&
+    length(design@calibration) > 0L
+  effective_degf <- if (has_calibration) acc_df else degf
+
   var_cols <- .add_variance_cols(
     se_vec = acc_se,
     estimate_vec = acc_mean,
     se_srs_vec = acc_sesrs,
     conf_level = conf_level,
-    degf = degf,
+    degf = effective_degf,
     variance = variance
   )
 
   col_vecs <- list()
   col_vecs$mean <- acc_mean
   col_vecs <- c(col_vecs, var_cols)
+  # Add df column only for calibrated Taylor designs
+  if (has_calibration) {
+    col_vecs$df <- acc_df
+  }
   col_vecs$n <- acc_n
 
   if (isTRUE(n_weighted)) {

--- a/R/analysis-totals-helpers.R
+++ b/R/analysis-totals-helpers.R
@@ -59,6 +59,9 @@
 
   lbl <- if (is.null(y_col)) "pop_total" else y_col
   infl_mat <- matrix(w * u, ncol = 1L, dimnames = list(NULL, lbl))
+  infl_mat <- .maybe_apply_calibration(infl_mat, design)
+  cal_df_reduction <- .get_calibration_df_reduction(design)
+
   v <- .svy_recvar(
     infl_mat,
     mats$clusters_mat,
@@ -68,6 +71,25 @@
   )
 
   se <- sqrt(max(0, v[1L, 1L]))
+
+  # Calibration-adjusted degrees of freedom
+  df_design <- max(1L, .degf_taylor(data, vars))
+  df_final <- df_design - cal_df_reduction
+  if (df_final <= 0L) {
+    cli::cli_warn(
+      c(
+        "!" = paste0(
+          "Calibration reduces design df ({df_design}) to {df_final}."
+        ),
+        "i" = "CIs and p-values may be invalid.",
+        "v" = paste0(
+          "Reduce the number of calibration columns or use a larger design."
+        )
+      ),
+      class = "surveycore_warning_zero_df_after_calibration"
+    )
+    df_final <- max(1L, df_final)
+  }
 
   # SRS-equivalent SE
   y_domain <- y_safe[domain > 0]
@@ -85,7 +107,8 @@
     se = se,
     se_srs = se_srs,
     n = if (is.null(y_col)) NULL else n_d,
-    n_weighted = N_d
+    n_weighted = N_d,
+    df = df_final
   )
 }
 
@@ -133,9 +156,11 @@
   R <- ncol(rep_mat)
   na_dropped <- sum(is.na(rep_Y))
   na_frac <- na_dropped / R
-  if (isTRUE(
-    .nonprob_rep_na_warn(design, na_frac, na_dropped, R, vars$scale)
-  )) {
+  if (
+    isTRUE(
+      .nonprob_rep_na_warn(design, na_frac, na_dropped, R, vars$scale)
+    )
+  ) {
     return(list(
       total = NA_real_,
       se = NA_real_,

--- a/R/calibration.R
+++ b/R/calibration.R
@@ -236,3 +236,110 @@ as_caldata <- function(base_weights, g_weights, model_matrix) {
     index = NULL
   )
 }
+
+
+# ── .apply_caldata_projection ─────────────────────────────────────────────────
+#
+# Project the linearization matrix `u` onto the orthogonal complement of the
+# calibration column space, following Deville & Sarndal (1992). This reduces
+# variance estimates to account for the information in the calibration
+# auxiliary variables.
+#
+# @param u        A numeric matrix (n × p). The linearized influence matrix.
+# @param caldata  A list of caldata elements (each created by as_caldata()).
+# @return The projected matrix `u`, same dimensions as input.
+# @noRd
+.apply_caldata_projection <- function(u, caldata) {
+  # Guard 0: empty list pass-through
+  if (length(caldata) == 0L) {
+    return(u)
+  }
+  # Guard 1: all-NA pass-through
+  if (all(is.na(u))) {
+    return(u)
+  }
+  # Guard 1b: NULL element check
+  bad_idx <- which(vapply(caldata, is.null, logical(1)))
+  if (length(bad_idx) > 0L) {
+    cli::cli_abort(
+      c(
+        "x" = "caldata element(s) {bad_idx} are NULL.",
+        "i" = paste0(
+          "All {.field @calibration} list elements must be constructed ",
+          "via {.fn as_caldata}."
+        ),
+        "v" = "Inspect {.code design@calibration} for NULL entries."
+      ),
+      class = "surveycore_error_caldata_invalid_element"
+    )
+  }
+  # Guard 2: stage check
+  bad_stage <- vapply(caldata, function(cd) cd$stage != 0L, logical(1))
+  if (any(bad_stage)) {
+    n_bad <- sum(bad_stage)
+    cli::cli_abort(
+      c(
+        "x" = "Within-PSU calibration (stage != 0) is not supported in v1.",
+        "i" = paste0(
+          "{n_bad} caldata element{?s} {?has/have} stage != 0L."
+        ),
+        "v" = "Use population-level calibration only."
+      ),
+      class = "surveycore_error_caldata_within_stage_unsupported"
+    )
+  }
+  # Loop: project out each calibration's column space
+  for (cd in caldata) {
+    # Guard 3: dimension check
+    if (nrow(u) != length(cd$w)) {
+      cli::cli_abort(
+        c(
+          "x" = "Calibration projection dimension mismatch.",
+          "i" = paste0(
+            "Linearization vector has {nrow(u)} rows; ",
+            "caldata {.code w} has length {length(cd$w)}."
+          )
+        ),
+        class = "surveycore_error_caldata_projection_dimension_mismatch"
+      )
+    }
+    u <- qr.resid(cd$qr, u / cd$w) * cd$w
+  }
+  u
+}
+
+
+# ── .maybe_apply_calibration ──────────────────────────────────────────────────
+#
+# Apply calibration projection if the design has calibration data, otherwise
+# return the linearized matrix unchanged.
+#
+# @param linearized  A numeric matrix. The linearized influence matrix.
+# @param design      A survey_taylor or survey_replicate object.
+# @return The (possibly projected) linearized matrix.
+# @noRd
+.maybe_apply_calibration <- function(linearized, design) {
+  if (!is.null(design@calibration) && length(design@calibration) > 0L) {
+    .apply_caldata_projection(linearized, design@calibration)
+  } else {
+    linearized
+  }
+}
+
+
+# ── .get_calibration_df_reduction ─────────────────────────────────────────────
+#
+# Compute the total degrees-of-freedom reduction from calibration. This equals
+# the sum of QR ranks across all caldata elements in the design's @calibration
+# list.
+#
+# @param design  A survey_taylor or survey_replicate object.
+# @return Integer(1). 0L when no calibration is set.
+# @noRd
+.get_calibration_df_reduction <- function(design) {
+  if (!is.null(design@calibration) && length(design@calibration) > 0L) {
+    sum(vapply(design@calibration, function(cd) cd$qr$rank, integer(1)))
+  } else {
+    0L
+  }
+}

--- a/R/update-design.R
+++ b/R/update-design.R
@@ -66,12 +66,16 @@
 #' # NHANES has two weight columns for different analysis types;
 #' # start with the MEC examination weight for exam participants
 #' exam <- nhanes_2017[nhanes_2017$ridstatr == 2, ]
-#' d <- as_survey(exam, ids = sdmvpsu, weights = wtmec2yr,
-#'                strata = sdmvstra, nest = TRUE)
+#' d <- as_survey(
+#'   exam,
+#'   ids = sdmvpsu,
+#'   weights = wtmec2yr,
+#'   strata = sdmvstra,
+#'   nest = TRUE
+#' )
 #'
 #' # Switch to interview weight for interview-based variables
 #' d_updated <- update_design(d, weights = wtint2yr)
-#'
 #' @seealso
 #'   [as_survey()] to create a `survey_taylor` object,
 #'   [as_survey_replicate()] to create a `survey_replicate` object
@@ -132,6 +136,23 @@ update_design <- function(
       changed_vars <- c(changed_vars, "fpc")
     }
 
+    # Warn when weights change on a calibrated design (CAL-13)
+    if (!is.null(new_weights) && !is.null(x@calibration)) {
+      cli::cli_warn(
+        c(
+          "!" = "Weight column changed on a calibrated design.",
+          "i" = paste0(
+            "{.field @calibration} was built from the previous weight column."
+          ),
+          "v" = paste0(
+            "Re-run calibration or set ",
+            "{.code design@calibration <- NULL} before analysing."
+          )
+        ),
+        class = "surveycore_warning_weight_change_invalidates_calibration"
+      )
+    }
+
     if (length(changed_vars) > 0L) {
       if (!isTRUE(validate)) {
         attr(x, ".should_validate") <- FALSE
@@ -163,6 +184,23 @@ update_design <- function(
     if (!is.null(new_repweights)) {
       new_variables$repweights <- new_repweights
       changed_vars <- c(changed_vars, "repweights")
+    }
+
+    # Warn when weights change on a calibrated design (CAL-13)
+    if (!is.null(new_weights) && !is.null(x@calibration)) {
+      cli::cli_warn(
+        c(
+          "!" = "Weight column changed on a calibrated design.",
+          "i" = paste0(
+            "{.field @calibration} was built from the previous weight column."
+          ),
+          "v" = paste0(
+            "Re-run calibration or set ",
+            "{.code design@calibration <- NULL} before analysing."
+          )
+        ),
+        class = "surveycore_warning_weight_change_invalidates_calibration"
+      )
     }
 
     if (length(changed_vars) > 0L) {

--- a/R/variance-taylor.R
+++ b/R/variance-taylor.R
@@ -262,7 +262,7 @@
 # ===========================================================================
 
 # Compute weighted mean and its variance for a single numeric variable.
-# Returns list(mean, var, se).
+# Returns list(mean, var, se, df).
 .taylor_mean <- function(design, y_col, na.rm = TRUE) {
   inp <- .taylor_build_inputs(design, y_col, na.rm = na.rm)
   lonely.psu <- getOption("survey.lonely.psu", "remove")
@@ -273,19 +273,45 @@
   average <- drop(crossprod(x, w) / psum) # weighted mean
 
   x_centered <- sweep(x, 2L, average)
+  linearized <- .maybe_apply_calibration(x_centered * w / psum, design)
+  cal_df_reduction <- .get_calibration_df_reduction(design)
+
   v <- .svy_recvar(
-    x_centered * w / psum,
+    linearized,
     inp$clusters,
     inp$stratas,
     inp$fpcs,
     lonely.psu = lonely.psu
   )
 
-  list(mean = average[[1L]], var = v[[1L, 1L]], se = sqrt(v[[1L, 1L]]))
+  df_design <- max(1L, .degf_taylor(design@data, design@variables))
+  df_final <- df_design - cal_df_reduction
+  if (df_final <= 0L) {
+    cli::cli_warn(
+      c(
+        "!" = paste0(
+          "Calibration reduces design df ({df_design}) to {df_final}."
+        ),
+        "i" = "CIs and p-values may be invalid.",
+        "v" = paste0(
+          "Reduce the number of calibration columns or use a larger design."
+        )
+      ),
+      class = "surveycore_warning_zero_df_after_calibration"
+    )
+    df_final <- max(1L, df_final)
+  }
+
+  list(
+    mean = average[[1L]],
+    var = v[[1L, 1L]],
+    se = sqrt(v[[1L, 1L]]),
+    df = df_final
+  )
 }
 
 # Compute weighted total and its variance for a single numeric variable.
-# Returns list(total, var, se).
+# Returns list(total, var, se, df).
 .taylor_total <- function(design, y_col, na.rm = TRUE) {
   inp <- .taylor_build_inputs(design, y_col, na.rm = na.rm)
   lonely.psu <- getOption("survey.lonely.psu", "remove")
@@ -294,15 +320,41 @@
   w <- inp$w
   total <- drop(crossprod(x, w)) # weighted total
 
+  linearized <- .maybe_apply_calibration(x * w, design)
+  cal_df_reduction <- .get_calibration_df_reduction(design)
+
   v <- .svy_recvar(
-    x * w,
+    linearized,
     inp$clusters,
     inp$stratas,
     inp$fpcs,
     lonely.psu = lonely.psu
   )
 
-  list(total = total[[1L]], var = v[[1L, 1L]], se = sqrt(v[[1L, 1L]]))
+  df_design <- max(1L, .degf_taylor(design@data, design@variables))
+  df_final <- df_design - cal_df_reduction
+  if (df_final <= 0L) {
+    cli::cli_warn(
+      c(
+        "!" = paste0(
+          "Calibration reduces design df ({df_design}) to {df_final}."
+        ),
+        "i" = "CIs and p-values may be invalid.",
+        "v" = paste0(
+          "Reduce the number of calibration columns or use a larger design."
+        )
+      ),
+      class = "surveycore_warning_zero_df_after_calibration"
+    )
+    df_final <- max(1L, df_final)
+  }
+
+  list(
+    total = total[[1L]],
+    var = v[[1L, 1L]],
+    se = sqrt(v[[1L, 1L]]),
+    df = df_final
+  )
 }
 
 

--- a/decisions.md
+++ b/decisions.md
@@ -39,3 +39,15 @@
 **User decision (2026-06-03)**: Override accepted. The coverage shortfall is pre-existing — before this PR coverage was 93.06%; this PR raised it to 93.13% (+0.07 pp). All code added by this PR (`R/calibration.R` and the `@calibration` property additions) is fully covered by the 39 new test assertions. The 95%+ target is tracked as a separate cleanup task, not a blocker for this PR.
 
 **Pipeline resumed** — proceeding to shipper.
+
+---
+
+# decisions.md — calibrate-survey-taylor PR 2
+
+## HOLD resolved: 2026-06-03
+
+**Pipeline stage**: reviewer → shipper
+
+**STOP condition (OVERRIDDEN by user)**: `covr::package_coverage()` = 92.84%, below the 95% absolute floor and −0.29 pp vs. PR 1 baseline (93.13%).
+
+**User decision (2026-06-03)**: Override accepted. The coverage decrease is attributable to new branches (calibration path guard conditions in `.taylor_mean_cell()`, `.taylor_total_cell()`, and `get_means()`) that are exercised only when `@calibration` is non-NULL; the fully-calibrated code paths are all covered by the 21 new test blocks. The 95%+ target is tracked as a separate cleanup task, not a blocker for this PR.

--- a/tests/testthat/_snaps/calibration.md
+++ b/tests/testthat/_snaps/calibration.md
@@ -116,3 +116,32 @@
       i `model_matrix` must contain only finite numeric values. Check for `NA`, `NaN`, or `Inf` in the matrix.
       v Impute or remove non-finite entries before calling `as_caldata()`.
 
+# .apply_caldata_projection() errors when any caldata entry has stage != 0L [direct]
+
+    Code
+      surveycore:::.apply_caldata_projection(u, list(cd_bad))
+    Condition
+      Error in `surveycore:::.apply_caldata_projection()`:
+      x Within-PSU calibration (stage != 0) is not supported in v1.
+      i 1 caldata element has stage != 0L.
+      v Use population-level calibration only.
+
+# .apply_caldata_projection() errors on dimension mismatch between u and cd$w [direct]
+
+    Code
+      surveycore:::.apply_caldata_projection(u_10, list(cd_5))
+    Condition
+      Error in `surveycore:::.apply_caldata_projection()`:
+      x Calibration projection dimension mismatch.
+      i Linearization vector has 10 rows; caldata `w` has length 5.
+
+# .apply_caldata_projection() errors on NULL element in caldata list [direct, B-5]
+
+    Code
+      surveycore:::.apply_caldata_projection(u, list(cd, NULL))
+    Condition
+      Error in `surveycore:::.apply_caldata_projection()`:
+      x caldata element(s) 2 are NULL.
+      i All @calibration list elements must be constructed via `as_caldata()`.
+      v Inspect `design@calibration` for NULL entries.
+

--- a/tests/testthat/_snaps/update-design.md
+++ b/tests/testthat/_snaps/update-design.md
@@ -1,0 +1,10 @@
+# update_design() warns when weight column changes on calibrated design [B-6]
+
+    Code
+      suppressMessages(update_design(d, weights = wt2))
+    Condition
+      Warning:
+      ! Weight column changed on a calibrated design.
+      i @calibration was built from the previous weight column.
+      v Re-run calibration or set `design@calibration <- NULL` before analysing.
+

--- a/tests/testthat/test-calibration.R
+++ b/tests/testthat/test-calibration.R
@@ -502,7 +502,7 @@ test_that("calibration-adjusted SE is applied to domain estimates [get_means wit
   sc_res_sorted <- sc_res[order(sc_res$riagendr), ]
   sc_ses <- sc_res_sorted$se
 
-  expect_equal(sc_ses, sv_ses, tolerance = 1e-6)
+  expect_equal(sc_ses, sv_ses, tolerance = 1e-8)
 })
 
 

--- a/tests/testthat/test-calibration.R
+++ b/tests/testthat/test-calibration.R
@@ -627,3 +627,61 @@ test_that("get_means() warns when calibration df reduction >= design df [R-7]", 
     class = "surveycore_warning_zero_df_after_calibration"
   )
 })
+
+test_that("calibration-adjusted SE from get_means() matches survey::rake() oracle [raking, nhanes]", {
+  skip_if_not_installed("survey")
+  # Two-margin raking: calibrate to gender proportions, then to linear age.
+  # Oracle: two sequential survey::calibrate() calls (= one raking pass).
+  # surveycore: two accumulated caldata entries.
+  nhanes_sub <- nhanes_2017[
+    nhanes_2017$wtmec2yr > 0 & nhanes_2017$ridstatr == 2,
+  ]
+  sv_design <- survey::svydesign(
+    ids = ~sdmvpsu,
+    weights = ~wtmec2yr,
+    strata = ~sdmvstra,
+    data = nhanes_sub,
+    nest = TRUE
+  )
+  # Population targets for margin 1 (gender) and margin 2 (age)
+  pop1 <- c(
+    "(Intercept)" = sum(nhanes_sub$wtmec2yr),
+    riagendr = sum(nhanes_sub$riagendr * nhanes_sub$wtmec2yr)
+  )
+  pop2 <- c(
+    "(Intercept)" = sum(nhanes_sub$wtmec2yr),
+    ridageyr = sum(nhanes_sub$ridageyr * nhanes_sub$wtmec2yr)
+  )
+  # Oracle: two sequential calibrations (one pass of raking)
+  sv_cal1 <- survey::calibrate(
+    sv_design,
+    formula = ~riagendr,
+    population = pop1
+  )
+  sv_raked <- survey::calibrate(sv_cal1, formula = ~ridageyr, population = pop2)
+  sv_se <- as.numeric(
+    survey::SE(survey::svymean(~bpxsy1, sv_raked, na.rm = TRUE))
+  )
+  # surveycore: two caldata entries
+  g1 <- weights(sv_cal1) / nhanes_sub$wtmec2yr
+  mm1 <- model.matrix(~riagendr, nhanes_sub)
+  cd1 <- as_caldata(nhanes_sub$wtmec2yr, g1, mm1)
+  wt_after1 <- weights(sv_cal1)
+  g2 <- weights(sv_raked) / wt_after1
+  mm2 <- model.matrix(~ridageyr, nhanes_sub)
+  cd2 <- as_caldata(wt_after1, g2, mm2)
+  sc_design <- as_survey(
+    nhanes_sub,
+    ids = sdmvpsu,
+    weights = wtmec2yr,
+    strata = sdmvstra,
+    nest = TRUE
+  )
+  sc_design@data$wt_raked <- weights(sv_raked)
+  sc_raked <- suppressMessages(
+    suppressWarnings(update_design(sc_design, weights = wt_raked))
+  )
+  sc_raked@calibration <- list(cd1, cd2)
+  sc_se <- get_means(sc_raked, bpxsy1, variance = "se")$se
+  expect_equal(sc_se, sv_se, tolerance = 1e-8)
+})

--- a/tests/testthat/test-calibration.R
+++ b/tests/testthat/test-calibration.R
@@ -216,3 +216,414 @@ test_that("as_caldata() rejects model_matrix with Inf values", {
     as_caldata(base_w, g, mm_inf)
   )
 })
+
+
+# ── .apply_caldata_projection() direct tests ───────────────────────────────────
+
+test_that(".apply_caldata_projection() errors when any caldata entry has stage != 0L [direct]", {
+  cd <- as_caldata(rep(1, 10), rep(1.1, 10), matrix(1, 10, 1))
+  cd_bad <- cd
+  cd_bad$stage <- 1L
+  u <- matrix(rnorm(10), 10, 1)
+  expect_error(
+    surveycore:::.apply_caldata_projection(u, list(cd_bad)),
+    class = "surveycore_error_caldata_within_stage_unsupported"
+  )
+  expect_snapshot(
+    error = TRUE,
+    surveycore:::.apply_caldata_projection(u, list(cd_bad))
+  )
+})
+
+test_that(".apply_caldata_projection() errors on dimension mismatch between u and cd$w [direct]", {
+  cd_5 <- as_caldata(rep(1, 5), rep(1.1, 5), matrix(1, 5, 1))
+  u_10 <- matrix(rnorm(10), 10, 1)
+  expect_error(
+    surveycore:::.apply_caldata_projection(u_10, list(cd_5)),
+    class = "surveycore_error_caldata_projection_dimension_mismatch"
+  )
+  expect_snapshot(
+    error = TRUE,
+    surveycore:::.apply_caldata_projection(u_10, list(cd_5))
+  )
+})
+
+test_that(".apply_caldata_projection() returns u unchanged when u is all-NA", {
+  cd <- as_caldata(rep(1, 10), rep(1.1, 10), matrix(1, 10, 1))
+  u_na <- matrix(NA_real_, 10, 1)
+  result <- surveycore:::.apply_caldata_projection(u_na, list(cd))
+  expect_true(all(is.na(result)))
+})
+
+test_that(".apply_caldata_projection() returns u unchanged when caldata is empty list [direct, B-7]", {
+  u <- matrix(rnorm(10), 10, 1)
+  result <- surveycore:::.apply_caldata_projection(u, list())
+  expect_identical(result, u)
+})
+
+test_that(".apply_caldata_projection() errors on NULL element in caldata list [direct, B-5]", {
+  cd <- as_caldata(rep(1, 10), rep(1.1, 10), matrix(1, 10, 1))
+  u <- matrix(rnorm(10), 10, 1)
+  expect_error(
+    surveycore:::.apply_caldata_projection(u, list(cd, NULL)),
+    class = "surveycore_error_caldata_invalid_element"
+  )
+  expect_snapshot(
+    error = TRUE,
+    surveycore:::.apply_caldata_projection(u, list(cd, NULL))
+  )
+})
+
+
+# ── Numerical / behavioral accuracy tests ─────────────────────────────────────
+#
+# Oracle setup helper (used in multiple tests below):
+#   nhanes_sub: nhanes_2017 filtered to positive wtmec2yr and ridstatr == 2
+#   sv_design / sv_cal: survey package reference designs
+#   sc_cal: surveycore calibrated design matching sv_cal
+#
+# The calibration uses riagendr as an auxiliary variable, calibrating to the
+# population totals implied by the interview weights. This produces g-weights
+# != 1 (real calibration effect).
+
+.make_nhanes_oracle <- function() {
+  skip_if_not_installed("survey")
+  nhanes_sub <- nhanes_2017[
+    nhanes_2017$wtmec2yr > 0 & nhanes_2017$ridstatr == 2,
+  ]
+  sv_design <- survey::svydesign(
+    ids = ~sdmvpsu,
+    weights = ~wtmec2yr,
+    strata = ~sdmvstra,
+    data = nhanes_sub,
+    nest = TRUE
+  )
+  gender_pop <- c(
+    "(Intercept)" = sum(nhanes_sub$wtmec2yr),
+    riagendr = sum(
+      nhanes_sub$riagendr * nhanes_sub$wtint2yr / sum(nhanes_sub$wtint2yr)
+    ) *
+      sum(nhanes_sub$wtmec2yr)
+  )
+  sv_cal <- survey::calibrate(
+    sv_design,
+    formula = ~riagendr,
+    population = gender_pop
+  )
+  g <- weights(sv_cal) / nhanes_sub$wtmec2yr
+  mm <- model.matrix(~riagendr, nhanes_sub)
+  cd <- as_caldata(nhanes_sub$wtmec2yr, g, mm)
+
+  sc_design <- as_survey(
+    nhanes_sub,
+    ids = sdmvpsu,
+    weights = wtmec2yr,
+    strata = sdmvstra,
+    nest = TRUE
+  )
+  sc_design@data$wtmec2yr_cal <- weights(sv_cal)
+  sc_cal <- suppressMessages(
+    suppressWarnings(update_design(sc_design, weights = wtmec2yr_cal))
+  )
+  sc_cal@calibration <- list(cd)
+
+  list(
+    nhanes_sub = nhanes_sub,
+    sv_design = sv_design,
+    sv_cal = sv_cal,
+    sc_design = sc_design,
+    sc_cal = sc_cal,
+    cd = cd
+  )
+}
+
+test_that("calibration-adjusted SE from get_means() matches survey oracle [linear, nhanes]", {
+  skip_if_not_installed("survey")
+  o <- .make_nhanes_oracle()
+  sv_se <- as.numeric(
+    survey::SE(survey::svymean(~bpxsy1, o$sv_cal, na.rm = TRUE))
+  )
+  sc_se <- get_means(o$sc_cal, bpxsy1, variance = "se")$se
+  expect_equal(sc_se, sv_se, tolerance = 1e-8)
+})
+
+test_that("post-calibration point estimate from get_means() matches survey oracle [linear, nhanes]", {
+  skip_if_not_installed("survey")
+  o <- .make_nhanes_oracle()
+  sv_mean <- as.numeric(survey::svymean(~bpxsy1, o$sv_cal, na.rm = TRUE))
+  sc_mean <- get_means(o$sc_cal, bpxsy1, variance = "se")$mean
+  expect_equal(sc_mean, sv_mean, tolerance = 1e-10)
+})
+
+test_that("calibration-adjusted SE from get_totals() matches survey oracle [linear, nhanes]", {
+  skip_if_not_installed("survey")
+  o <- .make_nhanes_oracle()
+  sv_se <- as.numeric(
+    survey::SE(survey::svytotal(~bpxsy1, o$sv_cal, na.rm = TRUE))
+  )
+  sc_se <- get_totals(o$sc_cal, bpxsy1, variance = "se")$se
+  expect_equal(sc_se, sv_se, tolerance = 1e-8)
+})
+
+test_that("calibration reduces SE when auxiliary variable correlates with outcome [nhanes]", {
+  skip_if_not_installed("survey")
+  o <- .make_nhanes_oracle()
+  se_uncal <- get_means(o$sc_design, bpxsy1, variance = "se")$se
+  se_cal <- get_means(o$sc_cal, bpxsy1, variance = "se")$se
+  # The calibration is on riagendr (gender), which is correlated with bpxsy1;
+  # calibration may increase or decrease SE depending on the correlation.
+  # The key test is that they differ (showing calibration had an effect).
+  expect_false(isTRUE(all.equal(se_uncal, se_cal, tolerance = 1e-10)))
+})
+
+test_that("calibration-adjusted SE matches oracle on SRS design [get_means, R-5]", {
+  skip_if_not_installed("survey")
+  # Use a small SRS-style design (no ids/strata) to test the SRS path
+  set.seed(123)
+  n <- 200L
+  df <- data.frame(
+    y = rnorm(n, 5, 2),
+    wt = runif(n, 0.8, 1.2)
+  )
+  sv_d <- survey::svydesign(ids = ~1, weights = ~wt, data = df)
+  pop_totals <- c("(Intercept)" = sum(df$wt))
+  sv_cal <- survey::calibrate(sv_d, formula = ~1, population = pop_totals)
+  g <- weights(sv_cal) / df$wt
+  mm <- model.matrix(~1, df)
+  cd <- as_caldata(df$wt, g, mm)
+  sc_d <- as_survey(df, weights = wt)
+  sc_d@data$wt_cal <- weights(sv_cal)
+  sc_cal <- suppressMessages(
+    suppressWarnings(update_design(sc_d, weights = wt_cal))
+  )
+  sc_cal@calibration <- list(cd)
+
+  sv_se <- as.numeric(survey::SE(survey::svymean(~y, sv_cal, na.rm = TRUE)))
+  sc_se <- get_means(sc_cal, y, variance = "se")$se
+  expect_equal(sc_se, sv_se, tolerance = 1e-8)
+})
+
+test_that("get_means() SE is unchanged when @calibration is NULL [regression]", {
+  df <- make_survey_data(n = 200L, seed = 99L)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
+  # No calibration set
+  expect_null(d@calibration)
+  se_result <- get_means(d, y1, variance = "se")$se
+  expect_true(is.numeric(se_result))
+  expect_true(se_result > 0)
+})
+
+test_that("get_means() SE is unchanged when @calibration is an empty list", {
+  df <- make_survey_data(n = 200L, seed = 100L)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
+  d@calibration <- list()
+  se_result <- get_means(d, y1, variance = "se")$se
+  expect_true(is.numeric(se_result))
+  expect_true(se_result > 0)
+})
+
+test_that("get_means() on survey_replicate with @calibration set returns same SE as uncalibrated", {
+  # Calibration projection is not applied to replicate path; @calibration on
+  # survey_replicate should be silently ignored by .maybe_apply_calibration
+  # (since the replicate path never calls .taylor_mean_cell).
+  df <- make_survey_data(
+    n = 200L,
+    design = "replicate",
+    type = "brr",
+    seed = 77L
+  )
+  repwt_cols <- grep("^repwt_", names(df), value = TRUE)
+  d_rep <- as_survey_replicate(
+    df,
+    weights = wt,
+    repweights = tidyselect::starts_with("repwt"),
+    type = "BRR"
+  )
+  # Attach a caldata element (should be ignored by replicate path)
+  cd <- as_caldata(df$wt, rep(1.05, nrow(df)), matrix(1, nrow(df), 1))
+  d_cal <- d_rep
+  d_cal@calibration <- list(cd)
+
+  se_rep <- get_means(d_rep, y1, variance = "se")$se
+  se_cal <- get_means(d_cal, y1, variance = "se")$se
+  # Calibration on replicate design should not change SE (ignored in replicate path)
+  expect_equal(se_rep, se_cal, tolerance = 1e-12)
+})
+
+test_that("get_means() returns NA SE on calibrated design with all-NA outcome column [R-8]", {
+  df <- make_survey_data(n = 200L, seed = 101L)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
+  df$y_na <- NA_real_
+  d@data$y_na <- NA_real_
+  cd <- as_caldata(df$wt, rep(1.05, nrow(df)), matrix(1, nrow(df), 1))
+  d@calibration <- list(cd)
+
+  result <- get_means(d, y_na, variance = "se")
+  expect_true(is.na(result$se))
+  expect_true(is.na(result$mean))
+})
+
+test_that("two accumulated caldata entries both applied by .apply_caldata_projection()", {
+  # Use a simple SRS design with two sequential calibrations
+  set.seed(42L)
+  n <- 50L
+  df <- data.frame(
+    y = rnorm(n),
+    wt = rep(1, n),
+    x1 = rnorm(n),
+    x2 = rnorm(n)
+  )
+  # Build two caldata elements
+  cd1 <- as_caldata(df$wt, rep(1.01, n), model.matrix(~1, df))
+  cd2 <- as_caldata(df$wt, rep(1.01, n), model.matrix(~x1, df))
+  d <- as_survey(df, weights = wt)
+  d@calibration <- list(cd1, cd2)
+
+  result <- get_means(d, y, variance = "se")
+  # Both projections applied: df should decrease by rank(cd1) + rank(cd2) = 1 + 2
+  expect_equal(result$df, max(1L, .degf(d) - 1L - 2L))
+})
+
+test_that("calibration-adjusted SE is applied to domain estimates [get_means with group]", {
+  skip_if_not_installed("survey")
+  o <- .make_nhanes_oracle()
+  # svyby returns a data frame with rows ordered by the by-variable
+  sv_res <- survey::svyby(
+    ~bpxsy1,
+    ~riagendr,
+    o$sv_cal,
+    survey::svymean,
+    na.rm = TRUE
+  )
+  # Extract SEs for riagendr == 1 and riagendr == 2 by position
+  sv_ses <- as.numeric(survey::SE(sv_res)) # SE() on svyby gives a vector
+
+  sc_res <- get_means(o$sc_cal, bpxsy1, group = riagendr, variance = "se")
+  sc_res_sorted <- sc_res[order(sc_res$riagendr), ]
+  sc_ses <- sc_res_sorted$se
+
+  expect_equal(sc_ses, sv_ses, tolerance = 1e-6)
+})
+
+
+# ── Df-adjustment tests ────────────────────────────────────────────────────────
+
+test_that("calibrated design has reduced df in get_means() output [nhanes, linear]", {
+  skip_if_not_installed("survey")
+  o <- .make_nhanes_oracle()
+  # Uncalibrated df
+  df_uncal <- .degf(o$sc_design)
+  # Calibrated df: reduced by qr rank of cd (rank = 2 for ~riagendr intercept + coef)
+  cd_rank <- o$cd$qr$rank
+  result_cal <- get_means(o$sc_cal, bpxsy1, variance = "se")
+  expect_equal(result_cal$df, df_uncal - cd_rank)
+})
+
+test_that("df column in get_means() decreases by qr$rank for each caldata entry", {
+  set.seed(10L)
+  n <- 100L
+  df <- data.frame(
+    y = rnorm(n),
+    wt = rep(1, n),
+    x1 = rnorm(n),
+    x2 = rnorm(n)
+  )
+  d <- as_survey(df, ids = NULL, weights = wt)
+
+  # No calibration
+  result_none <- get_means(d, y, variance = "se")
+  # The df column doesn't appear when uncalibrated
+  expect_false("df" %in% names(result_none))
+
+  # One caldata entry: rank = 1 (intercept only)
+  cd1 <- as_caldata(df$wt, rep(1.01, n), model.matrix(~1, df))
+  d1 <- d
+  d1@calibration <- list(cd1)
+  result1 <- get_means(d1, y, variance = "se")
+  base_df <- .degf(d)
+  expect_equal(result1$df, base_df - 1L)
+
+  # Two caldata entries: rank 1 + rank 2
+  cd2 <- as_caldata(df$wt, rep(1.01, n), model.matrix(~x1, df))
+  d2 <- d
+  d2@calibration <- list(cd1, cd2)
+  result2 <- get_means(d2, y, variance = "se")
+  expect_equal(result2$df, base_df - 1L - 2L)
+})
+
+test_that("calibration-adjusted SE from get_means() matches oracle with ridageyr aux [alternative calibration, nhanes]", {
+  skip_if_not_installed("survey")
+  # Second oracle test using ridageyr as auxiliary — verifies calibration works
+  # with a continuous auxiliary variable producing non-trivial g-weights.
+  nhanes_sub <- nhanes_2017[
+    nhanes_2017$wtmec2yr > 0 & nhanes_2017$ridstatr == 2,
+  ]
+  sv_design <- survey::svydesign(
+    ids = ~sdmvpsu,
+    weights = ~wtmec2yr,
+    strata = ~sdmvstra,
+    data = nhanes_sub,
+    nest = TRUE
+  )
+  # Calibrate to ridageyr totals derived from interview weights
+  age_pop <- c(
+    "(Intercept)" = sum(nhanes_sub$wtmec2yr),
+    ridageyr = sum(
+      nhanes_sub$ridageyr * nhanes_sub$wtint2yr / sum(nhanes_sub$wtint2yr)
+    ) *
+      sum(nhanes_sub$wtmec2yr)
+  )
+  sv_cal2 <- survey::calibrate(
+    sv_design,
+    formula = ~ridageyr,
+    population = age_pop
+  )
+  sv_se2 <- as.numeric(
+    survey::SE(survey::svymean(~bpxsy1, sv_cal2, na.rm = TRUE))
+  )
+
+  g2 <- weights(sv_cal2) / nhanes_sub$wtmec2yr
+  mm2 <- model.matrix(~ridageyr, nhanes_sub)
+  cd2 <- as_caldata(nhanes_sub$wtmec2yr, g2, mm2)
+
+  sc_design2 <- as_survey(
+    nhanes_sub,
+    ids = sdmvpsu,
+    weights = wtmec2yr,
+    strata = sdmvstra,
+    nest = TRUE
+  )
+  sc_design2@data$wt2 <- weights(sv_cal2)
+  sc_cal2 <- suppressMessages(
+    suppressWarnings(update_design(sc_design2, weights = wt2))
+  )
+  sc_cal2@calibration <- list(cd2)
+
+  sc_se2 <- get_means(sc_cal2, bpxsy1, variance = "se")$se
+  expect_equal(sc_se2, sv_se2, tolerance = 1e-8)
+})
+
+test_that("get_means() warns when calibration df reduction >= design df [R-7]", {
+  # Create a design where df reduction exceeds the design df.
+  # We need n >= min_cell_n (30) to avoid small_cell warning.
+  # Use a simple SRS design (no PSUs/strata): df = n - 1
+  # Then use a very high rank model matrix to make df reduction > df.
+  set.seed(55L)
+  n <- 40L
+  df <- data.frame(
+    y = rnorm(n),
+    wt = rep(1, n)
+  )
+  # SRS design: df_design = n - 1 = 39
+  d <- as_survey(df, weights = wt)
+  # Use a model matrix with rank > 39 to trigger warning
+  # Build identity matrix (rank = n = 40 > 39)
+  x_mat <- diag(n)
+  cd_high <- as_caldata(df$wt, rep(1.001, n), x_mat)
+  d@calibration <- list(cd_high)
+
+  expect_warning(
+    get_means(d, y, variance = "se"),
+    class = "surveycore_warning_zero_df_after_calibration"
+  )
+})

--- a/tests/testthat/test-update-design.R
+++ b/tests/testthat/test-update-design.R
@@ -277,3 +277,24 @@ test_that("update_design() validate=FALSE skips validation for survey_replicate"
     suppressMessages(update_design(d, weights = bad_wt, validate = FALSE))
   )
 })
+
+
+# ── Calibration guard ──────────────────────────────────────────────────────────
+
+test_that("update_design() warns when weight column changes on calibrated design [B-6]", {
+  df <- make_survey_data(n = 200L, seed = 42L)
+  df$wt2 <- df$wt * 1.1
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
+  # Attach a caldata element to simulate a calibrated design
+  cd <- as_caldata(df$wt, rep(1.05, nrow(df)), matrix(1, nrow(df), 1))
+  d@calibration <- list(cd)
+
+  expect_warning(
+    suppressMessages(update_design(d, weights = wt2)),
+    class = "surveycore_warning_weight_change_invalidates_calibration"
+  )
+  # Snapshot verifies the CLI warning message text
+  expect_snapshot(
+    suppressMessages(update_design(d, weights = wt2))
+  )
+})


### PR DESCRIPTION
## Summary

- Add `.apply_caldata_projection()`, `.maybe_apply_calibration()`, `.get_calibration_df_reduction()` to `R/calibration.R` — internal helpers implementing the Deville-Sarndal (1992) / RYH (2002) QR residual projection
- Wire calibration into `.taylor_mean_cell()`, `.taylor_total_cell()`, `.taylor_mean()`, `.taylor_total()` — projection applied when `design@calibration` is non-NULL and non-empty
- Add `df` column to `get_means()` / `get_totals()` output for calibrated Taylor designs; apply negative-df guard with `surveycore_warning_zero_df_after_calibration`
- Add calibration guard warning to `update_design()` for `survey_taylor` and `survey_replicate` (`surveycore_warning_weight_change_invalidates_calibration`)
- `survey_replicate` calibration passthrough verified: replicate SE unchanged when `@calibration` is set

## Spec coverage
See review.md — verdict PASS.
- Spec items covered: 15 checks, all PASS (tolerance integrity, convergence, guard order, variance integration, df guard, update_design guard, exports, error classes, coverage override, scope discipline, CRAN cookbook, profile gates, comprehension alignment, audit verdict)
- Test scenarios: 21 new test blocks, all PASS

## Test results
- devtools::test(): PASS (11,902 PASS, 0 FAIL)
- R CMD check --as-cran: 0 errors, 0 warnings, 2 pre-approved notes (pre-existing on baseline)
- pkgcheck: SKIPPED — scope (pre-existing baseline, not a new-package submission)
- pkgdown: PASS
- covr: 92.84% (override documented in decisions.md — all new calibration code paths exercised by 21 new test blocks; 95%+ cleanup deferred as separate task)

## Before/After
See audit.md — calibration-adjusted variance wired into all 4 Taylor cell/aggregate paths; oracle comparisons at 1e-8 match `survey::calibrate()` reference.

## Artifacts
- Implementation: plans/implementation-plan-2026-06-03-calibrate-survey-taylor.md
- Audit: audit.md
- Review: review.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)