### PR TITLE
feat(analysis): wire .survey_result attribute into all get_*() functions

### DIFF
--- a/R/analysis-corr.R
+++ b/R/analysis-corr.R
@@ -795,7 +795,9 @@ get_corr <- function(
     "survey_corr",
     design,
     meta_args,
-    CORR_META_KEYS
+    CORR_META_KEYS,
+    estimate_cols = c("r"),
+    statistic = "corr"
   )
 
   # ── Step 22: Convert var1/var2 to factors (levels in variable supply order) ─

--- a/R/analysis-covariance.R
+++ b/R/analysis-covariance.R
@@ -609,7 +609,9 @@ get_covariance <- function(
     "survey_covariance",
     design,
     meta_args,
-    COVARIANCE_META_KEYS
+    COVARIANCE_META_KEYS,
+    estimate_cols = c("covariance"),
+    statistic = "covariance"
   )
 
   # ── Step 20: Convert var1/var2 to factors (supply order) ────────────────────

--- a/R/analysis-diffs.R
+++ b/R/analysis-diffs.R
@@ -596,5 +596,19 @@ get_diffs <- function(
     "tbl",
     "data.frame"
   )
+
+  # ── Step 23: Attach .survey_result attribute ──────────────────────────────
+  # fit@degf is design-based residual df from survey_glm(); p = nrow(result).
+  # group_cols derived from .meta$group keys (empty character(0) when no group).
+  df_val <- as.numeric(fit@degf)
+  p_diffs <- nrow(result)
+  group_cols_diffs <- names(attr(result, ".meta")$group)
+  attr(result, ".survey_result") <- .build_survey_result_attr(
+    estimate_cols = c("estimate"),
+    group_cols = group_cols_diffs,
+    statistic = "diffs",
+    cell_df = rep(df_val, p_diffs)
+  )
+
   result
 }

--- a/R/analysis-freqs.R
+++ b/R/analysis-freqs.R
@@ -496,7 +496,9 @@ get_freqs <- function(
     "survey_freqs",
     design,
     meta_args,
-    required_keys
+    required_keys,
+    estimate_cols = c("pct"),
+    statistic = "freq"
   )
 
   # ── Step 13: Apply decimals and name style ──────────────────────────────────

--- a/R/analysis-means.R
+++ b/R/analysis-means.R
@@ -313,13 +313,25 @@ get_means <- function(
   )
 
   # ── Step 11: Assemble result ────────────────────────────────────────────────
+  # Thread per-cell df for calibrated Taylor designs; NULL defaults to Inf.
+  cal_df <- if (has_calibration) {
+    cell_df_vec <- acc_df
+    cell_df_vec[is.na(cell_df_vec)] <- Inf
+    cell_df_vec
+  } else {
+    NULL
+  }
+
   result <- .make_result_tibble(
     col_vecs,
     groups_df,
     "survey_means",
     design,
     meta_args,
-    MEANS_META_KEYS
+    MEANS_META_KEYS,
+    estimate_cols = c("mean"),
+    statistic = "mean",
+    cell_df = cal_df
   )
 
   # ── Step 12: Apply decimals and name style ──────────────────────────────────

--- a/R/analysis-quantiles.R
+++ b/R/analysis-quantiles.R
@@ -420,7 +420,9 @@ get_quantiles <- function(
     "survey_quantiles",
     design,
     meta_args,
-    QUANTILES_META_KEYS
+    QUANTILES_META_KEYS,
+    estimate_cols = c("estimate"),
+    statistic = "quantile"
   )
 
   # ── Step 13: Apply decimals and name style ──────────────────────────────────

--- a/R/analysis-ratios.R
+++ b/R/analysis-ratios.R
@@ -426,7 +426,9 @@ get_ratios <- function(
     "survey_ratios",
     design,
     meta_args,
-    RATIOS_META_KEYS
+    RATIOS_META_KEYS,
+    estimate_cols = c("ratio"),
+    statistic = "ratio"
   )
 
   # ── Step 13: Apply decimals and name style ────────────────────────────────

--- a/R/analysis-totals.R
+++ b/R/analysis-totals.R
@@ -322,7 +322,9 @@ get_totals <- function(
     "survey_totals",
     design,
     meta_args,
-    TOTALS_META_KEYS
+    TOTALS_META_KEYS,
+    estimate_cols = c("total"),
+    statistic = "total"
   )
 
   # ── Step 12: Apply decimals and name style ──────────────────────────────────

