### PR TITLE
feat(constructors): validate calibration= argument at construction time (CAL-15, CAL-16)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## New features
 
+* `as_survey()` and `as_survey_replicate()` now validate the `calibration =`
+  argument at construction time (errors CAL-15, CAL-16).
+
 * `as_caldata()` constructs a calibration data element suitable for assignment
   to `design@calibration` on `survey_taylor` and `survey_replicate` objects.
   Both classes now carry a `@calibration` property (default `NULL`) that will

--- a/R/calibration.R
+++ b/R/calibration.R
@@ -49,6 +49,36 @@
 #' GREG-GLM variance is implemented in a future release. The calibration
 #' correction is not applied in the GLM variance path.
 #'
+#' @section Inter-package contract:
+#' \strong{GREG calibration (single auxiliary variable or multiple uncorrelated
+#' variables):} pass the model matrix from \code{model.matrix(formula, data)}
+#' directly -- one column per calibration variable. The intercept column
+#' (`(Intercept)`) is included by default from \code{model.matrix()}; it
+#' contributes one degree of freedom to the calibration adjustment.
+#'
+#' \strong{Raking (multiple calibration margins, Architecture A):} combine all
+#' margin indicator matrices into a single matrix before calling
+#' \code{as_caldata()}. Column-bind the matrices and drop one reference column
+#' per margin to avoid rank deficiency (e.g., drop the last column of each
+#' per-margin block). Pass this single combined matrix. Do \strong{not} call
+#' \code{as_caldata()} once per margin; that uses Architecture B (sequential),
+#' which requires a separate \code{as_caldata()} element per calibration pass
+#' and stores them all in the \code{@calibration} list.
+#'
+#' \strong{q_k = 1 assumption:} \code{as_caldata()} always assumes
+#' \eqn{q_k = 1} (uniform calibration weights). If your calibration uses a
+#' non-unity \eqn{q_k} (variance-function weights from \code{survey::calibrate(
+#' calfun = "linear", variance = ...)}) you must absorb those weights into
+#' \code{model_matrix} before calling \code{as_caldata()}.
+#'
+#' @section For \code{survey_replicate} designs:
+#' \code{@calibration} on a \code{survey_replicate} object is
+#' \strong{provenance-only}: it documents that the replicate weights were
+#' derived from a calibrated design, but the variance estimator does not apply
+#' any GREG projection. Calibration is already encoded in the replicate weights
+#' themselves. Do not expect \code{get_means()} SE to differ between a
+#' \code{survey_replicate} with and without \code{@calibration} set.
+#'
 #' @references
 #' Deville, J.-C., and Sarndal, C.-E. (1992). Calibration estimators in
 #' survey sampling. *Journal of the American Statistical Association*, 87,
@@ -235,6 +265,96 @@ as_caldata <- function(base_weights, g_weights, model_matrix) {
     stage = 0L,
     index = NULL
   )
+}
+
+
+# ── .validate_calibration_arg ─────────────────────────────────────────────────
+#
+# Validate the `calibration` constructor argument before the survey object is
+# built. Called from as_survey() and as_survey_replicate() immediately before
+# the S7 constructor call.
+#
+# @param calibration  The value supplied to the `calibration =` argument.
+#   Must be NULL, an empty list, or a list of valid caldata objects.
+# @param nrow_data    Integer. The number of rows in the design's data frame.
+#   Each caldata element's `w` vector must have this length.
+# @return Invisibly TRUE on success; aborts on failure.
+# @noRd
+.validate_calibration_arg <- function(calibration, nrow_data) {
+  # Case 1: NULL is always valid (no calibration)
+  if (is.null(calibration)) {
+    return(invisible(TRUE))
+  }
+
+  # Case 2: empty list is valid (cleared calibration)
+  if (is.list(calibration) && length(calibration) == 0L) {
+    return(invisible(TRUE))
+  }
+
+  # Case 3: detect bare (un-wrapped) caldata -- a list whose top-level names are
+  # exactly the four caldata keys. User passed as_caldata() result directly
+  # instead of wrapping it in list().
+  .caldata_keys <- c("qr", "w", "stage", "index")
+  if (
+    is.list(calibration) &&
+      all(.caldata_keys %in% names(calibration))
+  ) {
+    cli::cli_abort(
+      c(
+        "x" = paste0(
+          "{.arg calibration} must be a list of {.fn as_caldata} outputs ",
+          "or {.code NULL}."
+        ),
+        "i" = paste0(
+          "Got {.cls {class(calibration)[[1L]]}}. It looks like you passed ",
+          "the result of {.fn as_caldata} directly -- wrap it in ",
+          "{.code list()}: {.code calibration = list(cd)}."
+        )
+      ),
+      class = "surveycore_error_calibration_not_list"
+    )
+  }
+
+  # Case 4: must be a plain list (data.frame is technically a list but not valid)
+  if (!is.list(calibration) || is.data.frame(calibration)) {
+    cli::cli_abort(
+      c(
+        "x" = paste0(
+          "{.arg calibration} must be a list of {.fn as_caldata} outputs ",
+          "or {.code NULL}."
+        ),
+        "i" = "Got {.cls {class(calibration)[[1L]]}}."
+      ),
+      class = "surveycore_error_calibration_not_list"
+    )
+  }
+
+  # Case 5: loop over list elements -- each must be a valid caldata structure
+  for (i in seq_along(calibration)) {
+    cd <- calibration[[i]]
+    is_valid <- (!is.null(cd) &&
+      is.list(cd) &&
+      all(c("qr", "w", "stage", "index") %in% names(cd)) &&
+      length(cd$w) == nrow_data)
+    if (!is_valid) {
+      cli::cli_abort(
+        c(
+          "x" = paste0(
+            "Element {.val {i}} of {.arg calibration} is not a valid ",
+            "caldata object."
+          ),
+          "i" = paste0(
+            "Each element must be a named list with fields {.val qr}, ",
+            "{.val w}, {.val stage}, and {.val index}, produced by ",
+            "{.fn as_caldata}."
+          )
+        ),
+        class = "surveycore_error_caldata_invalid_element"
+      )
+    }
+  }
+
+  invisible(TRUE)
 }
 
 

--- a/R/core-constructors.R
+++ b/R/core-constructors.R
@@ -51,13 +51,20 @@
 #'   distinct PSUs. Set `nest = TRUE` when PSU IDs are not globally unique
 #'   (e.g., NHANES, where PSU IDs restart from 1 in each stratum). Requires
 #'   `strata` to be specified. Default `FALSE`.
-#' @param calibration A list of calibration data elements produced by
-#'   [as_caldata()], or `NULL` (default) for no calibration adjustment.
-#'   When non-`NULL`, variance estimation routines apply a
-#'   Deville-Sarndal calibration projection to reduce standard errors
-#'   proportional to the correlation between auxiliary variables and the
-#'   outcome. Equivalent to assigning `design@calibration <- list(cd)`
-#'   after construction. Default `NULL`.
+#' @param calibration A list of calibration data elements, each produced by
+#'   [as_caldata()], or `NULL` (default) for no calibration adjustment. When
+#'   non-`NULL`, variance estimation applies a Deville-Sarndal GREG projection
+#'   that reduces standard errors proportional to the correlation between the
+#'   auxiliary variables and the outcome. Equivalent to assigning
+#'   `design@calibration <- list(cd)` after construction.
+#'
+#'   **Known limitations** (not validated at construction time):
+#'   - *Weight consistency*: surveycore cannot verify that `cd$w` encodes the
+#'     same base weights as the design weight column. Mismatched base weights
+#'     produce incorrect variance estimates.
+#'   - *Stale calibration after `update_design()`*: changing the weight column
+#'     on a calibrated design with [update_design()] makes `@calibration`
+#'     stale. Clear `@calibration` manually after any weight column change.
 #'
 #' @return A `survey_taylor` object.
 #'
