### PR TITLE
test(analysis): drop environment-dependent vctrs hash snapshot from C14

### DIFF
--- a/changelog/fix-collection-bind-snapshot-vctrs-hash.md
+++ b/changelog/fix-collection-bind-snapshot-vctrs-hash.md
@@ -1,0 +1,32 @@
+# Changelog: fix/collection-bind-snapshot-vctrs-hash
+
+**Branch:** `fix/collection-bind-snapshot-vctrs-hash`
+**Status:** Complete
+**Date:** 2026-08-20
+
+## Summary
+
+Fixes the R-CMD-check failure on `develop` (run 32404634951). The C14 test in
+`test-survey-collection-dispatch.R` snapshots an error message from
+`dplyr::bind_rows()`. That message embeds a vctrs factor hash (for example
+`<factor<38051>>`). The hash changed with vctrs 0.7.3, so the snapshot could
+never match on CI. No package code changed behavior — the typed error class
+`surveycore_error_collection_bind_type_mismatch` still fires correctly.
+
+Per `.claude/rules/testing-standards.md`, an error whose text cannot be made
+stable is tested with `expect_error(class = ...)` only. The snapshot is
+removed; the typed class check stays.
+
+## Files Modified
+
+- `tests/testthat/test-survey-collection-dispatch.R` — removed the
+  `expect_snapshot()` call from the C14 test; added a comment that explains
+  why no snapshot exists
+- `tests/testthat/_snaps/survey-collection-dispatch.md` — removed the stale
+  C14 snapshot block
+
+## Changes
+
+- Dropped the environment-dependent snapshot of the bind-type-mismatch error;
+  the `expect_error(class = "surveycore_error_collection_bind_type_mismatch")`
+  assertion remains as the regression test for this error path

--- a/tests/testthat/_snaps/survey-collection-dispatch.md
+++ b/tests/testthat/_snaps/survey-collection-dispatch.md
@@ -57,21 +57,6 @@
       x `.id` must be a single non-empty, non-NA character string.
       i Got <character> of length 1: NA.
 
-# C14: bind-type mismatch across surveys aborts with surveycore class
-
-    Code
-      get_means(coll, y1, group = grp)
-    Condition
-      Warning:
-      ! 1 cell has fewer than 30 unweighted observations. Estimates in these cells may be unreliable for public reporting (AAPOR guidance).
-      Warning:
-      ! 1 cell has fewer than 30 unweighted observations. Estimates in these cells may be unreliable for public reporting (AAPOR guidance).
-      Error in `tryCatchOne()`:
-      x Cannot combine per-survey results: column type mismatch. Each survey must produce compatible types for shared columns.
-      i Original error: Can't combine `..1$grp` <integer> and `..2$grp` <factor<38051>>.
-      Caused by error in `dplyr::bind_rows()`:
-      ! Can't combine `..1$grp` <integer> and `..2$grp` <factor<38051>>.
-
 # C10: tidy-selected variable absent raises surveycore_error_variable_not_found
 
     Code

--- a/tests/testthat/test-survey-collection-dispatch.R
+++ b/tests/testthat/test-survey-collection-dispatch.R
@@ -436,11 +436,12 @@ test_that("C14: bind-type mismatch across surveys aborts with surveycore class",
   )
   coll <- do.call(as_survey_collection, surveys)
 
+  # No snapshot: the message embeds a vctrs factor hash (e.g. <factor<3b1cd>>)
+  # that differs across environments, so the text can never match on CI.
   expect_error(
     get_means(coll, y1, group = grp),
     class = "surveycore_error_collection_bind_type_mismatch"
   )
-  expect_snapshot(error = TRUE, get_means(coll, y1, group = grp))
 })
 
 test_that("C10: tidy-selected variable absent raises surveycore_error_variable_not_found", {


### PR DESCRIPTION
## What

Fixes the R-CMD-check failure on `develop` (run 32404634951, all 4 platforms): the C14 collection-dispatch test snapshotted a `dplyr::bind_rows()` error whose text embeds a vctrs factor hash (`<factor<38051>>`), and vctrs 0.7.3 changed the hash, so the snapshot could never match. No package code changed behavior — the typed error class `surveycore_error_collection_bind_type_mismatch` still fires; per `testing-standards.md`, an error whose text cannot be made stable keeps `expect_error(class = ...)` only, so the snapshot is removed.

## Checklist

- [x] Tests written and passing (`devtools::test()` — FAIL 0, PASS 12580)
- [x] R CMD check: 0 errors, 0 warnings (`devtools::check()` — 0/0/0)
- [x] Roxygen docs updated and `devtools::document()` run (no roxygen changes)
- [x] `plans/error-messages.md` updated (no new errors/warnings)
- [x] `VENDORED.md` updated (no vendored code)
- [x] PR title is a valid Conventional Commit (`test(analysis): ...`)
- [x] PR targets `develop`, not `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)