--- a/tests/testthat/test-analysis-corr.R
+++ b/tests/testthat/test-analysis-corr.R
@@ -1817,3 +1817,29 @@ test_that("get_corr() all-NA ordinal returns NA (early-exit) through nonprob lat
   expect_equal(nrow(result), 1L)
   expect_true(is.na(result$r[[1L]]))
 })
+
+# ── .survey_result attribute tests ────────────────────────────────────────────
+
+test_that("get_corr() long format attaches .survey_result with estimate_cols = c('r')", {
+  df <- make_survey_data(n = 200, seed = 1)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_corr(d, x = c(y1, y2), format = "long")
+  sr <- attr(result, ".survey_result")
+  expect_false(is.null(sr))
+  expect_identical(sr$estimate_cols, c("r"))
+})
+
+test_that("get_corr() long format attaches .survey_result with statistic = 'corr'", {
+  df <- make_survey_data(n = 200, seed = 2)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_corr(d, x = c(y1, y2), format = "long")
+  sr <- attr(result, ".survey_result")
+  expect_identical(sr$statistic, "corr")
+})
+
+test_that("get_corr() wide format has NULL .survey_result attribute", {
+  df <- make_survey_data(n = 200, seed = 3)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_corr(d, x = c(y1, y2), format = "wide")
+  expect_null(attr(result, ".survey_result"))
+})

--- a/tests/testthat/test-analysis-covariance.R
+++ b/tests/testthat/test-analysis-covariance.R
@@ -117,7 +117,11 @@ test_that("get_covariance() diagonal-parity gate — Taylor", {
     ,
     drop = FALSE
   ]
-  expect_equal(diag_y1$covariance[[1L]], var_y1$variance[[1L]], tolerance = 1e-10)
+  expect_equal(
+    diag_y1$covariance[[1L]],
+    var_y1$variance[[1L]],
+    tolerance = 1e-10
+  )
   expect_equal(diag_y1$se[[1L]], var_y1$se[[1L]], tolerance = 1e-8)
 })
 
@@ -159,7 +163,11 @@ test_that("get_covariance() diagonal-parity gate — replicate (BRR)", {
     ,
     drop = FALSE
   ]
-  expect_equal(diag_y1$covariance[[1L]], var_y1$variance[[1L]], tolerance = 1e-10)
+  expect_equal(
+    diag_y1$covariance[[1L]],
+    var_y1$variance[[1L]],
+    tolerance = 1e-10
+  )
   expect_equal(diag_y1$se[[1L]], var_y1$se[[1L]], tolerance = 1e-8)
 })
 
@@ -520,7 +528,10 @@ test_that("get_covariance() .meta$x has one entry per resolved numeric variable 
   expect_identical(names(m$x), c("y1", "y2", "y3"))
   for (nm in names(m$x)) {
     expect_true(
-      all(c("variable_label", "question_preface", "value_labels") %in% names(m$x[[nm]]))
+      all(
+        c("variable_label", "question_preface", "value_labels") %in%
+          names(m$x[[nm]])
+      )
     )
   }
 })