@@ -528,6 +535,10 @@ as_survey <- function(
   metadata <- .extract_haven_metadata(data)
   metadata <- .promote_weighting_history(data, metadata)
 
+  # ── Validate calibration argument ──────────────────────────────────────────
+
+  .validate_calibration_arg(calibration, nrow(data))
+
   # ── Construct and return survey_taylor object ───────────────────────────────
 
   survey_taylor(
@@ -580,11 +591,17 @@ as_survey <- function(
 #' @param mse Logical. If `TRUE` (default), use mean-squared-error estimates
 #'   (subtract the full-sample estimate rather than the mean replicate estimate
 #'   when computing variance). Recommended for most designs.
-#' @param calibration A list of calibration data elements produced by
-#'   [as_caldata()], or `NULL` (default) for no calibration adjustment.
-#'   Stored at `@calibration` for reproducibility. Currently ignored by the
-#'   replicate variance estimator — variance is computed from replicate weights
-#'   only. Default `NULL`.
+#' @param calibration A list of calibration data elements, each produced by
+#'   [as_caldata()], or `NULL` (default). Stored at `@calibration` for
+#'   provenance and reproducibility. **Not used in variance estimation**: the
+#'   replicate variance estimator ignores `@calibration` entirely — calibration
+#'   is already encoded in the replicate weights.
+#'
+#'   **Known limitations** (not validated at construction time):
+#'   - *Weight consistency*: surveycore cannot verify that `cd$w` encodes the
+#'     same base weights as the design weight column.
+#'   - *Stale calibration after `update_design()`*: changing the weight column
+#'     makes `@calibration` stale; clear it manually.
 #'
 #' @return A `survey_replicate` object.
 #'
@@ -761,6 +778,10 @@ as_survey_replicate <- function(
 
   metadata <- .extract_haven_metadata(data)
   metadata <- .promote_weighting_history(data, metadata)
+
+  # ── Validate calibration argument ──────────────────────────────────────────
+
+  .validate_calibration_arg(calibration, nrow(data))
 
   # ── Construct and return survey_replicate object ────────────────────────────
 

--- a/R/core-constructors.R
+++ b/R/core-constructors.R
@@ -51,6 +51,13 @@
 #'   distinct PSUs. Set `nest = TRUE` when PSU IDs are not globally unique
 #'   (e.g., NHANES, where PSU IDs restart from 1 in each stratum). Requires
 #'   `strata` to be specified. Default `FALSE`.
+#' @param calibration A list of calibration data elements produced by
+#'   [as_caldata()], or `NULL` (default) for no calibration adjustment.
+#'   When non-`NULL`, variance estimation routines apply a
+#'   Deville-Sarndal calibration projection to reduce standard errors
+#'   proportional to the correlation between auxiliary variables and the
+#'   outcome. Equivalent to assigning `design@calibration <- list(cd)`
+#'   after construction. Default `NULL`.
 #'
 #' @return A `survey_taylor` object.
 #'
@@ -90,10 +97,10 @@
 #' # Full NHANES design: stratified cluster with PSU IDs nested within strata
 #' d <- as_survey(
 #'   nhanes_2017,
-#'   ids     = sdmvpsu,
+#'   ids = sdmvpsu,
 #'   weights = wtint2yr,
-#'   strata  = sdmvstra,
-#'   nest    = TRUE
+#'   strata = sdmvstra,
+#'   nest = TRUE
 #' )
 #'
 #' # Stratified design without PSU cluster IDs
@@ -101,14 +108,19 @@
 #'
 #' # Blood pressure analysis: filter to exam participants, use MEC weight
 #' exam <- nhanes_2017[nhanes_2017$ridstatr == 2, ]
-#' d_bp <- as_survey(exam, ids = sdmvpsu, weights = wtmec2yr,
-#'                   strata = sdmvstra, nest = TRUE)
+#' d_bp <- as_survey(
+#'   exam,
+#'   ids = sdmvpsu,
+#'   weights = wtmec2yr,
+#'   strata = sdmvstra,
+#'   nest = TRUE
+#' )
 #'
 #' # c() to combine multiple columns — sketched on a synthetic two-stage frame
 #' df <- data.frame(
 #'   psu = rep(1:5, each = 4),
 #'   ssu = 1:20,
-#'   wt  = runif(20, 0.5, 2)
+#'   wt = runif(20, 0.5, 2)
 #' )
 #' d_ms <- as_survey(df, ids = c(psu, ssu), weights = wt)
 #'
@@ -120,7 +132,6 @@
 #'   weights = starts_with("wtssn"),
 #'   nest = TRUE
 #' )
-#'
 #' @references
 #' Sarndal, C-E., Swensson, B. and Wretman, J. (1991)
 #' \emph{Model Assisted Survey Sampling}. Springer.
@@ -145,7 +156,8 @@ as_survey <- function(
   weights = NULL,
   strata = NULL,
   fpc = NULL,
-  nest = FALSE
+  nest = FALSE,
+  calibration = NULL
 ) {
   call <- match.call()
 
@@ -522,6 +534,7 @@ as_survey <- function(
     data = data,
     metadata = metadata,
     variables = variables,
+    calibration = calibration,
     call = call
   )
 }
@@ -567,6 +580,11 @@ as_survey <- function(
 #' @param mse Logical. If `TRUE` (default), use mean-squared-error estimates
 #'   (subtract the full-sample estimate rather than the mean replicate estimate
 #'   when computing variance). Recommended for most designs.
+#' @param calibration A list of calibration data elements produced by
+#'   [as_caldata()], or `NULL` (default) for no calibration adjustment.
+#'   Stored at `@calibration` for reproducibility. Currently ignored by the
+#'   replicate variance estimator — variance is computed from replicate weights
+#'   only. Default `NULL`.
 #'
 #' @return A `survey_replicate` object.
 #'
@@ -601,19 +619,18 @@ as_survey <- function(
 #' # ACS PUMS Wyoming: 80 successive-difference replicate weights
 #' d_acs <- as_survey_replicate(
 #'   acs_pums_wy,
-#'   weights    = pwgtp,
+#'   weights = pwgtp,
 #'   repweights = pwgtp1:pwgtp80,
-#'   type       = "successive-difference"
+#'   type = "successive-difference"
 #' )
 #'
 #' # Explicit replicate columns using c()
 #' d_sub <- as_survey_replicate(
 #'   acs_pums_wy,
-#'   weights    = pwgtp,
+#'   weights = pwgtp,
 #'   repweights = c(pwgtp1, pwgtp2, pwgtp3, pwgtp4),
-#'   type       = "JK1"
+#'   type = "JK1"
 #' )
-#'
 #' @references
 #' Judkins, D.R. (1990) Fay's method for variance estimation.
 #' \emph{Journal of the American Statistical Association}
@@ -650,7 +667,8 @@ as_survey_replicate <- function(
   rscales = NULL,
   fpc = NULL,
   fpctype = c("fraction", "correction"),
-  mse = TRUE
+  mse = TRUE,
+  calibration = NULL
 ) {
   call <- match.call()
   type <- match.arg(type)
@@ -750,6 +768,7 @@ as_survey_replicate <- function(
     data = data,
     metadata = metadata,
     variables = variables,
+    calibration = calibration,
     call = call
   )
 }
@@ -811,32 +830,31 @@ as_survey_replicate <- function(
 #' @examples
 #' # Minimal two-phase design: Phase 1 = full cohort, Phase 2 = random subset
 #' df <- data.frame(
-#'   id        = 1:20,
-#'   wt        = rep(2, 20),
+#'   id = 1:20,
+#'   wt = rep(2, 20),
 #'   in_phase2 = c(rep(TRUE, 10), rep(FALSE, 10)),
-#'   y         = rnorm(20)
+#'   y = rnorm(20)
 #' )
 #' phase1 <- as_survey(df, ids = id, weights = wt)
 #' d2 <- as_survey_twophase(phase1, subset = in_phase2)
 #'
 #' # With Phase 2 stratification and inclusion probabilities
 #' df2 <- data.frame(
-#'   id          = 1:30,
-#'   wt          = rep(3, 30),
-#'   in_phase2   = c(rep(TRUE, 15), rep(FALSE, 15)),
-#'   arm         = rep(c("A", "B", "C"), 10),
+#'   id = 1:30,
+#'   wt = rep(3, 30),
+#'   in_phase2 = c(rep(TRUE, 15), rep(FALSE, 15)),
+#'   arm = rep(c("A", "B", "C"), 10),
 #'   subsamprate = rep(c(0.5, 0.7, 0.3), 10),
-#'   y           = rnorm(30)
+#'   y = rnorm(30)
 #' )
 #' phase1b <- as_survey(df2, ids = id, weights = wt)
 #' d2b <- as_survey_twophase(
 #'   phase1b,
 #'   strata2 = arm,
-#'   probs2  = subsamprate,
-#'   subset  = in_phase2,
-#'   method  = "full"
+#'   probs2 = subsamprate,
+#'   subset = in_phase2,
+#'   method = "full"
 #' )
-#'
 #' @references
 #' Sarndal, C-E., Swensson, B. and Wretman, J. (1992)
 #' \emph{Model Assisted Survey Sampling}. Springer.
@@ -1213,12 +1231,11 @@ as_survey_twophase <- function(
 #' @examples
 #' # Minimal: pre-computed calibration weights from an external tool
 #' df <- data.frame(
-#'   y      = rnorm(200),
-#'   age    = sample(c("18-34", "35-54", "55+"), 200, replace = TRUE),
+#'   y = rnorm(200),
+#'   age = sample(c("18-34", "35-54", "55+"), 200, replace = TRUE),
 #'   cal_wt = runif(200, 0.5, 2.5)
 #' )
 #' d <- as_survey_nonprob(df, weights = cal_wt)
-#'
 #' @seealso
 #'   [as_survey()] for probability designs with Taylor variance,
 #'   [as_survey_replicate()] for replicate-weight designs
@@ -1308,18 +1325,22 @@ as_survey_nonprob <- function(
     R <- length(repweights_vars)
 
     # Step 8: normalize "jackknife" alias to "JK1"
-    if (is.character(type) &&
+    if (
+      is.character(type) &&
         length(type) == 1L &&
-        identical(type, "jackknife")) {
+        identical(type, "jackknife")
+    ) {
       type <- "JK1"
     }
 
     # Step 9: validate type — must be a single string in the supported set
     valid_types <- c("bootstrap", "JK1", "JK2", "JKn")
-    if (!is.character(type) ||
+    if (
+      !is.character(type) ||
         length(type) != 1L ||
         is.na(type) ||
-        !type %in% valid_types) {
+        !type %in% valid_types
+    ) {
       cli::cli_abort(
         c(
           "x" = paste0(
@@ -1377,14 +1398,18 @@ as_survey_nonprob <- function(
     }
 
     # Step 12: rscales default
-    if (is.null(rscales)) rscales <- rep(1, R)
+    if (is.null(rscales)) {
+      rscales <- rep(1, R)
+    }
 
     # Validate rscales (length mismatch and NA/negative)
     .validate_rscales(rscales, R)
 
     # Validate reference_sample type if provided
-    if (!is.null(reference_sample) &&
-        !S7::S7_inherits(reference_sample, survey_taylor)) {
+    if (
+      !is.null(reference_sample) &&
+        !S7::S7_inherits(reference_sample, survey_taylor)
+    ) {
       cli::cli_abort(
         c(
           "x" = paste0(
@@ -1445,23 +1470,25 @@ as_survey_nonprob <- function(
 
     # Build @variables with all 5 repweight keys populated
     variables <- list(
-      weights        = weights_var,
-      repweights     = repweights_vars,
-      type           = type,
-      scale          = scale,
-      rscales        = rscales,
-      mse            = isTRUE(mse),
+      weights = weights_var,
+      repweights = repweights_vars,
+      type = type,
+      scale = scale,
+      rscales = rscales,
+      mse = isTRUE(mse),
       probs_provided = FALSE,
-      ids            = NULL,
-      strata         = NULL,
-      fpc            = NULL,
-      nest           = FALSE,
-      visible_vars   = NULL
+      ids = NULL,
+      strata = NULL,
+      fpc = NULL,
+      nest = FALSE,
+      visible_vars = NULL
     )
   } else {
     # No repweights — validate reference_sample type if provided
-    if (!is.null(reference_sample) &&
-        !S7::S7_inherits(reference_sample, survey_taylor)) {
+    if (
+      !is.null(reference_sample) &&
+        !S7::S7_inherits(reference_sample, survey_taylor)
+    ) {
       cli::cli_abort(
         c(
           "x" = paste0(
@@ -1479,30 +1506,30 @@ as_survey_nonprob <- function(
 
     # No-repweights path — all 5 keys present as NULL
     variables <- list(
-      weights        = weights_var,
-      repweights     = NULL,
-      type           = NULL,
-      scale          = NULL,
-      rscales        = NULL,
-      mse            = NULL,
+      weights = weights_var,
+      repweights = NULL,
+      type = NULL,
+      scale = NULL,
+      rscales = NULL,
+      mse = NULL,
       probs_provided = FALSE,
-      ids            = NULL,
-      strata         = NULL,
-      fpc            = NULL,
-      nest           = FALSE,
-      visible_vars   = NULL
+      ids = NULL,
+      strata = NULL,
+      fpc = NULL,
+      nest = FALSE,
+      visible_vars = NULL
     )
   }
 
   # ── Construct and return survey_nonprob object ───────────────────────────
 
   survey_nonprob(
-    data             = data,
-    metadata         = metadata,
-    variables        = variables,
-    calibration      = calibration,
+    data = data,
+    metadata = metadata,
+    variables = variables,
+    calibration = calibration,
     reference_sample = reference_sample,
-    call             = call
+    call = call
   )
 }
 
@@ -1563,10 +1590,20 @@ as_survey_nonprob <- function(
 #' @return A `survey_collection` object containing the supplied surveys.
 #'
 #' @examples
-#' d1 <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
-#'                 strata = vstrat, nest = TRUE)
-#' d2 <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
-#'                 strata = vstrat, nest = TRUE)
+#' d1 <- as_survey(
+#'   gss_2024,
+#'   ids = vpsu,
+#'   weights = wtssps,
+#'   strata = vstrat,
+#'   nest = TRUE
+#' )
+#' d2 <- as_survey(
+#'   gss_2024,
+#'   ids = vpsu,
+#'   weights = wtssps,
+#'   strata = vstrat,
+#'   nest = TRUE
+#' )
 #'
 #' # Explicit names
 #' coll <- as_survey_collection("2020" = d1, "2024" = d2)
@@ -1579,7 +1616,6 @@ as_survey_nonprob <- function(
 #' # Uniform grouping across members
 #' coll3 <- as_survey_collection(d1, d2, group = vstrat)
 #' coll3@groups
-#'
 #' @seealso [survey_collection], [add_survey()], [remove_survey()]
 #' @family collections
 #' @export

--- a/man/as_caldata.Rd
+++ b/man/as_caldata.Rd
@@ -51,6 +51,40 @@ Taylor-series and replicate-weight variance estimates.
 GREG-GLM variance is implemented in a future release. The calibration
 correction is not applied in the GLM variance path.
 }
+\section{Inter-package contract}{
+
+\strong{GREG calibration (single auxiliary variable or multiple uncorrelated
+variables):} pass the model matrix from \code{model.matrix(formula, data)}
+directly -- one column per calibration variable. The intercept column
+(\code{(Intercept)}) is included by default from \code{model.matrix()}; it
+contributes one degree of freedom to the calibration adjustment.
+
+\strong{Raking (multiple calibration margins, Architecture A):} combine all
+margin indicator matrices into a single matrix before calling
+\code{as_caldata()}. Column-bind the matrices and drop one reference column
+per margin to avoid rank deficiency (e.g., drop the last column of each
+per-margin block). Pass this single combined matrix. Do \strong{not} call
+\code{as_caldata()} once per margin; that uses Architecture B (sequential),
+which requires a separate \code{as_caldata()} element per calibration pass
+and stores them all in the \code{@calibration} list.
+
+\strong{q_k = 1 assumption:} \code{as_caldata()} always assumes
+\eqn{q_k = 1} (uniform calibration weights). If your calibration uses a
+non-unity \eqn{q_k} (variance-function weights from \code{survey::calibrate(
+calfun = "linear", variance = ...)}) you must absorb those weights into
+\code{model_matrix} before calling \code{as_caldata()}.
+}
+
+\section{For \code{survey_replicate} designs}{
+
+\code{@calibration} on a \code{survey_replicate} object is
+\strong{provenance-only}: it documents that the replicate weights were
+derived from a calibrated design, but the variance estimator does not apply
+any GREG projection. Calibration is already encoded in the replicate weights
+themselves. Do not expect \code{get_means()} SE to differ between a
+\code{survey_replicate} with and without \code{@calibration} set.
+}
+
 \examples{
 # Minimal example: 3-unit design, intercept-only calibration
 base_weights <- c(2.5, 3.0, 4.0)

--- a/man/as_survey.Rd
+++ b/man/as_survey.Rd
@@ -11,7 +11,8 @@ as_survey(
   weights = NULL,
   strata = NULL,
   fpc = NULL,
-  nest = FALSE
+  nest = FALSE,
+  calibration = NULL
 )
 }
 \arguments{
@@ -47,6 +48,14 @@ strata — i.e., the same ID value in two different strata refers to two
 distinct PSUs. Set \code{nest = TRUE} when PSU IDs are not globally unique
 (e.g., NHANES, where PSU IDs restart from 1 in each stratum). Requires
 \code{strata} to be specified. Default \code{FALSE}.}
+
+\item{calibration}{A list of calibration data elements produced by
+\code{\link[=as_caldata]{as_caldata()}}, or \code{NULL} (default) for no calibration adjustment.
+When non-\code{NULL}, variance estimation routines apply a
+Deville-Sarndal calibration projection to reduce standard errors
+proportional to the correlation between auxiliary variables and the
+outcome. Equivalent to assigning \code{design@calibration <- list(cd)}
+after construction. Default \code{NULL}.}
 }
 \value{
 A \code{survey_taylor} object.

--- a/man/as_survey.Rd
+++ b/man/as_survey.Rd
@@ -49,13 +49,22 @@ distinct PSUs. Set \code{nest = TRUE} when PSU IDs are not globally unique
 (e.g., NHANES, where PSU IDs restart from 1 in each stratum). Requires
 \code{strata} to be specified. Default \code{FALSE}.}
 
-\item{calibration}{A list of calibration data elements produced by
-\code{\link[=as_caldata]{as_caldata()}}, or \code{NULL} (default) for no calibration adjustment.
-When non-\code{NULL}, variance estimation routines apply a
-Deville-Sarndal calibration projection to reduce standard errors
-proportional to the correlation between auxiliary variables and the
-outcome. Equivalent to assigning \code{design@calibration <- list(cd)}
-after construction. Default \code{NULL}.}
+\item{calibration}{A list of calibration data elements, each produced by
+\code{\link[=as_caldata]{as_caldata()}}, or \code{NULL} (default) for no calibration adjustment. When
+non-\code{NULL}, variance estimation applies a Deville-Sarndal GREG projection
+that reduces standard errors proportional to the correlation between the
+auxiliary variables and the outcome. Equivalent to assigning
+\code{design@calibration <- list(cd)} after construction.
+
+\strong{Known limitations} (not validated at construction time):
+\itemize{
+\item \emph{Weight consistency}: surveycore cannot verify that \code{cd$w} encodes the
+same base weights as the design weight column. Mismatched base weights
+produce incorrect variance estimates.
+\item \emph{Stale calibration after \code{update_design()}}: changing the weight column
+on a calibrated design with \code{\link[=update_design]{update_design()}} makes \verb{@calibration}
+stale. Clear \verb{@calibration} manually after any weight column change.
+}}
 }
 \value{
 A \code{survey_taylor} object.
@@ -108,10 +117,10 @@ d <- from_svydesign(d_survey)
 # Full NHANES design: stratified cluster with PSU IDs nested within strata
 d <- as_survey(
   nhanes_2017,
-  ids     = sdmvpsu,
+  ids = sdmvpsu,
   weights = wtint2yr,
-  strata  = sdmvstra,
-  nest    = TRUE
+  strata = sdmvstra,
+  nest = TRUE
 )
 
 # Stratified design without PSU cluster IDs
@@ -119,14 +128,19 @@ d_strat <- as_survey(nhanes_2017, weights = wtint2yr, strata = sdmvstra)
 
 # Blood pressure analysis: filter to exam participants, use MEC weight
 exam <- nhanes_2017[nhanes_2017$ridstatr == 2, ]
-d_bp <- as_survey(exam, ids = sdmvpsu, weights = wtmec2yr,
-                  strata = sdmvstra, nest = TRUE)
+d_bp <- as_survey(
+  exam,
+  ids = sdmvpsu,
+  weights = wtmec2yr,
+  strata = sdmvstra,
+  nest = TRUE
+)
 
 # c() to combine multiple columns — sketched on a synthetic two-stage frame
 df <- data.frame(
   psu = rep(1:5, each = 4),
   ssu = 1:20,
-  wt  = runif(20, 0.5, 2)
+  wt = runif(20, 0.5, 2)
 )
 d_ms <- as_survey(df, ids = c(psu, ssu), weights = wt)
 
@@ -138,7 +152,6 @@ d_h <- as_survey(
   weights = starts_with("wtssn"),
   nest = TRUE
 )
-
 }
 \references{
 Sarndal, C-E., Swensson, B. and Wretman, J. (1991)

--- a/man/as_survey_collection.Rd
+++ b/man/as_survey_collection.Rd
@@ -64,10 +64,20 @@ a \code{surveycore_warning_collection_duplicate_name_repaired} warning is
 emitted showing the \code{original -> repaired} mapping.
 }
 \examples{
-d1 <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
-                strata = vstrat, nest = TRUE)
-d2 <- as_survey(gss_2024, ids = vpsu, weights = wtssps,
-                strata = vstrat, nest = TRUE)
+d1 <- as_survey(
+  gss_2024,
+  ids = vpsu,
+  weights = wtssps,
+  strata = vstrat,
+  nest = TRUE
+)
+d2 <- as_survey(
+  gss_2024,
+  ids = vpsu,
+  weights = wtssps,
+  strata = vstrat,
+  nest = TRUE
+)
 
 # Explicit names
 coll <- as_survey_collection("2020" = d1, "2024" = d2)
@@ -80,7 +90,6 @@ names(coll2)
 # Uniform grouping across members
 coll3 <- as_survey_collection(d1, d2, group = vstrat)
 coll3@groups
-
 }
 \seealso{
 \link{survey_collection}, \code{\link[=add_survey]{add_survey()}}, \code{\link[=remove_survey]{remove_survey()}}

--- a/man/as_survey_nonprob.Rd
+++ b/man/as_survey_nonprob.Rd
@@ -147,12 +147,11 @@ non-probability samples.
 \examples{
 # Minimal: pre-computed calibration weights from an external tool
 df <- data.frame(
-  y      = rnorm(200),
-  age    = sample(c("18-34", "35-54", "55+"), 200, replace = TRUE),
+  y = rnorm(200),
+  age = sample(c("18-34", "35-54", "55+"), 200, replace = TRUE),
   cal_wt = runif(200, 0.5, 2.5)
 )
 d <- as_survey_nonprob(df, weights = cal_wt)
-
 }
 \references{
 Valliant, R. (2020). Comparing alternatives for estimation from

--- a/man/as_survey_replicate.Rd
+++ b/man/as_survey_replicate.Rd
@@ -58,11 +58,19 @@ Default \code{"fraction"}. Case-sensitive.}
 (subtract the full-sample estimate rather than the mean replicate estimate
 when computing variance). Recommended for most designs.}
 
-\item{calibration}{A list of calibration data elements produced by
-\code{\link[=as_caldata]{as_caldata()}}, or \code{NULL} (default) for no calibration adjustment.
-Stored at \verb{@calibration} for reproducibility. Currently ignored by the
-replicate variance estimator — variance is computed from replicate weights
-only. Default \code{NULL}.}
+\item{calibration}{A list of calibration data elements, each produced by
+\code{\link[=as_caldata]{as_caldata()}}, or \code{NULL} (default). Stored at \verb{@calibration} for
+provenance and reproducibility. \strong{Not used in variance estimation}: the
+replicate variance estimator ignores \verb{@calibration} entirely — calibration
+is already encoded in the replicate weights.
+
+\strong{Known limitations} (not validated at construction time):
+\itemize{
+\item \emph{Weight consistency}: surveycore cannot verify that \code{cd$w} encodes the
+same base weights as the design weight column.
+\item \emph{Stale calibration after \code{update_design()}}: changing the weight column
+makes \verb{@calibration} stale; clear it manually.
+}}
 }
 \value{
 A \code{survey_replicate} object.
@@ -111,19 +119,18 @@ This behaviour matches the \code{survey} package reference implementation.
 # ACS PUMS Wyoming: 80 successive-difference replicate weights
 d_acs <- as_survey_replicate(
   acs_pums_wy,
-  weights    = pwgtp,
+  weights = pwgtp,
   repweights = pwgtp1:pwgtp80,
-  type       = "successive-difference"
+  type = "successive-difference"
 )
 
 # Explicit replicate columns using c()
 d_sub <- as_survey_replicate(
   acs_pums_wy,
-  weights    = pwgtp,
+  weights = pwgtp,
   repweights = c(pwgtp1, pwgtp2, pwgtp3, pwgtp4),
-  type       = "JK1"
+  type = "JK1"
 )
-
 }
 \references{
 Judkins, D.R. (1990) Fay's method for variance estimation.

--- a/man/as_survey_replicate.Rd
+++ b/man/as_survey_replicate.Rd
@@ -14,7 +14,8 @@ as_survey_replicate(
   rscales = NULL,
   fpc = NULL,
   fpctype = c("fraction", "correction"),
-  mse = TRUE
+  mse = TRUE,
+  calibration = NULL
 )
 }
 \arguments{
@@ -56,6 +57,12 @@ Default \code{"fraction"}. Case-sensitive.}
 \item{mse}{Logical. If \code{TRUE} (default), use mean-squared-error estimates
 (subtract the full-sample estimate rather than the mean replicate estimate
 when computing variance). Recommended for most designs.}
+
+\item{calibration}{A list of calibration data elements produced by
+\code{\link[=as_caldata]{as_caldata()}}, or \code{NULL} (default) for no calibration adjustment.
+Stored at \verb{@calibration} for reproducibility. Currently ignored by the
+replicate variance estimator — variance is computed from replicate weights
+only. Default \code{NULL}.}
 }
 \value{
 A \code{survey_replicate} object.

--- a/man/as_survey_twophase.Rd
+++ b/man/as_survey_twophase.Rd
@@ -75,32 +75,31 @@ clustered designs.
 \examples{
 # Minimal two-phase design: Phase 1 = full cohort, Phase 2 = random subset
 df <- data.frame(
-  id        = 1:20,
-  wt        = rep(2, 20),
+  id = 1:20,
+  wt = rep(2, 20),
   in_phase2 = c(rep(TRUE, 10), rep(FALSE, 10)),
-  y         = rnorm(20)
+  y = rnorm(20)
 )
 phase1 <- as_survey(df, ids = id, weights = wt)
 d2 <- as_survey_twophase(phase1, subset = in_phase2)
 
 # With Phase 2 stratification and inclusion probabilities
 df2 <- data.frame(
-  id          = 1:30,
-  wt          = rep(3, 30),
-  in_phase2   = c(rep(TRUE, 15), rep(FALSE, 15)),
-  arm         = rep(c("A", "B", "C"), 10),
+  id = 1:30,
+  wt = rep(3, 30),
+  in_phase2 = c(rep(TRUE, 15), rep(FALSE, 15)),
+  arm = rep(c("A", "B", "C"), 10),
   subsamprate = rep(c(0.5, 0.7, 0.3), 10),
-  y           = rnorm(30)
+  y = rnorm(30)
 )
 phase1b <- as_survey(df2, ids = id, weights = wt)
 d2b <- as_survey_twophase(
   phase1b,
   strata2 = arm,
-  probs2  = subsamprate,
-  subset  = in_phase2,
-  method  = "full"
+  probs2 = subsamprate,
+  subset = in_phase2,
+  method = "full"
 )
-
 }
 \references{
 Sarndal, C-E., Swensson, B. and Wretman, J. (1992)

--- a/man/get_means.Rd
+++ b/man/get_means.Rd
@@ -104,8 +104,13 @@ with optional grouping, uncertainty quantification, and metadata-driven
 labelling.
 }
 \examples{
-d <- as_survey(nhanes_2017, ids = sdmvpsu, weights = wtint2yr,
-               strata = sdmvstra, nest = TRUE)
+d <- as_survey(
+  nhanes_2017,
+  ids = sdmvpsu,
+  weights = wtint2yr,
+  strata = sdmvstra,
+  nest = TRUE
+)
 get_means(d, ridageyr)
 
 # With grouped estimate
@@ -113,7 +118,6 @@ get_means(d, ridageyr, group = riagendr)
 
 # AAPOR-compliant
 get_means(d, ridageyr, variance = c("ci", "moe"), n_weighted = TRUE)
-
 }
 \seealso{
 Other analysis: 

--- a/man/update_design.Rd
+++ b/man/update_design.Rd
@@ -55,12 +55,16 @@ changed variables.
 # NHANES has two weight columns for different analysis types;
 # start with the MEC examination weight for exam participants
 exam <- nhanes_2017[nhanes_2017$ridstatr == 2, ]
-d <- as_survey(exam, ids = sdmvpsu, weights = wtmec2yr,
-               strata = sdmvstra, nest = TRUE)
+d <- as_survey(
+  exam,
+  ids = sdmvpsu,
+  weights = wtmec2yr,
+  strata = sdmvstra,
+  nest = TRUE
+)
 
 # Switch to interview weight for interview-based variables
 d_updated <- update_design(d, weights = wtint2yr)
-
 }
 \seealso{
 \code{\link[=as_survey]{as_survey()}} to create a \code{survey_taylor} object,

--- a/plans/error-messages.md
+++ b/plans/error-messages.md
@@ -325,6 +325,8 @@ against the messages defined here.
 | CAL-12 | `.apply_caldata_projection()` | NULL element found in caldata list | ERROR | `surveycore_error_caldata_invalid_element` | `"x" = "caldata element(s) {bad_idx} are NULL."` |
 | CAL-13 | `update_design()` | Weight column changes on a calibrated design | WARNING | `surveycore_warning_weight_change_invalidates_calibration` | `"!" = "Weight column changed on a calibrated design."` |
 | CAL-14 | `get_means()` / variance | Calibration df reduction >= design df | WARNING | `surveycore_warning_zero_df_after_calibration` | `"!" = "Calibration reduces design df ({df_design}) to {df_final}."` |
+| CAL-15 | `as_survey()`, `as_survey_replicate()` | `calibration` argument is non-`NULL` but not a list | ERROR | `surveycore_error_calibration_not_list` | `"x" = "{.arg calibration} must be a list of {.fn as_caldata} outputs or {.code NULL}.", "i" = "Got {.cls {class(calibration)[[1L]]}}."` |
+| CAL-16 | `as_survey()`, `as_survey_replicate()` | A list element of `calibration` fails the caldata structure check | ERROR | `surveycore_error_caldata_invalid_element` | `"x" = "Element {.val {i}} of {.arg calibration} is not a valid caldata object.", "i" = "Each element must be a named list with fields {.val qr}, {.val w}, {.val stage}, and {.val index}, produced by {.fn as_caldata}."` (reuses class from CAL-12) |
 
 ---
 

--- a/plans/error-messages.md
+++ b/plans/error-messages.md
@@ -391,3 +391,4 @@ Which test files cover which error table rows:
 | `test-analysis-pool-pvals.R` | PP-1, PP-2, PP-3, PP-4, PP-5, PP-6, PP-7, PP-8 |
 | `test-effective-n.R` | EN-1, EN-2, EN-3, EN-4 |
 | `test-metadata-system.R` | HI-1, HI-2, HI-3 (PR 1 — higher_is); RC-1, RC-2, RC-3 (PR 2 — reverse_coded) |
+| `test-calibration.R` | CAL-15, CAL-16 |

--- a/tests/testthat/_snaps/calibration.md
+++ b/tests/testthat/_snaps/calibration.md
@@ -145,3 +145,150 @@
       i All @calibration list elements must be constructed via `as_caldata()`.
       v Inspect `design@calibration` for NULL entries.
 
+# .validate_calibration_arg() errors on numeric vector (CAL-15) [direct]
+
+    Code
+      surveycore:::.validate_calibration_arg(c(1, 2, 3), 10L)
+    Condition
+      Error in `surveycore:::.validate_calibration_arg()`:
+      x `calibration` must be a list of `as_caldata()` outputs or `NULL`.
+      i Got <numeric>.
+
+# .validate_calibration_arg() errors on data frame (CAL-15) [direct]
+
+    Code
+      surveycore:::.validate_calibration_arg(data.frame(x = 1:3), 10L)
+    Condition
+      Error in `surveycore:::.validate_calibration_arg()`:
+      x `calibration` must be a list of `as_caldata()` outputs or `NULL`.
+      i Got <data.frame>.
+
+# .validate_calibration_arg() errors on bare caldata (not wrapped) (CAL-15) [direct]
+
+    Code
+      surveycore:::.validate_calibration_arg(bare_cd, 10L)
+    Condition
+      Error in `surveycore:::.validate_calibration_arg()`:
+      x `calibration` must be a list of `as_caldata()` outputs or `NULL`.
+      i Got <list>. It looks like you passed the result of `as_caldata()` directly -- wrap it in `list()`: `calibration = list(cd)`.
+
+# .validate_calibration_arg() errors on NULL element in list (CAL-16) [direct]
+
+    Code
+      surveycore:::.validate_calibration_arg(list(cd, NULL), 10L)
+    Condition
+      Error in `surveycore:::.validate_calibration_arg()`:
+      x Element 2 of `calibration` is not a valid caldata object.
+      i Each element must be a named list with fields "qr", "w", "stage", and "index", produced by `as_caldata()`.
+
+# .validate_calibration_arg() errors on element missing index field (CAL-16) [direct]
+
+    Code
+      surveycore:::.validate_calibration_arg(list(cd_bad), 10L)
+    Condition
+      Error in `surveycore:::.validate_calibration_arg()`:
+      x Element 1 of `calibration` is not a valid caldata object.
+      i Each element must be a named list with fields "qr", "w", "stage", and "index", produced by `as_caldata()`.
+
+# .validate_calibration_arg() errors when length(cd$w) != nrow_data (CAL-16) [direct]
+
+    Code
+      surveycore:::.validate_calibration_arg(list(cd), 5L)
+    Condition
+      Error in `surveycore:::.validate_calibration_arg()`:
+      x Element 1 of `calibration` is not a valid caldata object.
+      i Each element must be a named list with fields "qr", "w", "stage", and "index", produced by `as_caldata()`.
+
+# as_survey() errors on bare caldata (not wrapped) (CAL-15)
+
+    Code
+      as_survey(df, weights = wt, calibration = bare_cd)
+    Condition
+      Error in `.validate_calibration_arg()`:
+      x `calibration` must be a list of `as_caldata()` outputs or `NULL`.
+      i Got <list>. It looks like you passed the result of `as_caldata()` directly -- wrap it in `list()`: `calibration = list(cd)`.
+
+# as_survey() errors on numeric vector calibration (CAL-15)
+
+    Code
+      as_survey(df, weights = wt, calibration = c(1, 2, 3))
+    Condition
+      Error in `.validate_calibration_arg()`:
+      x `calibration` must be a list of `as_caldata()` outputs or `NULL`.
+      i Got <numeric>.
+
+# as_survey() errors on data frame calibration (CAL-15)
+
+    Code
+      as_survey(df, weights = wt, calibration = data.frame(x = 1:3))
+    Condition
+      Error in `.validate_calibration_arg()`:
+      x `calibration` must be a list of `as_caldata()` outputs or `NULL`.
+      i Got <data.frame>.
+
+# as_survey() errors on element missing index field (CAL-16)
+
+    Code
+      as_survey(df, weights = wt, calibration = list(cd_bad))
+    Condition
+      Error in `.validate_calibration_arg()`:
+      x Element 1 of `calibration` is not a valid caldata object.
+      i Each element must be a named list with fields "qr", "w", "stage", and "index", produced by `as_caldata()`.
+
+# as_survey() errors on NULL element in calibration list (CAL-16)
+
+    Code
+      as_survey(df, weights = wt, calibration = list(cd, NULL))
+    Condition
+      Error in `.validate_calibration_arg()`:
+      x Element 2 of `calibration` is not a valid caldata object.
+      i Each element must be a named list with fields "qr", "w", "stage", and "index", produced by `as_caldata()`.
+
+# as_survey() errors when length(cd$w) != nrow(data) (CAL-16)
+
+    Code
+      as_survey(df, weights = wt, calibration = list(cd_wrong))
+    Condition
+      Error in `.validate_calibration_arg()`:
+      x Element 1 of `calibration` is not a valid caldata object.
+      i Each element must be a named list with fields "qr", "w", "stage", and "index", produced by `as_caldata()`.
+
+# as_survey() errors on second bad element in two-element list (CAL-16)
+
+    Code
+      as_survey(df, weights = wt, calibration = list(cd_good, cd_bad))
+    Condition
+      Error in `.validate_calibration_arg()`:
+      x Element 2 of `calibration` is not a valid caldata object.
+      i Each element must be a named list with fields "qr", "w", "stage", and "index", produced by `as_caldata()`.
+
+# as_survey_replicate() errors on non-list calibration (CAL-15)
+
+    Code
+      as_survey_replicate(df, weights = wt, repweights = tidyselect::all_of(
+        repwt_cols), type = "BRR", calibration = c(1, 2, 3))
+    Condition
+      Error in `.validate_calibration_arg()`:
+      x `calibration` must be a list of `as_caldata()` outputs or `NULL`.
+      i Got <numeric>.
+
+# as_survey_replicate() errors on invalid caldata structure (CAL-16)
+
+    Code
+      as_survey_replicate(df, weights = wt, repweights = tidyselect::all_of(
+        repwt_cols), type = "BRR", calibration = list(cd_bad))
+    Condition
+      Error in `.validate_calibration_arg()`:
+      x Element 1 of `calibration` is not a valid caldata object.
+      i Each element must be a named list with fields "qr", "w", "stage", and "index", produced by `as_caldata()`.
+
+# as_survey_replicate() errors when length(cd$w) != nrow(data) (CAL-16)
+
+    Code
+      as_survey_replicate(df, weights = wt, repweights = tidyselect::all_of(
+        repwt_cols), type = "BRR", calibration = list(cd_wrong))
+    Condition
+      Error in `.validate_calibration_arg()`:
+      x Element 1 of `calibration` is not a valid caldata object.
+      i Each element must be a named list with fields "qr", "w", "stage", and "index", produced by `as_caldata()`.
+

--- a/tests/testthat/test-calibration.R
+++ b/tests/testthat/test-calibration.R
@@ -1031,6 +1031,7 @@ test_that("as_survey_replicate() with calibration = list() succeeds", {
     type = "BRR",
     calibration = list()
   )
+  test_invariants(d)
   expect_identical(d@calibration, list())
 })
 
@@ -1044,6 +1045,7 @@ test_that("as_survey_replicate() with calibration = NULL succeeds", {
     type = "BRR",
     calibration = NULL
   )
+  test_invariants(d)
   expect_null(d@calibration)
 })
 
@@ -1062,6 +1064,7 @@ test_that("as_survey_replicate() SE unchanged with/without @calibration (provena
     repweights = tidyselect::all_of(repwt_cols),
     type = "BRR"
   )
+  test_invariants(d_without)
   cd <- as_caldata(df$wt, rep(1.05, nrow(df)), matrix(1, nrow(df), 1))
   d_with <- as_survey_replicate(
     df,
@@ -1083,7 +1086,27 @@ test_that("as_survey() stores calibration argument at @calibration", {
   mm <- model.matrix(~strata, df)
   cd <- as_caldata(base_w, g_w, mm)
   d <- as_survey(df, weights = wt, calibration = list(cd))
+  test_invariants(d)
   expect_identical(d@calibration, list(cd))
+})
+
+test_that("as_survey() stores list of two caldata elements at @calibration", {
+  df <- make_survey_data(n = 200L, seed = 10L)
+  cd1 <- as_caldata(df$wt, rep(1.05, nrow(df)), matrix(1, nrow(df), 1))
+  cd2 <- as_caldata(df$wt, rep(1.02, nrow(df)), matrix(1, nrow(df), 1))
+  d <- as_survey(df, weights = wt, calibration = list(cd1, cd2))
+  test_invariants(d)
+  expect_identical(d@calibration, list(cd1, cd2))
+})
+
+test_that("as_survey() @calibration matches whether set via arg or post-construction", {
+  df <- make_survey_data(n = 200L, seed = 11L)
+  cd <- as_caldata(df$wt, rep(1.05, nrow(df)), matrix(1, nrow(df), 1))
+  d_via_arg <- as_survey(df, weights = wt, calibration = list(cd))
+  d_post <- as_survey(df, weights = wt)
+  d_post@calibration <- list(cd)
+  test_invariants(d_via_arg)
+  expect_identical(d_via_arg@calibration, d_post@calibration)
 })
 
 test_that("as_survey_replicate() stores calibration argument at @calibration", {
@@ -1100,5 +1123,6 @@ test_that("as_survey_replicate() stores calibration argument at @calibration", {
     type = "BRR",
     calibration = list(cd)
   )
+  test_invariants(d)
   expect_identical(d@calibration, list(cd))
 })

--- a/tests/testthat/test-calibration.R
+++ b/tests/testthat/test-calibration.R
@@ -630,12 +630,25 @@ test_that("get_means() warns when calibration df reduction >= design df [R-7]", 
 
 test_that("calibration-adjusted SE from get_means() matches survey::rake() oracle [raking, nhanes]", {
   skip_if_not_installed("survey")
-  # Two-margin raking: calibrate to gender proportions, then to linear age.
-  # Oracle: two sequential survey::calibrate() calls (= one raking pass).
-  # surveycore: two accumulated caldata entries.
+  # Two-margin sequential calibration (equivalent to one raking pass) using
+  # factor variables for gender and discretised age groups.
+  # Oracle: two sequential survey::calibrate() calls with factor model matrices.
+  # surveycore: two accumulated caldata entries, one per margin calibration.
+  #
+  # Note: survey::rake() and survey::calibrate() compute different variance
+  # formulas (postStrata vs caldata GREG linearization). This test uses the
+  # calibrate()-based oracle because surveycore's GREG projection exactly
+  # matches survey::calibrate(), not survey::rake().
   nhanes_sub <- nhanes_2017[
     nhanes_2017$wtmec2yr > 0 & nhanes_2017$ridstatr == 2,
   ]
+  nhanes_sub$age_group <- cut(
+    nhanes_sub$ridageyr,
+    breaks = c(0, 18, 40, 60, Inf),
+    right = FALSE
+  )
+  nhanes_sub$riagendr_f <- factor(nhanes_sub$riagendr)
+
   sv_design <- survey::svydesign(
     ids = ~sdmvpsu,
     weights = ~wtmec2yr,
@@ -643,33 +656,49 @@ test_that("calibration-adjusted SE from get_means() matches survey::rake() oracl
     data = nhanes_sub,
     nest = TRUE
   )
-  # Population targets for margin 1 (gender) and margin 2 (age)
-  pop1 <- c(
+
+  # Population targets for each margin calibration
+  pop_gender <- c(
     "(Intercept)" = sum(nhanes_sub$wtmec2yr),
-    riagendr = sum(nhanes_sub$riagendr * nhanes_sub$wtmec2yr)
+    "riagendr_f2" = sum(nhanes_sub$wtmec2yr[nhanes_sub$riagendr_f == "2"])
   )
-  pop2 <- c(
+  pop_age <- c(
     "(Intercept)" = sum(nhanes_sub$wtmec2yr),
-    ridageyr = sum(nhanes_sub$ridageyr * nhanes_sub$wtmec2yr)
+    "age_group[18,40)" = sum(
+      nhanes_sub$wtmec2yr[nhanes_sub$age_group == "[18,40)"]
+    ),
+    "age_group[40,60)" = sum(
+      nhanes_sub$wtmec2yr[nhanes_sub$age_group == "[40,60)"]
+    ),
+    "age_group[60,Inf)" = sum(
+      nhanes_sub$wtmec2yr[nhanes_sub$age_group == "[60,Inf)"]
+    )
   )
-  # Oracle: two sequential calibrations (one pass of raking)
+
+  # Oracle: two sequential calibrations (gender margin, then age-group margin)
   sv_cal1 <- survey::calibrate(
     sv_design,
-    formula = ~riagendr,
-    population = pop1
+    formula = ~riagendr_f,
+    population = pop_gender
   )
-  sv_raked <- survey::calibrate(sv_cal1, formula = ~ridageyr, population = pop2)
+  sv_raked <- survey::calibrate(
+    sv_cal1,
+    formula = ~age_group,
+    population = pop_age
+  )
   sv_se <- as.numeric(
     survey::SE(survey::svymean(~bpxsy1, sv_raked, na.rm = TRUE))
   )
-  # surveycore: two caldata entries
+
+  # surveycore: two caldata entries, one per sequential calibration
   g1 <- weights(sv_cal1) / nhanes_sub$wtmec2yr
-  mm1 <- model.matrix(~riagendr, nhanes_sub)
+  mm1 <- model.matrix(~riagendr_f, nhanes_sub)
   cd1 <- as_caldata(nhanes_sub$wtmec2yr, g1, mm1)
   wt_after1 <- weights(sv_cal1)
   g2 <- weights(sv_raked) / wt_after1
-  mm2 <- model.matrix(~ridageyr, nhanes_sub)
+  mm2 <- model.matrix(~age_group, nhanes_sub)
   cd2 <- as_caldata(wt_after1, g2, mm2)
+
   sc_design <- as_survey(
     nhanes_sub,
     ids = sdmvpsu,
@@ -684,4 +713,34 @@ test_that("calibration-adjusted SE from get_means() matches survey::rake() oracl
   sc_raked@calibration <- list(cd1, cd2)
   sc_se <- get_means(sc_raked, bpxsy1, variance = "se")$se
   expect_equal(sc_se, sv_se, tolerance = 1e-8)
+})
+
+
+# ── Constructor calibration parameter tests ────────────────────────────────────
+
+test_that("as_survey() stores calibration argument at @calibration", {
+  df <- make_survey_data(n = 200L, seed = 1L)
+  base_w <- df$wt
+  g_w <- rep(1, nrow(df))
+  mm <- model.matrix(~strata, df)
+  cd <- as_caldata(base_w, g_w, mm)
+  d <- as_survey(df, weights = wt, calibration = list(cd))
+  expect_identical(d@calibration, list(cd))
+})
+
+test_that("as_survey_replicate() stores calibration argument at @calibration", {
+  df <- make_survey_data(n = 200L, design = "replicate", seed = 2L)
+  base_w <- df$wt
+  g_w <- rep(1, nrow(df))
+  mm <- model.matrix(~strata, df)
+  cd <- as_caldata(base_w, g_w, mm)
+  repwt_cols <- grep("^repwt_", names(df), value = TRUE)
+  d <- as_survey_replicate(
+    df,
+    weights = wt,
+    repweights = tidyselect::all_of(repwt_cols),
+    type = "BRR",
+    calibration = list(cd)
+  )
+  expect_identical(d@calibration, list(cd))
 })

--- a/tests/testthat/test-calibration.R
+++ b/tests/testthat/test-calibration.R
@@ -716,7 +716,365 @@ test_that("calibration-adjusted SE from get_means() matches survey::rake() oracl
 })
 
 
+# ── .validate_calibration_arg() unit tests ───────────────────────────────────
+
+test_that(".validate_calibration_arg() returns invisible TRUE for NULL [direct]", {
+  result <- withVisible(surveycore:::.validate_calibration_arg(NULL, 10L))
+  expect_true(result$value)
+  expect_false(result$visible)
+})
+
+test_that(".validate_calibration_arg() returns invisible TRUE for list() [direct]", {
+  result <- withVisible(surveycore:::.validate_calibration_arg(list(), 10L))
+  expect_true(result$value)
+  expect_false(result$visible)
+})
+
+test_that(".validate_calibration_arg() errors on numeric vector (CAL-15) [direct]", {
+  expect_error(
+    surveycore:::.validate_calibration_arg(c(1, 2, 3), 10L),
+    class = "surveycore_error_calibration_not_list"
+  )
+  expect_snapshot(
+    error = TRUE,
+    surveycore:::.validate_calibration_arg(c(1, 2, 3), 10L)
+  )
+})
+
+test_that(".validate_calibration_arg() errors on data frame (CAL-15) [direct]", {
+  expect_error(
+    surveycore:::.validate_calibration_arg(
+      data.frame(x = 1:3),
+      10L
+    ),
+    class = "surveycore_error_calibration_not_list"
+  )
+  expect_snapshot(
+    error = TRUE,
+    surveycore:::.validate_calibration_arg(data.frame(x = 1:3), 10L)
+  )
+})
+
+test_that(".validate_calibration_arg() errors on bare caldata (not wrapped) (CAL-15) [direct]", {
+  bare_cd <- as_caldata(rep(1, 10), rep(1.1, 10), matrix(1, 10, 1))
+  # bare_cd is a list with all four caldata keys at top level — detected as
+  # a bare (un-wrapped) caldata and triggers CAL-15, not CAL-16.
+  expect_error(
+    surveycore:::.validate_calibration_arg(bare_cd, 10L),
+    class = "surveycore_error_calibration_not_list"
+  )
+  expect_snapshot(
+    error = TRUE,
+    surveycore:::.validate_calibration_arg(bare_cd, 10L)
+  )
+})
+
+test_that(".validate_calibration_arg() errors on NULL element in list (CAL-16) [direct]", {
+  cd <- as_caldata(rep(1, 10), rep(1.1, 10), matrix(1, 10, 1))
+  expect_error(
+    surveycore:::.validate_calibration_arg(list(cd, NULL), 10L),
+    class = "surveycore_error_caldata_invalid_element"
+  )
+  expect_snapshot(
+    error = TRUE,
+    surveycore:::.validate_calibration_arg(list(cd, NULL), 10L)
+  )
+})
+
+test_that(".validate_calibration_arg() errors on element missing index field (CAL-16) [direct]", {
+  cd <- as_caldata(rep(1, 10), rep(1.1, 10), matrix(1, 10, 1))
+  cd_bad <- cd
+  cd_bad$index <- NULL # remove index field
+  expect_error(
+    surveycore:::.validate_calibration_arg(list(cd_bad), 10L),
+    class = "surveycore_error_caldata_invalid_element"
+  )
+  expect_snapshot(
+    error = TRUE,
+    surveycore:::.validate_calibration_arg(list(cd_bad), 10L)
+  )
+})
+
+test_that(".validate_calibration_arg() errors when length(cd$w) != nrow_data (CAL-16) [direct]", {
+  # cd built for 10 obs but we pass nrow_data = 5
+  cd <- as_caldata(rep(1, 10), rep(1.1, 10), matrix(1, 10, 1))
+  expect_error(
+    surveycore:::.validate_calibration_arg(list(cd), 5L),
+    class = "surveycore_error_caldata_invalid_element"
+  )
+  expect_snapshot(
+    error = TRUE,
+    surveycore:::.validate_calibration_arg(list(cd), 5L)
+  )
+})
+
+test_that(".validate_calibration_arg() passes for two valid elements [direct]", {
+  cd1 <- as_caldata(rep(1, 10), rep(1.1, 10), matrix(1, 10, 1))
+  cd2 <- as_caldata(rep(1, 10), rep(1.0, 10), matrix(1:10, 10, 1))
+  result <- withVisible(
+    surveycore:::.validate_calibration_arg(list(cd1, cd2), 10L)
+  )
+  expect_true(result$value)
+  expect_false(result$visible)
+})
+
+test_that(".validate_calibration_arg() tolerates extra fields on caldata element [direct]", {
+  cd <- as_caldata(rep(1, 10), rep(1.1, 10), matrix(1, 10, 1))
+  cd$extra_field <- "hello"
+  result <- withVisible(
+    surveycore:::.validate_calibration_arg(list(cd), 10L)
+  )
+  expect_true(result$value)
+  expect_false(result$visible)
+})
+
+
 # ── Constructor calibration parameter tests ────────────────────────────────────
+
+# as_survey() error paths ──────────────────────────────────────────────────────
+
+test_that("as_survey() errors on bare caldata (not wrapped) (CAL-15)", {
+  df <- data.frame(y = 1:10, wt = rep(1, 10))
+  bare_cd <- as_caldata(df$wt, rep(1.1, 10), matrix(1, 10, 1))
+  # bare_cd has all four caldata keys at top level — detected as bare caldata
+  expect_error(
+    as_survey(df, weights = wt, calibration = bare_cd),
+    class = "surveycore_error_calibration_not_list"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey(df, weights = wt, calibration = bare_cd)
+  )
+})
+
+test_that("as_survey() errors on numeric vector calibration (CAL-15)", {
+  df <- data.frame(y = 1:10, wt = rep(1, 10))
+  expect_error(
+    as_survey(df, weights = wt, calibration = c(1, 2, 3)),
+    class = "surveycore_error_calibration_not_list"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey(df, weights = wt, calibration = c(1, 2, 3))
+  )
+})
+
+test_that("as_survey() errors on data frame calibration (CAL-15)", {
+  df <- data.frame(y = 1:10, wt = rep(1, 10))
+  expect_error(
+    as_survey(df, weights = wt, calibration = data.frame(x = 1:3)),
+    class = "surveycore_error_calibration_not_list"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey(df, weights = wt, calibration = data.frame(x = 1:3))
+  )
+})
+
+test_that("as_survey() errors on element missing index field (CAL-16)", {
+  df <- data.frame(y = 1:10, wt = rep(1, 10))
+  cd <- as_caldata(df$wt, rep(1.1, 10), matrix(1, 10, 1))
+  cd_bad <- cd
+  cd_bad$index <- NULL
+  expect_error(
+    as_survey(df, weights = wt, calibration = list(cd_bad)),
+    class = "surveycore_error_caldata_invalid_element"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey(df, weights = wt, calibration = list(cd_bad))
+  )
+})
+
+test_that("as_survey() errors on NULL element in calibration list (CAL-16)", {
+  df <- data.frame(y = 1:10, wt = rep(1, 10))
+  cd <- as_caldata(df$wt, rep(1.1, 10), matrix(1, 10, 1))
+  expect_error(
+    as_survey(df, weights = wt, calibration = list(cd, NULL)),
+    class = "surveycore_error_caldata_invalid_element"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey(df, weights = wt, calibration = list(cd, NULL))
+  )
+})
+
+test_that("as_survey() errors when length(cd$w) != nrow(data) (CAL-16)", {
+  df <- data.frame(y = 1:10, wt = rep(1, 10))
+  cd_wrong <- as_caldata(rep(1, 5), rep(1.1, 5), matrix(1, 5, 1))
+  expect_error(
+    as_survey(df, weights = wt, calibration = list(cd_wrong)),
+    class = "surveycore_error_caldata_invalid_element"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey(df, weights = wt, calibration = list(cd_wrong))
+  )
+})
+
+test_that("as_survey() errors on second bad element in two-element list (CAL-16)", {
+  df <- data.frame(y = 1:10, wt = rep(1, 10))
+  cd_good <- as_caldata(df$wt, rep(1.1, 10), matrix(1, 10, 1))
+  cd_bad <- as_caldata(rep(1, 5), rep(1.1, 5), matrix(1, 5, 1))
+  expect_error(
+    as_survey(df, weights = wt, calibration = list(cd_good, cd_bad)),
+    class = "surveycore_error_caldata_invalid_element"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey(df, weights = wt, calibration = list(cd_good, cd_bad))
+  )
+})
+
+test_that("as_survey() with calibration = list() succeeds; @calibration is list()", {
+  df <- data.frame(y = 1:10, wt = rep(1, 10))
+  d <- as_survey(df, weights = wt, calibration = list())
+  test_invariants(d)
+  expect_identical(d@calibration, list())
+})
+
+test_that("as_survey() with calibration = NULL succeeds; @calibration is NULL", {
+  df <- data.frame(y = 1:10, wt = rep(1, 10))
+  d <- suppressWarnings(as_survey(df, weights = wt, calibration = NULL))
+  test_invariants(d)
+  expect_null(d@calibration)
+})
+
+# as_survey_replicate() error paths ───────────────────────────────────────────
+
+test_that("as_survey_replicate() errors on non-list calibration (CAL-15)", {
+  df <- make_survey_data(n = 200L, design = "replicate", seed = 3L)
+  repwt_cols <- grep("^repwt_", names(df), value = TRUE)
+  expect_error(
+    as_survey_replicate(
+      df,
+      weights = wt,
+      repweights = tidyselect::all_of(repwt_cols),
+      type = "BRR",
+      calibration = c(1, 2, 3)
+    ),
+    class = "surveycore_error_calibration_not_list"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey_replicate(
+      df,
+      weights = wt,
+      repweights = tidyselect::all_of(repwt_cols),
+      type = "BRR",
+      calibration = c(1, 2, 3)
+    )
+  )
+})
+
+test_that("as_survey_replicate() errors on invalid caldata structure (CAL-16)", {
+  df <- make_survey_data(n = 200L, design = "replicate", seed = 4L)
+  repwt_cols <- grep("^repwt_", names(df), value = TRUE)
+  cd <- as_caldata(df$wt, rep(1.1, nrow(df)), matrix(1, nrow(df), 1))
+  cd_bad <- cd
+  cd_bad$index <- NULL
+  expect_error(
+    as_survey_replicate(
+      df,
+      weights = wt,
+      repweights = tidyselect::all_of(repwt_cols),
+      type = "BRR",
+      calibration = list(cd_bad)
+    ),
+    class = "surveycore_error_caldata_invalid_element"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey_replicate(
+      df,
+      weights = wt,
+      repweights = tidyselect::all_of(repwt_cols),
+      type = "BRR",
+      calibration = list(cd_bad)
+    )
+  )
+})
+
+test_that("as_survey_replicate() errors when length(cd$w) != nrow(data) (CAL-16)", {
+  df <- make_survey_data(n = 200L, design = "replicate", seed = 5L)
+  repwt_cols <- grep("^repwt_", names(df), value = TRUE)
+  cd_wrong <- as_caldata(rep(1, 10), rep(1.1, 10), matrix(1, 10, 1))
+  expect_error(
+    as_survey_replicate(
+      df,
+      weights = wt,
+      repweights = tidyselect::all_of(repwt_cols),
+      type = "BRR",
+      calibration = list(cd_wrong)
+    ),
+    class = "surveycore_error_caldata_invalid_element"
+  )
+  expect_snapshot(
+    error = TRUE,
+    as_survey_replicate(
+      df,
+      weights = wt,
+      repweights = tidyselect::all_of(repwt_cols),
+      type = "BRR",
+      calibration = list(cd_wrong)
+    )
+  )
+})
+
+test_that("as_survey_replicate() with calibration = list() succeeds", {
+  df <- make_survey_data(n = 200L, design = "replicate", seed = 6L)
+  repwt_cols <- grep("^repwt_", names(df), value = TRUE)
+  d <- as_survey_replicate(
+    df,
+    weights = wt,
+    repweights = tidyselect::all_of(repwt_cols),
+    type = "BRR",
+    calibration = list()
+  )
+  expect_identical(d@calibration, list())
+})
+
+test_that("as_survey_replicate() with calibration = NULL succeeds", {
+  df <- make_survey_data(n = 200L, design = "replicate", seed = 7L)
+  repwt_cols <- grep("^repwt_", names(df), value = TRUE)
+  d <- as_survey_replicate(
+    df,
+    weights = wt,
+    repweights = tidyselect::all_of(repwt_cols),
+    type = "BRR",
+    calibration = NULL
+  )
+  expect_null(d@calibration)
+})
+
+test_that("as_survey_replicate() SE unchanged with/without @calibration (provenance-only)", {
+  df <- make_survey_data(
+    n = 200L,
+    design = "replicate",
+    type = "brr",
+    seed = 42L
+  )
+  repwt_cols <- grep("^repwt_", names(df), value = TRUE)
+
+  d_without <- as_survey_replicate(
+    df,
+    weights = wt,
+    repweights = tidyselect::all_of(repwt_cols),
+    type = "BRR"
+  )
+  cd <- as_caldata(df$wt, rep(1.05, nrow(df)), matrix(1, nrow(df), 1))
+  d_with <- as_survey_replicate(
+    df,
+    weights = wt,
+    repweights = tidyselect::all_of(repwt_cols),
+    type = "BRR",
+    calibration = list(cd)
+  )
+
+  se_without <- get_means(d_without, y1, variance = "se")$se
+  se_with <- get_means(d_with, y1, variance = "se")$se
+  expect_equal(se_without, se_with, tolerance = 1e-12)
+})
 
 test_that("as_survey() stores calibration argument at @calibration", {
   df <- make_survey_data(n = 200L, seed = 1L)


### PR DESCRIPTION
## Summary

- Adds `.validate_calibration_arg(calibration, nrow_data)` to `R/calibration.R`: NULL and empty-list pass-through; CAL-15 fires when `calibration` is non-NULL non-list; CAL-16 fires when any element is NULL, missing a required field (`qr`, `w`, `stage`, `index`), or has `length(cd$w) != nrow_data`
- Calls `.validate_calibration_arg()` in both `as_survey()` and `as_survey_replicate()` immediately before the S7 construction call, after all other argument validation
- Expands `@param calibration` roxygen on both constructors with type, validation semantics, and two known limitations (weight-column consistency and `update_design()` staleness)
- Adds inter-package contract section to `as_caldata()` roxygen (GREG vs raking `model_matrix` semantics, Architecture A combined-matrix requirement, provenance-only behavior for `survey_replicate`)
- Adds provenance-only SE-identity test for `survey_replicate` (tolerance 1e-12)

## Spec coverage

See review.md — verdict PASS.
- Spec items covered: 12/12 (all convergence table rows)
- Test scenarios: 12,141 PASS, 0 FAIL

## Test results

- devtools::test(): PASS (12,141 PASS, 0 FAIL)
- R CMD check --as-cran: 0 errors, 0 warnings, 1 pre-existing NOTE (non-standard top-level files)
- pkgcheck: SKIPPED — environment constraint
- pkgdown: SKIPPED — no NAMESPACE changes (no new exports); hard rule does not trigger
- covr: 92.87% — pre-existing deficit; PR adds +0.03pp; no new uncovered lines

## Before/After

| | Before | After |
|---|---|---|
| `as_survey(df, wt, calibration = bare_cd)` | Stored silently (invalid structure) | `surveycore_error_calibration_not_list` |
| `as_survey(df, wt, calibration = list(bad_cd))` | Stored silently (missing fields) | `surveycore_error_caldata_invalid_element` |
| `as_survey(df, wt, calibration = list(valid_cd))` | Stored correctly | Stored correctly (unchanged) |
| `@param calibration` docs | Minimal | Full type + validation + known limitations |

## Files changed

- `R/calibration.R` — `.validate_calibration_arg()` + `as_caldata()` roxygen
- `R/core-constructors.R` — validation call in `as_survey()` and `as_survey_replicate()`; expanded `@param calibration`
- `tests/testthat/test-calibration.R` — constructor validation tests (error paths, edge cases, provenance-only SE test)
- `tests/testthat/_snaps/calibration.md` — snapshot artifacts from dual-pattern tests
- `man/as_survey.Rd`, `man/as_survey_replicate.Rd`, `man/as_caldata.Rd` — regenerated by `devtools::document()`
- `plans/error-messages.md` — coverage map updated for CAL-15, CAL-16
- `NEWS.md` — bullet added

## Artifacts

- Implementation: `plans/implementation-plan-surveywts-calibration.md`
- Audit: `audit.md`
- Review: `review.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)