### PR TITLE
fix(analysis): fix regex metacharacter injection and pct_change NA in get_diffs()

### DIFF
--- a/R/analysis-diffs-helpers.R
+++ b/R/analysis-diffs-helpers.R
@@ -101,16 +101,16 @@
   result_means <- reference_mean + result_estimates
 
   list(
-    result_levels   = result_levels,
+    result_levels = result_levels,
     result_estimates = result_estimates,
-    result_ses      = result_ses,
-    result_ci_lows  = result_ci_lows,
+    result_ses = result_ses,
+    result_ci_lows = result_ci_lows,
     result_ci_highs = result_ci_highs,
     result_p_values = result_p_values,
-    result_means    = result_means,
-    result_groups   = NULL,
-    reference_mean  = reference_mean,
-    preds_df        = NULL
+    result_means = result_means,
+    result_groups = NULL,
+    reference_mean = reference_mean,
+    preds_df = NULL
   )
 }
 
@@ -146,18 +146,18 @@
     slopes <- marginaleffects::avg_slopes(
       fit,
       variables = treats_name,
-      by        = group_names,
-      type      = me_type,
-      wts       = fit@weights,
-      df        = res_df
+      by = group_names,
+      type = me_type,
+      wts = fit@weights,
+      df = res_df
     )
   } else {
     slopes <- marginaleffects::avg_slopes(
       fit,
       variables = treats_name,
-      type      = me_type,
-      wts       = fit@weights,
-      df        = res_df
+      type = me_type,
+      wts = fit@weights,
+      df = res_df
     )
   }
   slopes_df <- as.data.frame(slopes)
@@ -168,34 +168,38 @@
     if (has_group) {
       preds <- marginaleffects::avg_predictions(
         fit,
-        by   = c(treats_name, group_names),
+        by = c(treats_name, group_names),
         type = me_type,
-        wts  = fit@weights,
-        df   = res_df
+        wts = fit@weights,
+        df = res_df
       )
     } else {
       preds <- marginaleffects::avg_predictions(
         fit,
-        by   = treats_name,
+        by = treats_name,
         type = me_type,
-        wts  = fit@weights,
-        df   = res_df
+        wts = fit@weights,
+        df = res_df
       )
     }
     preds_df <- as.data.frame(preds)
   }
 
-  # Parse level names from "X - ref" contrast format
+  # Parse level names from "X - ref" contrast format.
+  # Use fixed = TRUE so ref_level metacharacters (e.g. "(Control)", "A.B")
+  # are treated as literal strings, not regex patterns.
+  ref_suffix <- paste0(" - ", ref_level)
   result_levels <- sub(
-    paste0("^(.+) - ", ref_level, "$"),
-    "\\1",
-    as.character(slopes_df$contrast)
+    ref_suffix,
+    "",
+    as.character(slopes_df$contrast),
+    fixed = TRUE
   )
   result_estimates <- slopes_df$estimate
-  result_ses       <- slopes_df$std.error
-  result_ci_lows   <- slopes_df$conf.low
-  result_ci_highs  <- slopes_df$conf.high
-  result_p_values  <- slopes_df$p.value
+  result_ses <- slopes_df$std.error
+  result_ci_lows <- slopes_df$conf.low
+  result_ci_highs <- slopes_df$conf.high
+  result_p_values <- slopes_df$p.value
 
   # Group columns from slopes output
   result_groups <- if (has_group) {
@@ -229,16 +233,16 @@
   }
 
   list(
-    result_levels   = result_levels,
+    result_levels = result_levels,
     result_estimates = result_estimates,
-    result_ses      = result_ses,
-    result_ci_lows  = result_ci_lows,
+    result_ses = result_ses,
+    result_ci_lows = result_ci_lows,
     result_ci_highs = result_ci_highs,
     result_p_values = result_p_values,
-    result_means    = result_means,
-    result_groups   = result_groups,
-    reference_mean  = NULL,
-    preds_df        = preds_df
+    result_means = result_means,
+    result_groups = result_groups,
+    reference_mean = NULL,
+    preds_df = preds_df
   )
 }
 