@@ -598,7 +609,15 @@ test_that("get_covariance() decimals = 3 rounds every numeric output column", {
     decimals = 3
   )
 
-  for (nm in c("covariance", "se", "ci_low", "ci_high", "moe", "deff", "n_weighted")) {
+  for (nm in c(
+    "covariance",
+    "se",
+    "ci_low",
+    "ci_high",
+    "moe",
+    "deff",
+    "n_weighted"
+  )) {
     if (is.finite(res_full[[nm]][[1L]])) {
       expect_identical(
         res_r[[nm]][[1L]],
@@ -1302,4 +1321,32 @@ test_that("get_covariance() collection diagonal-parity matches per-survey get_va
       tolerance = 1e-8
     )
   }
+})
+
+# ── .survey_result attribute tests ────────────────────────────────────────────
+
+test_that("get_covariance() attaches .survey_result with estimate_cols = c('covariance')", {
+  df <- make_survey_data(n = 200, seed = 1)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_covariance(d, x = c(y1, y2))
+  sr <- attr(result, ".survey_result")
+  expect_false(is.null(sr))
+  expect_identical(sr$estimate_cols, c("covariance"))
+})
+
+test_that("get_covariance() attaches .survey_result with statistic = 'covariance'", {
+  df <- make_survey_data(n = 200, seed = 2)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_covariance(d, x = c(y1, y2))
+  sr <- attr(result, ".survey_result")
+  expect_identical(sr$statistic, "covariance")
+})
+
+test_that("get_covariance() .survey_result$df is rep(Inf, p) for non-calibrated design", {
+  df <- make_survey_data(n = 200, seed = 3)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_covariance(d, x = c(y1, y2))
+  sr <- attr(result, ".survey_result")
+  expect_true(all(is.infinite(sr$df)))
+  expect_equal(length(sr$df), nrow(result))
 })

--- a/tests/testthat/test-analysis-diffs.R
+++ b/tests/testthat/test-analysis-diffs.R
@@ -1040,3 +1040,62 @@ test_that("get_diffs() pct_change is non-NA with show_means = FALSE (grouped)", 
   # pct_change non-NA for all rows (all are non-reference)
   expect_false(any(is.na(result$pct_change)))
 })
+
+# ── .survey_result attribute tests ────────────────────────────────────────────
+
+test_that("get_diffs() attaches non-NULL .survey_result attribute", {
+  set.seed(42)
+  df <- data.frame(
+    id = 1:200,
+    wt = runif(200, 0.5, 2),
+    dv = rnorm(200, 50, 10),
+    arm = factor(sample(c("Control", "A", "B"), 200, TRUE))
+  )
+  d <- as_survey(df, weights = wt)
+  result <- get_diffs(d, dv, arm)
+  sr <- attr(result, ".survey_result")
+  expect_false(is.null(sr))
+})
+
+test_that("get_diffs() .survey_result$estimate_cols == c('estimate')", {
+  set.seed(42)
+  df <- data.frame(
+    id = 1:200,
+    wt = runif(200, 0.5, 2),
+    dv = rnorm(200, 50, 10),
+    arm = factor(sample(c("Control", "A", "B"), 200, TRUE))
+  )
+  d <- as_survey(df, weights = wt)
+  result <- get_diffs(d, dv, arm)
+  sr <- attr(result, ".survey_result")
+  expect_identical(sr$estimate_cols, c("estimate"))
+})
+
+test_that("get_diffs() .survey_result$statistic == 'diffs'", {
+  set.seed(42)
+  df <- data.frame(
+    id = 1:200,
+    wt = runif(200, 0.5, 2),
+    dv = rnorm(200, 50, 10),
+    arm = factor(sample(c("Control", "A", "B"), 200, TRUE))
+  )
+  d <- as_survey(df, weights = wt)
+  result <- get_diffs(d, dv, arm)
+  sr <- attr(result, ".survey_result")
+  expect_identical(sr$statistic, "diffs")
+})
+
+test_that("get_diffs() .survey_result$df is numeric vector of length p", {
+  set.seed(42)
+  df <- data.frame(
+    id = 1:200,
+    wt = runif(200, 0.5, 2),
+    dv = rnorm(200, 50, 10),
+    arm = factor(sample(c("Control", "A", "B"), 200, TRUE))
+  )
+  d <- as_survey(df, weights = wt)
+  result <- get_diffs(d, dv, arm)
+  sr <- attr(result, ".survey_result")
+  expect_true(is.numeric(sr$df))
+  expect_equal(length(sr$df), nrow(result))
+})

--- a/tests/testthat/test-analysis-freqs.R
+++ b/tests/testthat/test-analysis-freqs.R
@@ -2173,3 +2173,37 @@ test_that("get_freqs() on SRS design with non-proportional weights matches surve
   expect_equal(sc_b$pct, as.numeric(coef(sv_est)["xB"]), tolerance = 1e-10)
   expect_equal(sc_b$se, as.numeric(survey::SE(sv_est)["xB"]), tolerance = 1e-8)
 })
+
+# ── .survey_result attribute tests ────────────────────────────────────────────
+
+test_that("get_freqs() attaches .survey_result attribute with estimate_cols = c('pct')", {
+  df <- make_survey_data(n = 200, seed = 1)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  # Add a categorical variable
+  df2 <- df
+  df2$cat <- factor(sample(c("A", "B", "C"), 200, replace = TRUE))
+  d2 <- as_survey(df2, ids = psu, weights = wt, strata = strata)
+  result <- get_freqs(d2, cat)
+  sr <- attr(result, ".survey_result")
+  expect_false(is.null(sr))
+  expect_identical(sr$estimate_cols, c("pct"))
+})
+
+test_that("get_freqs() attaches .survey_result attribute with statistic = 'freq'", {
+  df <- make_survey_data(n = 200, seed = 2)
+  df$cat <- factor(sample(c("A", "B"), 200, replace = TRUE))
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_freqs(d, cat)
+  sr <- attr(result, ".survey_result")
+  expect_identical(sr$statistic, "freq")
+})
+
+test_that("get_freqs() .survey_result$df is rep(Inf, p) for non-calibrated design", {
+  df <- make_survey_data(n = 200, seed = 3)
+  df$cat <- factor(sample(c("A", "B"), 200, replace = TRUE))
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_freqs(d, cat)
+  sr <- attr(result, ".survey_result")
+  expect_true(all(is.infinite(sr$df)))
+  expect_equal(length(sr$df), nrow(result))
+})

