### PR TITLE
test(analysis): cover single-level group warning in get_effective_n()

### DIFF
--- a/R/analysis-effective-n.R
+++ b/R/analysis-effective-n.R
@@ -97,6 +97,9 @@
 #' # Kish effective N (weight-only approximation)
 #' get_effective_n(d)
 #'
+#' # Kish effective N by group (one row per level of riagendr)
+#' get_effective_n(d, group = riagendr)
+#'
 #' # Full DEFF effective N for a specific variable
 #' get_effective_n(d, ridageyr, method = "deff")
 #' @family analysis

--- a/man/get_effective_n.Rd
+++ b/man/get_effective_n.Rd
@@ -97,6 +97,9 @@ d <- as_survey(
 # Kish effective N (weight-only approximation)
 get_effective_n(d)
 
+# Kish effective N by group (one row per level of riagendr)
+get_effective_n(d, group = riagendr)
+
 # Full DEFF effective N for a specific variable
 get_effective_n(d, ridageyr, method = "deff")
 }

--- a/tests/testthat/test-effective-n.R
+++ b/tests/testthat/test-effective-n.R
@@ -369,6 +369,17 @@ test_that("get_effective_n() kish: na.rm=FALSE with NA weight produces NA n_eff"
   expect_equal(result_true$n[[1L]], 4L)  # 4 non-NA weights
 })
 
+test_that("get_effective_n() warns with single-level group variable", {
+  d <- make_all_na_group_design()
+  expect_warning(
+    r <- get_effective_n(d, group = grp, na.rm = FALSE),
+    class = "surveycore_warning_single_level"
+  )
+  expect_equal(nrow(r), 1L)
+  expect_true(is.na(r$grp[[1L]]))
+  expect_true(is.finite(r$n_eff[[1L]]))
+})
+
 # ══════════════════════════════════════════════════════════════════════════════
 # Section 5 — survey_collection dispatch
 # ══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Add a test_that() block asserting get_effective_n() raises surveycore_warning_single_level when the group variable has one observed level.
- Assert the result stays usable: 1 row, finite n_eff.
- Extend the @examples block with a group = riagendr call and regenerate man/get_effective_n.Rd to match.

## Spec coverage
Quality gate: audit.md (simplified workflow) — verdict PASS.
- Acceptance criteria covered: 7 of 7
- Test scenarios: 8 of 8 PASS (Per-Test Result Table)

## Test results
- devtools::test(): PASS (full suite: FAIL 0, PASS 12598, WARN 256, SKIP 4)
- R CMD check --as-cran --no-manual (project CI invocation): PASS, 0 ERROR, 0 WARNING, 3 pre-existing NOTEs
- pkgdown: PASS
- covr: 93.74% package-wide (pre-existing, unrelated files below floor; this PR's only production file, R/analysis-effective-n.R, is at 99.50% and this PR is coverage-neutral-to-positive)

## Before/After
| Metric | Before PR | After PR | Delta |
|---|---|---|---|
| tests passing | 12597 (inferred) | 12598 | +1 |
| coverage (package-wide) | <= 93.74% (inferred) | 93.74% | 0 to +eps (no regression) |
| R CMD check notes (--as-cran --no-manual) | 3 (pre-existing) | 3 (unchanged) | 0 |

## Artifacts
- Request: .surveycore-workspace/runs/effective-n-single-level/request.md
- Implementation: .surveycore-workspace/runs/effective-n-single-level/implementation.md
- Audit: .surveycore-workspace/runs/effective-n-single-level/audit.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)