@@ -355,16 +359,16 @@
       }
 
       ref_row <- list(
-        level     = ref_level,
-        estimate  = 0,
-        mean      = ref_mean,
-        n         = as.integer(ref_n),
+        level = ref_level,
+        estimate = 0,
+        mean = ref_mean,
+        n = as.integer(ref_n),
         n_weighted = ref_nw,
-        se        = NA_real_,
-        ci_low    = NA_real_,
-        ci_high   = NA_real_,
-        p_value   = NA_real_,
-        stars     = ""
+        se = NA_real_,
+        ci_low = NA_real_,
+        ci_high = NA_real_,
+        p_value = NA_real_,
+        stars = ""
       )
       all_rows <- c(all_rows, list(ref_row))
       if (has_group) {
@@ -410,20 +414,20 @@
       }
 
       treat_row <- list(
-        level     = lvl,
-        estimate  = result$result_estimates[[i]],
-        mean      = if (!is.null(result$result_means)) {
+        level = lvl,
+        estimate = result$result_estimates[[i]],
+        mean = if (!is.null(result$result_means)) {
           result$result_means[[i]]
         } else {
           NA_real_
         },
-        n         = as.integer(lvl_n),
+        n = as.integer(lvl_n),
         n_weighted = lvl_nw,
-        se        = result$result_ses[[i]],
-        ci_low    = result$result_ci_lows[[i]],
-        ci_high   = result$result_ci_highs[[i]],
-        p_value   = result$result_p_values[[i]],
-        stars     = ""
+        se = result$result_ses[[i]],
+        ci_low = result$result_ci_lows[[i]],
+        ci_high = result$result_ci_highs[[i]],
+        p_value = result$result_p_values[[i]],
+        stars = ""
       )
       all_rows <- c(all_rows, list(treat_row))
       if (has_group) {
@@ -482,7 +486,9 @@
         }
         if (length(comp_idx) > 0L) {
           pvals <- vapply(
-            all_rows[comp_idx], function(r) r$p_value, double(1L)
+            all_rows[comp_idx],
+            function(r) r$p_value,
+            double(1L)
           )
           adj_pvals <- stats::p.adjust(pvals, method = pval_adj)
           for (j in seq_along(comp_idx)) {
@@ -613,10 +619,14 @@
   col_vecs <- list()
 
   col_vecs[[treats_name]] <- vapply(
-    all_rows, function(r) r$level, character(1L)
+    all_rows,
+    function(r) r$level,
+    character(1L)
   )
   col_vecs[["estimate"]] <- vapply(
-    all_rows, function(r) r$estimate, double(1L)
+    all_rows,
+    function(r) r$estimate,
+    double(1L)
   )
 
   if (show_pct_change && !suppress_mean) {
@@ -629,40 +639,56 @@
 
   if (show_means && !suppress_mean) {
     col_vecs[["mean"]] <- vapply(
-      all_rows, function(r) r$mean, double(1L)
+      all_rows,
+      function(r) r$mean,
+      double(1L)
     )
   }
 
   col_vecs[["n"]] <- vapply(
-    all_rows, function(r) r$n, integer(1L)
+    all_rows,
+    function(r) r$n,
+    integer(1L)
   )
 
   if (n_weighted) {
     col_vecs[["n_weighted"]] <- vapply(
-      all_rows, function(r) r$n_weighted, double(1L)
+      all_rows,
+      function(r) r$n_weighted,
+      double(1L)
     )
   }
 
   if (!is.null(variance) && "se" %in% variance) {
     col_vecs[["se"]] <- vapply(
-      all_rows, function(r) r$se, double(1L)
+      all_rows,
+      function(r) r$se,
+      double(1L)
     )
   }
 
   if (!is.null(variance) && "ci" %in% variance) {
     col_vecs[["ci_low"]] <- vapply(
-      all_rows, function(r) r$ci_low, double(1L)
+      all_rows,
+      function(r) r$ci_low,
+      double(1L)
     )
     col_vecs[["ci_high"]] <- vapply(
-      all_rows, function(r) r$ci_high, double(1L)
+      all_rows,
+      function(r) r$ci_high,
+      double(1L)
     )
   }
 
   col_vecs[["p_value"]] <- vapply(
-    all_rows, function(r) r$p_value, double(1L)
+    all_rows,
+    function(r) r$p_value,
+    double(1L)
   )
   col_vecs[["stars"]] <- vapply(
-    all_rows, function(r) r$stars, character(1L)
+    all_rows,
+    function(r) r$stars,
+    character(1L)
   )
 
   # ── Assemble groups_df ────────────────────────────────────────────────────

--- a/tests/testthat/test-analysis-diffs.R
+++ b/tests/testthat/test-analysis-diffs.R
@@ -190,7 +190,11 @@ test_that("get_diffs() basic bivariate gaussian returns correct structure", {
 test_that("get_diffs() show_means = FALSE omits reference row and mean", {
   d <- .make_diffs_design()
   result <- get_diffs(
-    d, dv, treats, ref_level = "Control", show_means = FALSE
+    d,
+    dv,
+    treats,
+    ref_level = "Control",
+    show_means = FALSE
   )
 
   expect_equal(nrow(result), 2L)
@@ -202,7 +206,11 @@ test_that("get_diffs() show_means = FALSE omits reference row and mean", {
 test_that("get_diffs() show_pct_change = TRUE adds pct_change column", {
   d <- .make_diffs_design()
   result <- get_diffs(
-    d, dv, treats, ref_level = "Control", show_pct_change = TRUE
+    d,
+    dv,
+    treats,
+    ref_level = "Control",
+    show_pct_change = TRUE
   )
 
   expect_true("pct_change" %in% names(result))
@@ -225,7 +233,11 @@ test_that("get_diffs() ref_level changes reference row", {
 test_that("get_diffs() variance = 'se' includes SE, no CI", {
   d <- .make_diffs_design()
   result <- get_diffs(
-    d, dv, treats, ref_level = "Control", variance = "se"
+    d,
+    dv,
+    treats,
+    ref_level = "Control",
+    variance = "se"
   )
 
   expect_true("se" %in% names(result))
@@ -236,7 +248,10 @@ test_that("get_diffs() variance = 'se' includes SE, no CI", {
 test_that("get_diffs() variance = c('se', 'ci') includes both", {
   d <- .make_diffs_design()
   result <- get_diffs(
-    d, dv, treats, ref_level = "Control",
+    d,
+    dv,
+    treats,
+    ref_level = "Control",
     variance = c("se", "ci")
   )
 
@@ -248,7 +263,11 @@ test_that("get_diffs() variance = c('se', 'ci') includes both", {
 test_that("get_diffs() variance = NULL includes no uncertainty", {
   d <- .make_diffs_design()
   result <- get_diffs(
-    d, dv, treats, ref_level = "Control", variance = NULL
+    d,
+    dv,
+    treats,
+    ref_level = "Control",
+    variance = NULL
   )
 
   expect_false("se" %in% names(result))
@@ -259,7 +278,11 @@ test_that("get_diffs() variance = NULL includes no uncertainty", {
 test_that("get_diffs() decimals rounds correctly", {
   d <- .make_diffs_design()
   result <- get_diffs(
-    d, dv, treats, ref_level = "Control", decimals = 2
+    d,
+    dv,
+    treats,
+    ref_level = "Control",
+    decimals = 2
   )
 
   # estimate rounded to 2 decimal places
@@ -276,8 +299,12 @@ test_that("get_diffs() decimals rounds correctly", {
 test_that("get_diffs() decimals + pct_change rounds to decimals + 2", {
   d <- .make_diffs_design()
   result <- get_diffs(
-    d, dv, treats, ref_level = "Control",
-    show_pct_change = TRUE, decimals = 2
+    d,
+    dv,
+    treats,
+    ref_level = "Control",
+    show_pct_change = TRUE,
+    decimals = 2
   )
 
   for (i in seq_len(nrow(result))) {
@@ -293,10 +320,17 @@ test_that("get_diffs() decimals + pct_change rounds to decimals + 2", {
 test_that("get_diffs() pval_adj = 'BH' adjusts p-values", {
   d <- .make_diffs_design()
   result_adj <- get_diffs(
-    d, dv, treats, ref_level = "Control", pval_adj = "BH"
+    d,
+    dv,
+    treats,
+    ref_level = "Control",
+    pval_adj = "BH"
   )
   result_raw <- get_diffs(
-    d, dv, treats, ref_level = "Control"
+    d,
+    dv,
+    treats,
+    ref_level = "Control"
   )
 
   m <- meta(result_adj)
@@ -310,11 +344,15 @@ test_that("get_diffs() label_values = TRUE labels treats column", {
   # Set value labels
   d <- as_survey(df, ids = psu, weights = wt, strata = strata)
   d <- set_val_labels(
-    d, treats = c("Control Group" = "Control", "Group A" = "A",
-                  "Group B" = "B")
+    d,
+    treats = c("Control Group" = "Control", "Group A" = "A", "Group B" = "B")
   )
   result <- get_diffs(
-    d, dv, treats, ref_level = "Control", label_values = TRUE
+    d,
+    dv,
+    treats,
+    ref_level = "Control",
+    label_values = TRUE
   )
 
   expect_true(is.factor(result$treats))
@@ -323,7 +361,11 @@ test_that("get_diffs() label_values = TRUE labels treats column", {
 test_that("get_diffs() label_values = FALSE keeps raw codes", {
   d <- .make_diffs_design()
   result <- get_diffs(
-    d, dv, treats, ref_level = "Control", label_values = FALSE
+    d,
+    dv,
+    treats,
+    ref_level = "Control",
+    label_values = FALSE
   )
   # treats column should be character or factor with raw level names
   expect_true(is.character(result$treats) || is.factor(result$treats))
@@ -332,8 +374,12 @@ test_that("get_diffs() label_values = FALSE keeps raw codes", {
 test_that("get_diffs() name_style = 'broom' renames columns, mean excluded", {
   d <- .make_diffs_design()
   result <- get_diffs(
-    d, dv, treats, ref_level = "Control",
-    variance = c("se", "ci"), name_style = "broom"
+    d,
+    dv,
+    treats,
+    ref_level = "Control",
+    variance = c("se", "ci"),
+    name_style = "broom"
   )
 
   expect_true("std.error" %in% names(result))
@@ -348,7 +394,11 @@ test_that("get_diffs() name_style = 'broom' renames columns, mean excluded", {
 test_that("get_diffs() n_weighted = TRUE adds n_weighted column", {
   d <- .make_diffs_design()
   result <- get_diffs(
-    d, dv, treats, ref_level = "Control", n_weighted = TRUE
+    d,
+    dv,
+    treats,
+    ref_level = "Control",
+    n_weighted = TRUE
   )
 
   expect_true("n_weighted" %in% names(result))
@@ -395,7 +445,11 @@ test_that("get_diffs() print snapshot", {
 test_that("get_diffs() with covariates uses marginaleffects path", {
   d <- .make_diffs_design()
   result <- get_diffs(
-    d, dv, treats, covariates = "age", ref_level = "Control"
+    d,
+    dv,
+    treats,
+    covariates = "age",
+    ref_level = "Control"
   )
 
   m <- meta(result)
@@ -421,8 +475,12 @@ test_that("get_diffs() with covariates and group", {
   d <- .make_diffs_design()
   result <- suppressWarnings(
     get_diffs(
-      d, dv, treats, group = gender,
-      covariates = "age", ref_level = "Control"
+      d,
+      dv,
+      treats,
+      group = gender,
+      covariates = "age",
+      ref_level = "Control"
     )
   )
 
@@ -435,7 +493,10 @@ test_that("get_diffs() with covariates and group", {
 test_that("get_diffs() non-gaussian (quasibinomial) uses AME path", {
   d <- .make_diffs_design()
   result <- get_diffs(
-    d, binary_dv, treats, ref_level = "Control",
+    d,
+    binary_dv,
+    treats,
+    ref_level = "Control",
     family = quasibinomial()
   )
 
@@ -450,8 +511,12 @@ test_that("get_diffs() non-gaussian (quasibinomial) uses AME path", {
 test_that("get_diffs() scale = 'link' + non-gaussian suppresses mean", {
   d <- .make_diffs_design()
   result <- get_diffs(
-    d, binary_dv, treats, ref_level = "Control",
-    scale = "link", family = quasibinomial()
+    d,
+    binary_dv,
+    treats,
+    ref_level = "Control",
+    scale = "link",
+    family = quasibinomial()
   )
 
   expect_false("mean" %in% names(result))
@@ -465,25 +530,41 @@ test_that("get_diffs() scale = 'link' + non-gaussian suppresses mean", {
 test_that("get_diffs() gaussian ame == link produces identical output", {
   d <- .make_diffs_design()
   result_ame <- get_diffs(
-    d, dv, treats, ref_level = "Control", scale = "ame"
+    d,
+    dv,
+    treats,
+    ref_level = "Control",
+    scale = "ame"
   )
   result_link <- get_diffs(
-    d, dv, treats, ref_level = "Control", scale = "link"
+    d,
+    dv,
+    treats,
+    ref_level = "Control",
+    scale = "link"
   )
 
   expect_equal(result_ame$estimate, result_link$estimate, tolerance = 1e-10)
   expect_equal(
-    result_ame$ci_low, result_link$ci_low, tolerance = 1e-8
+    result_ame$ci_low,
+    result_link$ci_low,
+    tolerance = 1e-8
   )
   expect_equal(
-    result_ame$ci_high, result_link$ci_high, tolerance = 1e-8
+    result_ame$ci_high,
+    result_link$ci_high,
+    tolerance = 1e-8
   )
 })
 
 test_that("get_diffs() pval_adj with group adjusts within groups", {
   d <- .make_diffs_design()
   result_adj <- suppressWarnings(get_diffs(
-    d, dv, treats, group = gender, ref_level = "Control",
+    d,
+    dv,
+    treats,
+    group = gender,
+    ref_level = "Control",
     pval_adj = "BH"
   ))
 
@@ -504,8 +585,12 @@ test_that("get_diffs() works with survey_taylor design", {
 test_that("get_diffs() works with survey_replicate design", {
   df <- .make_diffs_data()
   df_rep <- make_survey_data(
-    n = 200, n_psu = 20, n_strata = 4,
-    design = "replicate", type = "jk1", seed = 42
+    n = 200,
+    n_psu = 20,
+    n_strata = 4,
+    design = "replicate",
+    type = "jk1",
+    seed = 42
   )
   df_rep$treats <- factor(
     sample(c("Control", "A", "B"), nrow(df_rep), replace = TRUE)
@@ -513,7 +598,8 @@ test_that("get_diffs() works with survey_replicate design", {
   df_rep$dv <- rnorm(nrow(df_rep), 50, 10)
 
   d <- as_survey_replicate(
-    df_rep, weights = wt,
+    df_rep,
+    weights = wt,
     repweights = starts_with("repwt_"),
     type = "JK1"
   )
@@ -523,8 +609,11 @@ test_that("get_diffs() works with survey_replicate design", {
 
 test_that("get_diffs() works with survey_twophase design", {
   df <- make_survey_data(
-    n = 200, n_psu = 20, n_strata = 4,
-    design = "twophase", seed = 42
+    n = 200,
+    n_psu = 20,
+    n_strata = 4,
+    design = "twophase",
+    seed = 42
   )
   df$treats <- factor(
     sample(c("Control", "A", "B"), nrow(df), replace = TRUE)
@@ -533,7 +622,9 @@ test_that("get_diffs() works with survey_twophase design", {
 
   phase1 <- as_survey(df, ids = psu, strata = strata)
   d <- as_survey_twophase(
-    phase1, subset = subset, probs2 = phase2_prob
+    phase1,
+    subset = subset,
+    probs2 = phase2_prob
   )
   result <- get_diffs(d, dv, treats, ref_level = "Control")
   expect_identical(meta(result)$design_type, "twophase")
@@ -583,7 +674,8 @@ test_that("get_diffs() works with many levels (10+)", {
   )
   d <- as_survey(df, ids = psu, weights = wt, strata = strata)
 
-  suppressWarnings(  # small cell warnings
+  suppressWarnings(
+    # small cell warnings
     result <- get_diffs(d, dv, many_arm)
   )
   # 1 ref + 9 treatment = 10 rows
@@ -614,8 +706,7 @@ test_that("get_diffs() warns when ref mean is 0 with show_pct_change", {
   d <- as_survey(df, ids = psu, weights = wt, strata = strata)
 
   expect_warning(
-    get_diffs(d, zero_dv, arm, ref_level = "Control",
-              show_pct_change = TRUE),
+    get_diffs(d, zero_dv, arm, ref_level = "Control", show_pct_change = TRUE),
     class = "surveycore_warning_pct_change_zero_ref"
   )
 })
@@ -777,7 +868,13 @@ test_that("get_diffs() show_favorability: custom alpha = 0.001 keeps highly sig 
 test_that("get_diffs() show_favorability + name_style='broom': favorable/backlash present, uses p.value", {
   d <- .make_fav_design()
   d <- set_higher_is(d, dv = "worse")
-  result <- get_diffs(d, dv, treats, show_favorability = TRUE, name_style = "broom")
+  result <- get_diffs(
+    d,
+    dv,
+    treats,
+    show_favorability = TRUE,
+    name_style = "broom"
+  )
   expect_true("favorable" %in% names(result))
   expect_true("backlash" %in% names(result))
   expect_true("p.value" %in% names(result))
@@ -801,7 +898,13 @@ test_that("get_diffs() show_favorability + group: columns present, aligned per g
 test_that("get_diffs() show_favorability + pval_adj: classification uses adjusted p-value", {
   d <- .make_fav_design()
   d <- set_higher_is(d, dv = "worse")
-  result <- get_diffs(d, dv, treats, show_favorability = TRUE, pval_adj = "bonferroni")
+  result <- get_diffs(
+    d,
+    dv,
+    treats,
+    show_favorability = TRUE,
+    pval_adj = "bonferroni"
+  )
   expect_true("favorable" %in% names(result))
   expect_true("backlash" %in% names(result))
   a_row <- result[result$treats == "A", ]
@@ -832,8 +935,10 @@ test_that("get_diffs() show_favorability: p_value == alpha → both FALSE (stric
   # Exclude the reference row (p_value = NA) before finding min p
   valid_pvals <- baseline$p_value[!is.na(baseline$p_value)]
   min_p <- min(valid_pvals)
-  skip_if(min_p == 0 || !is.finite(min_p),
-          "p-value is exactly 0 or non-finite; boundary cannot be tested")
+  skip_if(
+    min_p == 0 || !is.finite(min_p),
+    "p-value is exactly 0 or non-finite; boundary cannot be tested"
+  )
   skip_if(min_p >= 1, "p-value >= 1; outside valid alpha range")
   # With alpha == min_p: strict < means p is NOT < alpha → not significant
   result <- get_diffs(d, dv, treats, show_favorability = TRUE, alpha = min_p)
@@ -843,4 +948,95 @@ test_that("get_diffs() show_favorability: p_value == alpha → both FALSE (stric
     expect_false(obs_rows$favorable[[1]])
     expect_false(obs_rows$backlash[[1]])
   }
+})
+
+# ═══════════════════════════════════════════════════════════════════════════
+# BUG FIXES
+# ═══════════════════════════════════════════════════════════════════════════
+
+test_that("get_diffs() strips metacharacter ref level from contrast label (ME path)", {
+  # Bug 1: ref_level containing regex metacharacters (e.g. "(Control)") must
+  # be treated as a literal string, not a regex pattern, when stripping the
+  # " - ref_level" suffix from contrast strings.
+  set.seed(42)
+  df <- data.frame(
+    wt = runif(200, 0.5, 2),
+    dv = rnorm(200, 50, 10),
+    age = rnorm(200, 40, 10),
+    arm = factor(sample(c("(Control)", "Treatment"), 200, TRUE))
+  )
+  d <- as_survey(df, weights = wt)
+
+  # covariates forces the marginaleffects path which calls avg_slopes() and
+  # parses contrast strings of the form "Treatment - (Control)"
+  result <- get_diffs(
+    d,
+    dv,
+    arm,
+    covariates = "age",
+    ref_level = "(Control)",
+    label_values = FALSE
+  )
+
+  # Treatment level should be "Treatment", not "Treatment - (Control)"
+  non_ref <- result[result$arm != "(Control)", ]
+  expect_equal(nrow(non_ref), 1L)
+  expect_identical(non_ref$arm[[1L]], "Treatment")
+})
+
+test_that("get_diffs() pct_change is non-NA with show_means = FALSE (ungrouped)", {
+  # Bug 2: when show_means = FALSE, reference rows are absent from all_rows;
+  # the fallback must read the reference mean from result$reference_mean (clean
+  # path) or preds_df (ME path) so pct_change is not NA.
+  set.seed(42)
+  df <- data.frame(
+    wt = runif(200, 0.5, 2),
+    dv = rnorm(200, 50, 10),
+    arm = factor(sample(c("Control", "A", "B"), 200, TRUE))
+  )
+  d <- as_survey(df, weights = wt)
+
+  result <- get_diffs(
+    d,
+    dv,
+    arm,
+    ref_level = "Control",
+    show_pct_change = TRUE,
+    show_means = FALSE
+  )
+
+  # No reference row present
+  expect_false(any(result$estimate == 0))
+  # pct_change must be non-NA for all non-reference rows
+  expect_false(any(is.na(result$pct_change)))
+  expect_equal(nrow(result), 2L)
+})
+
+test_that("get_diffs() pct_change is non-NA with show_means = FALSE (grouped)", {
+  # Bug 2: same fallback must work on the marginaleffects (grouped) path.
+  set.seed(42)
+  df <- data.frame(
+    wt = runif(300, 0.5, 2),
+    dv = rnorm(300, 50, 10),
+    arm = factor(sample(c("Control", "A", "B"), 300, TRUE)),
+    grp = factor(sample(c("M", "F"), 300, TRUE))
+  )
+  d <- as_survey(df, weights = wt)
+
+  result <- suppressWarnings(get_diffs(
+    d,
+    dv,
+    arm,
+    group = grp,
+    ref_level = "Control",
+    show_pct_change = TRUE,
+    show_means = FALSE
+  ))
+
+  # grp column present (grouped output)
+  expect_true("grp" %in% names(result))
+  # No reference rows in output
+  expect_false(any(result$estimate == 0))
+  # pct_change non-NA for all rows (all are non-reference)
+  expect_false(any(is.na(result$pct_change)))
 })


### PR DESCRIPTION
## Summary
- Replace `sub()` regex with `fixed = TRUE` form in `.extract_me_estimates()` so factor ref levels containing metacharacters (e.g. `"(Control)"`, `"A.B"`) are stripped as literal strings, not regex patterns
- Verify `pct_change` NA-when-`show_means=FALSE` fallback already consolidated in `.build_diffs_output()`; no changes needed in `R/analysis-diffs.R`
- Add 3 new test blocks (8 assertions) covering metacharacter strip on ME path and non-NA `pct_change` with `show_means = FALSE` (ungrouped + grouped)

## Spec coverage
See audit.md — verdict PASS.
- Acceptance criteria covered: 5 (AC1–AC5)
- Test scenarios: 5, all PASS

## Test results
- devtools::test(): PASS — FAIL 0, WARN 259, SKIP 4, PASS 12179
- R CMD check --as-cran: 0 errors, 0 warnings, 2 pre-approved notes
- pkgcheck: SKIPPED — scope (bug fix)
- pkgdown: SKIPPED — scope (bug fix)
- covr: not measured (simplified workflow; scope is bug fixes + targeted tests)

## Before/After

| Metric | Before PR | After PR | Delta |
|---|---|---|---|
| tests passing | 12171 | 12179 | +8 |
| test failures | 0 | 0 | 0 |
| warnings | 259 | 259 | 0 |
| R CMD check errors | 0 | 0 | 0 |
| R CMD check warnings | 0 | 0 | 0 |
| R CMD check notes | 2 | 2 | 0 |

## Artifacts
- Implementation: /Users/jacobdennen/surveycore/.surveycore-workspace/runs/2026-06-06-get-diffs-bug-fixes/implementation.md
- Audit: /Users/jacobdennen/surveycore/.surveycore-workspace/runs/2026-06-06-get-diffs-bug-fixes/audit.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)