--- a/tests/testthat/test-analysis-means.R
+++ b/tests/testthat/test-analysis-means.R
@@ -1220,3 +1220,47 @@ test_that(".mean_cell() errors for unsupported design class", {
     class = "surveycore_error_unsupported_class"
   )
 })
+
+# ── .survey_result attribute tests ────────────────────────────────────────────
+
+test_that("get_means() attaches .survey_result attribute with correct estimate_cols", {
+  df <- make_survey_data(n = 100, seed = 1)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_means(d, y1)
+  sr <- attr(result, ".survey_result")
+  expect_false(is.null(sr))
+  expect_identical(sr$estimate_cols, c("mean"))
+})
+
+test_that("get_means() attaches .survey_result attribute with statistic = 'mean'", {
+  df <- make_survey_data(n = 100, seed = 2)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_means(d, y1)
+  sr <- attr(result, ".survey_result")
+  expect_identical(sr$statistic, "mean")
+})
+
+test_that("get_means() .survey_result$df is rep(Inf, p) for non-calibrated design", {
+  df <- make_survey_data(n = 100, seed = 3)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_means(d, y1)
+  sr <- attr(result, ".survey_result")
+  expect_true(all(is.infinite(sr$df)))
+  expect_equal(length(sr$df), nrow(result))
+})
+
+test_that("get_means() .survey_result$group_cols is character(0) when no group", {
+  df <- make_survey_data(n = 100, seed = 4)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_means(d, y1)
+  sr <- attr(result, ".survey_result")
+  expect_identical(sr$group_cols, character(0))
+})
+
+test_that("get_means() .survey_result$group_cols contains group vars when grouped", {
+  df <- make_survey_data(n = 200, seed = 5)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_means(d, y1, group = strata)
+  sr <- attr(result, ".survey_result")
+  expect_identical(sr$group_cols, "strata")
+})

--- a/tests/testthat/test-analysis-quantiles.R
+++ b/tests/testthat/test-analysis-quantiles.R
@@ -1418,3 +1418,31 @@ test_that("get_quantiles() single-row SRS domain: CI collapses to point estimate
   expect_equal(result$ci_low[[1L]], result$estimate[[1L]])
   expect_equal(result$ci_high[[1L]], result$estimate[[1L]])
 })
+
+# ── .survey_result attribute tests ────────────────────────────────────────────
+
+test_that("get_quantiles() attaches .survey_result with estimate_cols = c('estimate')", {
+  df <- make_survey_data(n = 200, seed = 1)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_quantiles(d, y1)
+  sr <- attr(result, ".survey_result")
+  expect_false(is.null(sr))
+  expect_identical(sr$estimate_cols, c("estimate"))
+})
+
+test_that("get_quantiles() attaches .survey_result with statistic = 'quantile'", {
+  df <- make_survey_data(n = 200, seed = 2)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_quantiles(d, y1)
+  sr <- attr(result, ".survey_result")
+  expect_identical(sr$statistic, "quantile")
+})
+
+test_that("get_quantiles() .survey_result$df is rep(Inf, p) for non-calibrated design", {
+  df <- make_survey_data(n = 200, seed = 3)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_quantiles(d, y1)
+  sr <- attr(result, ".survey_result")
+  expect_true(all(is.infinite(sr$df)))
+  expect_equal(length(sr$df), nrow(result))
+})

--- a/tests/testthat/test-analysis-ratios.R
+++ b/tests/testthat/test-analysis-ratios.R
@@ -1406,3 +1406,31 @@ test_that("get_ratios() replicate single-row domain hits se_srs=0 path in .repli
   result <- suppressWarnings(get_ratios(sc, numerator = y1, denominator = y2))
   expect_true(is.finite(result$ratio[[1L]]) || is.na(result$ratio[[1L]]))
 })
+
+# ── .survey_result attribute tests ────────────────────────────────────────────
+
+test_that("get_ratios() attaches .survey_result with estimate_cols = c('ratio')", {
+  df <- make_survey_data(n = 200, seed = 1)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_ratios(d, numerator = y1, denominator = y2)
+  sr <- attr(result, ".survey_result")
+  expect_false(is.null(sr))
+  expect_identical(sr$estimate_cols, c("ratio"))
+})
+
+test_that("get_ratios() attaches .survey_result with statistic = 'ratio'", {
+  df <- make_survey_data(n = 200, seed = 2)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_ratios(d, numerator = y1, denominator = y2)
+  sr <- attr(result, ".survey_result")
+  expect_identical(sr$statistic, "ratio")
+})
+
+test_that("get_ratios() .survey_result$df is rep(Inf, p) for non-calibrated design", {
+  df <- make_survey_data(n = 200, seed = 3)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_ratios(d, numerator = y1, denominator = y2)
+  sr <- attr(result, ".survey_result")
+  expect_true(all(is.infinite(sr$df)))
+  expect_equal(length(sr$df), nrow(result))
+})

--- a/tests/testthat/test-analysis-totals.R
+++ b/tests/testthat/test-analysis-totals.R
@@ -1057,3 +1057,31 @@ test_that(".total_cell() errors for unsupported design class", {
     class = "surveycore_error_unsupported_class"
   )
 })
+
+# ── .survey_result attribute tests ────────────────────────────────────────────
+
+test_that("get_totals() attaches .survey_result attribute with estimate_cols = c('total')", {
+  df <- make_survey_data(n = 100, seed = 1)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_totals(d, y1)
+  sr <- attr(result, ".survey_result")
+  expect_false(is.null(sr))
+  expect_identical(sr$estimate_cols, c("total"))
+})
+
+test_that("get_totals() attaches .survey_result attribute with statistic = 'total'", {
+  df <- make_survey_data(n = 100, seed = 2)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_totals(d, y1)
+  sr <- attr(result, ".survey_result")
+  expect_identical(sr$statistic, "total")
+})
+
+test_that("get_totals() .survey_result$df is rep(Inf, p) for non-calibrated design", {
+  df <- make_survey_data(n = 100, seed = 3)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  result <- get_totals(d, y1)
+  sr <- attr(result, ".survey_result")
+  expect_true(all(is.infinite(sr$df)))
+  expect_equal(length(sr$df), nrow(result))
+})


### PR DESCRIPTION
## Summary
- Passes `estimate_cols` and `statistic` to every `.make_result_tibble()` call in all 8 `get_*()` functions, attaching the `.survey_result` metadata attribute needed by `coef()`/`vcov()`/`SE()`/`confint()` (PR 3)
- `get_diffs()` attaches the attribute manually (it bypasses `.make_result_tibble()`); df sourced from `fit@degf`
- `get_corr()` wide-format correctly leaves attribute NULL; long-format gets `estimate_cols = c("r")`
- Calibrated Taylor designs thread per-cell df vectors through `cell_df =`

## Spec coverage
See review.md — verdict PASS.
- Spec items covered: 22 (all Per-Test Result Table rows pass)
- Test scenarios: 41 new attribute assertion tests across 8 test files

## Test results
- devtools::test(): PASS (12238 tests, 0 failures)
- R CMD check --as-cran: 0 errors, 0 warnings, 1 transient note ("unable to verify current time" — not a code issue)
- pkgcheck: PASS
- pkgdown: PASS
- covr: 93.05% (pre-existing gap; coverage-floor override granted in decisions-coef-vcov-methods.md 2026-06-23; new code fully covered, +0.02% vs. baseline)

## Before/After
All 8 get_*() functions now attach .survey_result attribute to their return tibble. Previously the attribute was absent; coef()/vcov()/SE()/confint() could not introspect results.

## Artifacts
- Implementation: .surveycore-workspace/runs/2026-06-22-coef-vcov-methods/prs/pr-2-coef-vcov-wire-getstar/implementation.md
- Audit: .surveycore-workspace/runs/2026-06-22-coef-vcov-methods/prs/pr-2-coef-vcov-wire-getstar/audit.md
- Review: .surveycore-workspace/runs/2026-06-22-coef-vcov-methods/prs/pr-2-coef-vcov-wire-getstar/review.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)