### PR TITLE
chore(pipeline): reduce token usage of the pipeline skill family

### DIFF
--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -13,7 +13,7 @@ You implement one PR at a time. You receive `spec.md` and the PR's write surface
 - `spec.md` — behavioral contract
 - `implementation-plan.md` excerpt for your PR — tasks, acceptance criteria, write surface
 - `request.md` and `impact.md` — context
-- `.claude/rules/` — code style, testing standards, R package conventions
+- Project rules (CLAUDE.md + `.claude/rules/`) auto-load into your context — do NOT re-read them. When a rule's application is unclear, read `.claude/references/code-style-detail.md` or `.claude/references/r-package-detail.md` for worked examples.
 - `skills/pipeline-shared/references/r-package-profile.md` — R-specific builder rules
 - On BLOCK re-dispatch: the BLOCK body only (failing scenario, observed, expected, classification) — NEVER the full `audit.md`, NEVER `test-spec.md`
 

--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -54,6 +54,22 @@ For each task in the PR's task list:
 5. **Run the full test file.** Confirm no regression.
 6. **Commit (if using worktree).** Small commits, one per task.
 
+### Full-suite budget
+
+Iterate with `devtools::test(filter = "{pattern}")` on the test files you
+touch. Run the FULL suite (`devtools::test()` with no filter) at most twice
+per PR: once before writing `implementation.md`, and once after a BLOCK fix.
+Measured cost of ignoring this: one builder ran the full suite ~10 times in
+one PR. Redirect full-suite output to a log file and read only the tail:
+
+```bash
+Rscript -e 'devtools::test()' > .test-full.log 2>&1
+tail -25 .test-full.log
+grep -E "^(FAIL|Failure|Error)" .test-full.log
+```
+
+Delete `.test-full.log` before committing.
+
 ## Step 3 — Roxygen and NAMESPACE
 
 After implementing any function with roxygen changes:

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -78,7 +78,7 @@ Follow `artifact-schemas.md` §test-spec.md exactly. Key rules:
 - Every named error class from spec gets an `expect_error(class = ...)` test AND a snapshot test (dual pattern — `rules/testing-standards.md` §3).
 - Every edge case from spec gets a test.
 - `test_invariants(design)` is the first assertion of every test that constructs a survey object.
-- Profile gates list (document, test, run_examples, R CMD check --as-cran, pkgcheck, pkgdown, covr) is always included verbatim.
+- Profile gates list (document, test, run_examples, R CMD check --as-cran, pkgdown, covr) is always included verbatim.
 
 Test-spec is for tester. Do not write about what the code looks like.
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -17,8 +17,8 @@ You are the only agent in the pipeline who reads both sides. Your job is to veri
 - `implementation-plan.md`
 - `implementation.md` for this PR
 - `audit.md` for this PR
-- `.claude/rules/`
-- `skills/pipeline-shared/references/` (all files)
+- Project rules auto-load into your context — do NOT re-read `.claude/rules/`.
+- `skills/pipeline-shared/references/signals.md`, `artifact-schemas.md`, and `r-package-profile.md` — the only shared references you need (verdict schemas, tolerance defaults, gate skip rules).
 
 ## Produces
 

--- a/.claude/agents/shipper.md
+++ b/.claude/agents/shipper.md
@@ -145,7 +145,7 @@ sleep N && gh pr checks ...
 gh run list   # in any loop
 ```
 
-Required checks: `R-CMD-check` (all OS matrix), `pkgdown`. `pkgcheck` is NOT a required check — ignore it.
+Required checks: `R-CMD-check` (all OS matrix), `pkgdown`.
 
 | CI state | Action |
 |---|---|

--- a/.claude/agents/shipper.md
+++ b/.claude/agents/shipper.md
@@ -2,6 +2,7 @@
 name: shipper
 description: Ships a PR after review.md verdict=PASS. Branch, commit (Conventional Commits), push, open PR against develop, monitor CI, merge (squash), post-merge cleanup. Refuses to run without a PASS review. Dispatched by pipeline-ship.
 tools: Read, Bash, Edit
+model: sonnet
 ---
 
 # Agent: shipper
@@ -75,7 +76,7 @@ git commit -m "$(cat <<'EOF'
 
 {2–4 bullet details from implementation.md §Summary}
 
-Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+Co-Authored-By: Claude <noreply@anthropic.com>
 EOF
 )"
 ```

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -13,7 +13,7 @@ You are the quality gate. You validate merged code against `test-spec.md`. You d
 
 - `test-spec.md` — validation scenarios, tolerances, datasets, profile gates
 - `request.md` and `impact.md` — scope context
-- `.claude/rules/` — testing standards
+- Project rules (CLAUDE.md + `.claude/rules/`) auto-load into your context — do NOT re-read them. When a rule's application is unclear, read `.claude/references/testing-detail.md` for worked examples.
 - `skills/pipeline-shared/references/r-package-profile.md` — command order, cookbook rules
 - The merged checkout (working directory) with all builder changes applied
 

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -2,6 +2,7 @@
 name: tester
 description: Validates a merged PR against test-spec.md. Receives only the test-spec, never spec.md or implementation.md. Runs all profile gates. Enforces Tolerance Integrity. Writes audit.md with verdict PASS or BLOCK. Dispatched by pipeline-ship and pipeline-simplified.
 tools: Read, Grep, Glob, Write, Bash
+model: sonnet
 ---
 
 # Agent: tester

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -50,9 +50,10 @@ Follow `r-package-profile.md` §Validation commands table:
 3. `Rscript -e 'devtools::run_examples()'`
 4. `R CMD build .`
 5. `R CMD check --as-cran <tarball>`
-6. `Rscript -e 'pkgcheck::pkgcheck()'`
-7. `Rscript -e 'pkgdown::build_site(preview = FALSE)'` — skip ONLY if scope is tests-only (log skip in audit.md)
-8. `Rscript -e 'covr::package_coverage()'`
+6. `Rscript -e 'pkgdown::build_site(preview = FALSE)'` — skip ONLY if scope is tests-only (log skip in audit.md)
+7. `Rscript -e 'covr::package_coverage()'`
+
+After the last gate, record `git rev-parse 'HEAD^{tree}'` in `audit.md` §Profile gates as `Tree: {hash}` — the pre-PR gate uses it to skip duplicate reruns.
 
 Follow `r-package-profile.md` §Output discipline: full output goes to workspace log files; only the filtered summary enters context. Summaries go in `audit.md` with log paths.
 

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -29,6 +29,8 @@ You are the quality gate. You validate merged code against `test-spec.md`. You d
 - Relaxes tolerances (see Tolerance Integrity below)
 - Skips a required profile gate (skip conditions are limited — see r-package-profile.md)
 - Writes code (you only validate)
+- Runs `sleep`/`until` polling loops (use `run_in_background` and wait for the notification)
+- Reconstructs the pre-PR state (the Before column comes from the dispatch baseline)
 
 ## Tolerance Integrity (ABSOLUTE)
 
@@ -41,21 +43,26 @@ If `test-spec.md` is silent on a tolerance for a specific scenario, use the defa
 
 If you believe the test-spec default is wrong for a scenario (e.g., known survey-package quirk), emit HOLD — do not silently change it.
 
-## Step 1 — Run the profile gates in order
+## Step 1 — Run the profile gates (ONE background command)
 
-Follow `r-package-profile.md` §Validation commands table:
+Run ALL gates with a single command — never gate-by-gate, never with
+sleep/poll loops (measured cost of ignoring this: one tester spent 683
+turns polling):
 
-1. `Rscript -e 'devtools::document()'` — fail if `git diff --exit-code NAMESPACE man/` shows drift
-2. `Rscript -e 'devtools::test()'`
-3. `Rscript -e 'devtools::run_examples()'`
-4. `R CMD build .`
-5. `R CMD check --as-cran <tarball>`
-6. `Rscript -e 'pkgdown::build_site(preview = FALSE)'` — skip ONLY if scope is tests-only (log skip in audit.md)
-7. `Rscript -e 'covr::package_coverage()'`
+1. Start `bash .claude/scripts/run-gates.sh {workspace-run-dir}/logs`
+   with `run_in_background: true`. Add `--skip-pkgdown` ONLY under the
+   `r-package-profile.md` skip conditions.
+2. While it runs, prepare Steps 2–3 (read `test-spec.md` scenarios, list
+   changed files). Do NOT run `sleep`, `until` loops, or repeated status
+   checks — the harness notifies you when the command finishes.
+3. Read ONLY the printed Gate summary table. On a FAIL, read the one log
+   file the summary names; never read logs of passing gates.
 
-After the last gate, record `git rev-parse 'HEAD^{tree}'` in `audit.md` §Profile gates as `Tree: {hash}` — the pre-PR gate uses it to skip duplicate reruns.
-
-Follow `r-package-profile.md` §Output discipline: full output goes to workspace log files; only the filtered summary enters context. Summaries go in `audit.md` with log paths.
+The gates themselves are defined in `r-package-profile.md` §Validation
+commands. Copy the summary table and its `Tree: {hash}` line into
+`audit.md` §Profile gates — the pre-PR gate uses the hash to skip
+duplicate reruns. Review any NOTEs from gate 5 against the pre-approved
+list in `r-package-profile.md`.
 
 ## Step 2 — Validate per-function scenarios
 
@@ -89,7 +96,12 @@ If there are zero violations, write "None".
 
 ## Step 4 — Before/After comparison
 
-Run tests and coverage on the PRE-PR checkout (use `git stash` or a second worktree) and the POST-PR checkout. Record in the Before/After Comparison Table in `audit.md`:
+The Before column comes from the baseline results passed in your dispatch
+— NEVER reconstruct the pre-PR state (no `git stash`, `git apply`, or
+checkout of old trees; measured cost: doubled gate runs). The After column
+comes from the Step 1 gate run. If no baseline was passed, write "no
+baseline provided" in the Before column and emit HOLD. Record in the
+Before/After Comparison Table in `audit.md`:
 
 ```
 | Metric | Before PR | After PR | Δ |

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -54,7 +54,7 @@ Follow `r-package-profile.md` §Validation commands table:
 7. `Rscript -e 'pkgdown::build_site(preview = FALSE)'` — skip ONLY if scope is tests-only (log skip in audit.md)
 8. `Rscript -e 'covr::package_coverage()'`
 
-Capture full output of each command. Summaries go in `audit.md`; full logs stay in the workspace directory for forensics.
+Follow `r-package-profile.md` §Output discipline: full output goes to workspace log files; only the filtered summary enters context. Summaries go in `audit.md` with log paths.
 
 ## Step 2 — Validate per-function scenarios
 

--- a/.claude/references/code-style-detail.md
+++ b/.claude/references/code-style-detail.md
@@ -1,0 +1,417 @@
+# Code Style — Worked Examples and Rationale
+
+Detail moved out of `.claude/rules/code-style.md` and
+`.claude/rules/engineering-preferences.md`. The rules themselves live there;
+this file shows how to apply them. Read this when writing new code and the
+correct application is not obvious from the rule tables.
+
+---
+
+## General R style examples
+
+### Indentation (2 spaces)
+
+Matches rlang, tidyselect, cli, and S7 source.
+
+```r
+# Correct
+survey_taylor <- S7::new_class(
+  "survey_taylor",
+  parent = survey_base,
+  validator = function(self) {
+    if (is.null(self@variables$weights)) {
+      cli::cli_abort("...")
+    }
+  }
+)
+
+# Wrong
+survey_taylor <- S7::new_class(
+    "survey_taylor",           # 4-space indent
+    parent = survey_base,
+```
+
+### Line length (80 characters)
+
+For long function signatures, break after the opening `(` and align arguments:
+
+```r
+# Good — break after (
+as_survey <- function(
+  data,
+  ids = NULL,
+  probs = NULL,
+  weights = NULL,
+  strata = NULL,
+  fpc = NULL,
+  nest = FALSE
+) {
+
+# Also good for short signatures — keep on one line if under 80 chars
+set_var_label <- function(x, var, label) {
+```
+
+For long `cli_abort()` calls, break the named vector across lines:
+
+```r
+cli::cli_abort(
+  c(
+    "x" = "Weight column {.field {weights_var}} must be numeric.",
+    "i" = "Got class {.cls {class(wt_col)}}.",
+    "v" = "Use {.code as.numeric({.field {weights_var}})} to convert."
+  ),
+  class = "surveycore_error_weights_not_numeric"
+)
+```
+
+### Auto-formatter (`air`)
+
+```r
+# Install
+pak::pak("posit-dev/air")
+
+# Format the entire package
+air::format_package()
+
+# Format a single file (or use the RStudio/Positron addin)
+air::format_file("R/03-constructors.R")
+```
+
+Run on save or before committing. Do not manually adjust spacing after
+running `air`. If `air` output looks wrong, there's a syntax problem — don't
+work around it. Run `air::format_package()` before opening a PR. Do not
+commit `air`-reformatted files in the same commit as functional changes —
+reformat first, then make the change.
+
+### Pipe and assignment
+
+```r
+# Correct
+survey_obj |>
+  set_var_label(age, "Age in years") |>
+  set_var_label(income, "Annual income")
+weights_var <- names(weights_cols)
+
+# Wrong
+survey_obj %>%
+  set_var_label(age, "Age in years")
+weights_var = names(weights_cols)
+```
+
+Enforced by `lintr::pipe_consistency_linter("native")`.
+
+---
+
+## S7 pattern examples
+
+### Property access accessors
+
+```r
+# Accessor functions (defined in 07-utils.R, exported)
+survey_data     <- function(x) x@data
+survey_metadata <- function(x) x@metadata
+
+# Internal code always uses @ directly
+wt_col <- x@data[[x@variables$weights]]
+n_labels <- length(x@metadata@variable_labels)
+```
+
+### Method registration comment
+
+Every method registration in the methods files must include a comment
+pointing to the class definition:
+
+```r
+# Class defined in R/00-s7-classes.R
+S7::method(print, survey_taylor) <- function(x, n = 10, ...) {
+  ...
+}
+```
+
+### Class membership testing
+
+```r
+# Correct — class object; rename caught at load time
+if (!S7::S7_inherits(phase1, survey_taylor)) {
+  cli::cli_abort(...)
+}
+
+# Wrong — string; rename silently breaks the check
+if (!inherits(phase1, "survey_taylor")) {
+  cli::cli_abort(...)
+}
+
+# Also wrong — S4 idiom in an S7 codebase
+if (!is(phase1, "survey_taylor")) {
+  cli::cli_abort(...)
+}
+```
+
+### `@variables` list: all keys always present
+
+```r
+# Correct — all keys present
+variables <- list(
+  ids             = NULL,    # NULL means "not specified"
+  weights         = weights_var,
+  strata          = NULL,
+  fpc             = NULL,
+  nest            = nest,
+  probs_provided  = FALSE
+)
+
+# Wrong — missing keys
+variables <- list(
+  weights = weights_var,
+  nest    = nest
+  # ids, strata, fpc absent — ambiguous: "not specified" or "forgot"?
+)
+```
+
+Code throughout the codebase checks `is.null(x@variables$strata)` — this only
+works reliably when keys are always present.
+
+---
+
+## Error and warning examples
+
+### `cli_abort()` good vs bad
+
+```r
+# Good
+cli::cli_abort(
+  c(
+    "x" = "{.arg fpc} column {.field {fpc_var}} contains {sum(is.na(fpc_col))} NA value(s).",
+    "i" = "FPC must be fully observed for finite population correction.",
+    "v" = "Remove rows with missing FPC or set {.arg fpc = NULL} to omit the correction."
+  ),
+  class = "surveycore_error_fpc_na"
+)
+
+# Bad — no class, no context
+cli::cli_abort("FPC has NAs")
+```
+
+### `cli_warn()` structure
+
+Same structure and same `class=` requirement as `cli_abort()`:
+
+```r
+cli::cli_warn(
+  c(
+    "!" = "What triggered the warning.",
+    "i" = "Why this matters.",
+    "i" = "What to do if this is unexpected."
+  ),
+  class = "surveycore_warning_{condition}"    # ALWAYS required
+)
+```
+
+### Class name examples
+
+```r
+# Error class examples
+"surveycore_error_not_data_frame"
+"surveycore_error_weights_nonpositive"
+"surveycore_error_subset_degenerate"
+
+# Warning class examples
+"surveycore_warning_srs_no_weights"
+"surveycore_warning_single_stratum"
+"surveycore_warning_psu_multi_strata"
+```
+
+For the full inline markup reference (50+ classes, pluralization, progress
+bars, theming), see the `cli` skill in `.claude/skills/cli/`.
+
+---
+
+## Function design examples
+
+### Return visibility
+
+```r
+# Setter — always invisible
+set_var_label.survey_base <- function(x, var, label) {
+  var_name <- rlang::as_name(rlang::enquo(var))
+  x@metadata@variable_labels[[var_name]] <- label
+  invisible(x)
+}
+
+# Getter — always visible
+extract_var_label.survey_base <- function(x, var) {
+  var_name <- rlang::as_name(rlang::enquo(var))
+  x@metadata@variable_labels[[var_name]]
+}
+```
+
+### Argument order
+
+```r
+# as_survey_rep: data (1), weights (2, required), repweights (2, required),
+#                type (3, required scalar), then optional scalars
+as_survey_rep <- function(
+  data,
+  weights,
+  repweights,
+  type = c("JK1", "JK2", "JKn", "BRR", "Fay", "bootstrap", ...),
+  scale = NULL,
+  rscales = NULL,
+  fpc = NULL,
+  fpctype = c("fraction", "correction"),
+  mse = TRUE
+)
+
+# set_var_label: x (1), var (2, required NSE), label (3, required scalar)
+set_var_label <- function(x, var, label)
+```
+
+Named-only control args go after `...` — R's argument-matching rule forces
+named supply for any parameter after `...`, the tidyverse idiom for control
+flags like `.id`, `.on_missing`, `group`, `names_to`, `values_to`. Examples:
+`get_freqs(design, x, ..., group, names_to, values_to, variance)`;
+`get_means(coll, y, ..., .id = ".survey", .on_missing = "error")`.
+
+### Dispatch rule
+
+```r
+# CORRECT — extending print (existing generic)
+S7::method(print, survey_taylor) <- function(x, n = 10, ...) { ... }
+
+# CORRECT — new surveycore-owned generic
+# Plain function; S7::S7_inherits() validates the type explicitly.
+set_var_label <- function(x, var, label) {
+  if (!S7::S7_inherits(x, survey_base)) {
+    cli::cli_abort(
+      c("x" = "{.arg x} must be a survey design object."),
+      class = "surveycore_error_not_survey_object"
+    )
+  }
+  # implementation
+}
+
+# WRONG — UseMethod() cannot find name.surveycore::survey_base methods
+set_var_label <- function(x, var, label) UseMethod("set_var_label")
+set_var_label.survey_base <- function(x, var, label) { ... }  # never dispatched
+
+# WRONG — S3 dispatch silently ignored for S7 objects when generic is S7-aware
+print.survey_taylor <- function(x, n = 10, ...) { ... }   # never dispatched
+summary.survey_taylor <- function(object, ...) { ... }    # never dispatched
+```
+
+### Internal helper placement
+
+```r
+# In R/03-constructors.R — used only by as_survey()
+.check_probs_weights_consistency <- function(probs_var, weights_var, data, tol = 1e-6) {
+  ...
+}
+
+# In R/07-utils.R — used by constructors AND update_design()
+.get_design_vars_flat <- function(design) {
+  c(
+    design@variables$ids,
+    design@variables$weights,
+    design@variables$strata,
+    design@variables$fpc
+  )
+}
+```
+
+When a single-use inline helper grows a second call site, promote it to
+`07-utils.R` in the same PR that adds the second call.
+
+---
+
+## Tooling configuration
+
+### `.lintr` (in package root)
+
+```yaml
+linters: linters_with_defaults(
+  line_length_linter(80),
+  pipe_consistency_linter("native"),
+  object_name_linter("snake_case"),
+  assignment_linter()
+)
+exclusions: list("data-raw")
+```
+
+### `.editorconfig` (in package root)
+
+```ini
+root = true
+
+[*.R]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{md,yaml,yml}]
+indent_size = 2
+```
+
+---
+
+## Engineering preferences — detail
+
+The five principles live in `.claude/rules/engineering-preferences.md`.
+Their sub-points:
+
+### 1. DRY — flag repetition aggressively
+
+- Repeated patterns in 2+ functions → extract a shared internal helper
+- Repeated validation logic → consolidate into a single validator
+- Repeated test setup → move to `helper-*.R`
+- Do not defer DRY violations as "we can clean this up later." Surface them
+  during spec review, not after the code is written.
+
+### 2. Well-tested — more tests is better
+
+- When unsure whether an edge case needs a test, write the test
+- Never suggest removing coverage to hit a deadline
+- 98%+ line coverage is the floor, not the target
+- Every error class gets a test; every edge case in the spec gets a test
+
+### 3. Engineered enough — not under, not over
+
+**Under-engineered** (fragile, hacky): missing edge case handling; contracts
+that don't specify behavior at the boundaries; validation that only checks
+the happy path.
+
+**Over-engineered** (premature abstraction, unnecessary complexity):
+abstraction layers that don't yet have two real call sites; generalization
+for hypothetical future requirements not in the roadmap; clever solutions
+when a straightforward one works fine.
+
+The right amount of engineering is determined by what's in the current spec,
+not by what might be needed in a later phase.
+
+### 4. Handle more edge cases, not fewer
+
+- All-NA inputs, zero-weight rows, single-level groups, empty domains — these
+  are not hypothetical; they appear in real survey data
+- "That probably won't happen" is not a reason to skip an edge case
+- Thoughtfulness > speed: a slower implementation that handles edge cases
+  correctly is always preferred
+
+### 5. Explicit over clever
+
+- `S7::S7_inherits(x, ClassName)` not `inherits(x, "survey_taylor")`
+- Named error classes on every `cli_abort()`, not bare messages
+- Spell out behavior in the spec rather than relying on "the reader will infer"
+- Document assumptions rather than leaving them implicit
+
+### How to apply these during review
+
+1. Read through with DRY as the first lens — find repetition before anything else
+2. Check every error condition and edge case in the spec against the test plan
+3. For each design decision, ask: is this the right level of abstraction for
+   what's actually needed now?
+4. For each boundary condition mentioned in the spec, ask: is the behavior
+   fully specified, or is it left implicit?
+5. For any "shortcut" in the implementation plan, ask: does this skip something
+   that will need to be added back later anyway?

--- a/.claude/references/github-strategy-detail.md
+++ b/.claude/references/github-strategy-detail.md
@@ -1,0 +1,69 @@
+# GitHub Strategy — Worked Examples and Release Detail
+
+Detail moved out of `.claude/rules/github-strategy.md`. The decision tables
+live there; this file shows how to apply them. Read this when choosing a
+workflow tier for a borderline change, or when preparing a release.
+
+---
+
+## Workflow tier worked examples
+
+Use these to calibrate. When in doubt about a tier, find the closest example
+below.
+
+**Tier 1 — New exported function `get_contrasts()`**
+New API surface, behavior not fully specified, multiple design choices
+(contrast coding, CI method, interaction with domain estimation). → spec →
+implementation plan → `/r-implement`
+
+**Tier 1 — Adding `method =` to `get_quantiles()` for interpolation strategy**
+Multiple valid approaches exist in the survey literature (linear, Type 7,
+Woodruff). Correct behavior is genuinely undecided until it's specified.
+Feels like "one argument" but it's actually a behavioral commitment.
+→ Tier 1, not Tier 2.
+
+**Tier 2 — Adding `variance =` argument to `get_means()`**
+Behavior is obvious: let the caller pick Taylor vs. replicate variance when
+both are available. But the approach isn't: how does it interact with
+`survey_twophase`, what's the default, what error fires when the requested
+method isn't supported? Write an implementation plan to settle these before
+touching code. → implementation plan → `/r-implement`
+
+**Tier 2 → Tier 3 boundary — Adding `na.rm =` to `get_freqs()`**
+One new argument, behavior obvious (`TRUE` drops NA cells). But wiring it
+through all design paths and deciding whether NA gets its own frequency row
+or disappears entirely isn't obvious. → Tier 2 (plan first), not Tier 3.
+
+**Tier 3 — `get_means()` returns wrong SE when `nest = TRUE` is omitted on
+NHANES data**
+Clear bug, localized to the variance calculation in `R/variance-taylor.R`.
+The correct behavior is known (match `survey::svymean`). Fix the logic, add
+a regression test. → branch → `/r-implement` → `/commit-and-pr`
+
+**Tier 0 — Fix a typo in the `@param fpc` description**
+One-word change in roxygen comment. No branch, no PR needed. → direct commit
+to `develop`
+
+---
+
+## Release preparation
+
+Use `/merge-main`. It handles: NEWS.md update → version bump →
+`devtools::check()` → PR `develop` → `main` → tag → post-release `.9000`
+bump.
+
+PR template for feature PRs lives in `.github/PULL_REQUEST_TEMPLATE.md`.
+
+Hotfixes branch from `main`, merge to `main`, then also merge to `develop`
+to stay in sync.
+
+GitHub settings: allow both squash merges and merge commits; auto-delete
+head branches.
+
+| Tag | Milestone |
+|-----|-----------|
+| `v0.1.0` | Phase 0 complete — core infrastructure |
+| `v0.2.0` | Phase 0.5 complete — surveytidy |
+| `v0.3.0` | Phase 1 complete — estimation functions |
+| `v0.4.0` | Phase 2 complete — regression |
+| `v1.0.0` | Stable API, CRAN submission |

--- a/.claude/references/r-package-detail.md
+++ b/.claude/references/r-package-detail.md
@@ -1,0 +1,236 @@
+# R Package Conventions — Worked Examples and Templates
+
+Detail moved out of `.claude/rules/r-package-conventions.md` and
+`.claude/rules/surveycore-conventions.md`. The rules live there; this file
+shows how to apply them. Read this when writing roxygen docs, DESCRIPTION
+fields, or package-level documentation.
+
+---
+
+## `@param` verbosity examples
+
+**Terse** (one sentence) for simple, self-evident arguments:
+
+```r
+#' @param data A data.frame.
+#' @param label A character string.
+#' @param ... Additional arguments (currently unused).
+```
+
+**Fuller** for arguments with non-obvious behavior, constraints, or
+interactions:
+
+```r
+#' @param weights <[`tidy-select`][tidyselect::language]> Column(s) for
+#'   survey weights. If multiple columns, they are combined. Cannot contain
+#'   `NA`. Default `NULL` (uniform weights).
+```
+
+## `@return` examples
+
+```r
+#' @return A survey design object.
+#' @return A data.frame of results.
+#' @return A character string, or `NULL` if not set.
+#' @return The modified object, invisibly.
+```
+
+For survey objects:
+
+```r
+#' @return A `survey_taylor` object — a complete survey design specification
+#'   ready for variance estimation via Taylor series linearization.
+#'   See [survey_taylor] for structure.
+```
+
+## `@examples` — runnable, small
+
+If an example is slow, use a smaller inline dataset instead of `\dontrun{}`:
+
+```r
+#' @examples
+#' # Small inline example (preferred)
+#' df <- data.frame(id = 1:10, y = rnorm(10))
+#' result <- my_function(df)
+```
+
+## Internal function documentation
+
+```r
+# One-liner — no roxygen needed
+.get_col <- function(x, col) x[[col]]
+
+# Complex helper — document but suppress .Rd
+#' Validate survey design structure
+#'
+#' @param x A survey design object.
+#' @return Invisibly, `TRUE` on success (errors otherwise).
+#' @keywords internal
+#' @noRd
+.validate_design <- function(x) { ... }
+```
+
+## Import style examples
+
+```r
+# Correct
+result <- rlang::enquo(x)
+cli::cli_abort("message", class = "error_class")
+
+# Wrong
+result <- enquo(x)           # requires @importFrom rlang enquo
+cli_abort("message")         # requires @importFrom cli cli_abort
+
+# Wrong — no re-exports; don't do this
+#' @importFrom magrittr %>%
+#' @export
+`%>%` <- magrittr::`%>%`
+```
+
+## Version pinning example
+
+```r
+Imports:
+    cli (>= 3.6.0),        # cli_abort() with class= argument
+    rlang (>= 1.1.0),      # rlang::check_required()
+    S7 (>= 0.1.0)          # S7 class system
+Suggests:
+    testthat (>= 3.0.0)
+```
+
+Set the bound to the oldest version where the required feature exists. Do
+NOT use exact version pins (`==`) — rejected by CRAN and too fragile.
+
+## `devtools::document()` cadence example
+
+```r
+# Before committing changes to R/03-functions.R
+devtools::document()
+git add NAMESPACE man/my_function.Rd
+git commit -m "docs(functions): update roxygen"
+```
+
+---
+
+## DESCRIPTION template (all surveyverse packages)
+
+```
+Package: surveyXXX
+Title: [Descriptive title matching the package role]
+Version: 0.0.0.9000
+Authors@R: person("Jacob", "Dennen", role = c("aut", "cre"), email = "...")
+Description: [1-2 sentence description of what the package does]
+License: GPL-3
+Encoding: UTF-8
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.x.x
+```
+
+## Package documentation template (surveypkg-package.R)
+
+```r
+#' surveytidy: dplyr/tidyr verbs for survey objects
+#'
+#' @description
+#' surveytidy provides dplyr and tidyr verbs that work with survey design objects
+#' from surveycore, allowing...
+#'
+#' @section Key Functions:
+#' - [filter()] — domain-aware filtering
+#' - [select()] — column selection
+#' - [mutate()] — add/modify variables
+#'
+#' @section Documentation:
+#' For ecosystem architecture, see [the ecosystem guide](../survey-standards/ECOSYSTEM.md).
+#'
+#' @keywords internal
+#' "_PACKAGE"
+```
+
+---
+
+## surveycore documentation examples
+
+Survey-specific arguments like `nest`, `fpc`, and `type` need fuller
+documentation because they have non-obvious behavior:
+
+```r
+#' Create a Taylor series survey design
+#'
+#' @param data A data.frame containing survey data.
+#'
+#' @param ids <[`tidy-select`][tidyselect::language]> Primary sampling unit IDs.
+#'   Use bare column names (e.g., `psu`, or `c(psu1, psu2)` for multiple levels).
+#'   Default `NULL` (assumed SRS within strata).
+#'
+#' @param weights <[`tidy-select`][tidyselect::language]> Column(s) for survey
+#'   weights. If multiple columns specified, they are multiplied together.
+#'   Cannot contain `NA` or non-positive values. Default `NULL` (uniform weights).
+#'
+#' @param strata <[`tidy-select`][tidyselect::language]> Stratum IDs.
+#'   Use bare column names (e.g., `strata`). Default `NULL` (no stratification).
+#'
+#' @param fpc <[`tidy-select`][tidyselect::language]> Finite population
+#'   correction column. Supply either:
+#'   - An integer column with population size (e.g., stratum population)
+#'   - A numeric column (0-1) with sampling fraction
+#'   Cannot contain `NA`. If `NULL`, design assumes sampling from infinite
+#'   population. Default `NULL`.
+#'
+#' @param nest Logical. If `TRUE`, PSU IDs are treated as nested within strata —
+#'   i.e., the same PSU ID value in two different strata refers to two distinct
+#'   PSUs. Set `nest = TRUE` when PSU IDs are not globally unique (e.g., NHANES
+#'   uses IDs 1–30 within each stratum). Requires `strata` to be specified.
+#'   Default `FALSE`.
+#'
+#' @examples
+#' # Stratified cluster design with FPC (NHANES)
+#' d <- as_survey(
+#'   nhanes_2017,
+#'   ids = sdmvpsu,
+#'   weights = wtmec2yr,
+#'   strata = sdmvstra,
+#'   fpc = NULL,  # Assume infinite population
+#'   nest = TRUE  # PSU IDs are nested within strata
+#' )
+#'
+#' # Simple random sample with custom weights
+#' df <- data.frame(id = 1:100, y = rnorm(100), w = runif(100, 0.5, 2))
+#' d <- as_survey(df, weights = w)
+#'
+#' # Two-level cluster design (schools -> students)
+#' d <- as_survey(
+#'   schools_data,
+#'   ids = c(school_id, student_id),
+#'   weights = sampling_weight
+#' )
+```
+
+### `@seealso` — constructors only
+
+Only the three constructors (`as_survey()`, `as_survey_rep()`,
+`as_survey_twophase()`) carry `@seealso`:
+
+```r
+#' @seealso
+#'   [as_survey_rep()] for replicate-weight designs,
+#'   [as_survey_twophase()] for two-phase designs,
+#'   [update_design()] to modify an existing design,
+#'   [extract_var_label()] to retrieve variable labels
+```
+
+Getters, setters, validators, and other functions do **not** carry
+`@seealso`.
+
+### Documentation checklist (before committing roxygen changes)
+
+- [ ] `devtools::document()` has been run
+- [ ] `NAMESPACE` file has been updated
+- [ ] All exported functions have `@return`
+- [ ] All `@examples` are runnable
+- [ ] Internal helpers have `@keywords internal` + `@noRd` if needed
+- [ ] `@family` tags are correct
+- [ ] Constructor functions have `@seealso`
+- [ ] No `@importFrom` tags anywhere
+- [ ] All external calls use `::`
+- [ ] `R CMD check` passes with 0 errors, 0 warnings, ≤2 notes

--- a/.claude/references/testing-detail.md
+++ b/.claude/references/testing-detail.md
@@ -1,0 +1,270 @@
+# Testing Standards — Worked Examples and Templates
+
+Detail moved out of `.claude/rules/testing-standards.md` and
+`.claude/rules/testing-surveycore.md`. The rules live there; this file shows
+how to apply them. Read this when writing new test files and the correct
+pattern is not obvious from the rule tables.
+
+---
+
+## Test structure examples
+
+### `test_that()` descriptions
+
+```r
+# Correct — specific, present-tense assertion
+test_that("my_fn() rejects data frames with 0 rows", { ... })
+test_that("my_fn() assigns a default weight when none is given", { ... })
+
+# Wrong — vague category
+test_that("my_fn() validates input", { ... })
+test_that("weights work", { ... })
+```
+
+### No `describe()` blocks
+
+```r
+# Correct
+test_that("my_class stores the x property", { ... })
+test_that("my_class stores the y property", { ... })
+
+# Wrong
+describe("my_class properties", {
+  test_that("stores x", { ... })
+})
+```
+
+### `# nocov` marking
+
+```r
+# nocov start
+# Defensive: this branch is unreachable via any public function.
+# Tested implicitly by all constructor tests.
+if (is.null(x@data)) {
+  cli::cli_abort("Internal error: @data is NULL", class = "mypkg_error_internal")
+}
+# nocov end
+```
+
+---
+
+## The three mandatory test categories
+
+**1. Happy path** — normal inputs, expected behavior:
+
+```r
+test_that("my_fn() creates the right class for standard input", {
+  result <- my_fn(data, weights = w)
+  expect_true(inherits(result, "my_class"))
+})
+```
+
+**2. Error paths** — every typed error class from the package's error table:
+
+```r
+test_that("my_fn() rejects non-data-frame input", {
+  expect_snapshot(error = TRUE, my_fn(list(x = 1)))
+  expect_error(my_fn(list(x = 1)), class = "mypkg_error_not_data_frame")
+})
+```
+
+**3. Edge cases** — boundary conditions, NAs, empty inputs, single-row inputs:
+
+```r
+test_that("my_fn() warns for single-row data", {
+  single_row <- data.frame(x = 1, w = 1)
+  expect_warning(
+    my_fn(single_row, weights = w),
+    class = "mypkg_warning_single_row"
+  )
+})
+```
+
+---
+
+## Private function testing
+
+```r
+# Indirect (preferred) — .validate_weights() tested via the public API
+test_that("my_fn() rejects non-positive weights", {
+  df <- data.frame(x = 1:5, w = c(1, 0, 1, 1, 1))
+  expect_error(my_fn(df, weights = w), class = "mypkg_error_weights_nonpositive")
+})
+
+# Direct (only when necessary)
+test_that(".validate_fpc() rejects NA in fpc column [direct]", {
+  df <- data.frame(y = 1, fpc = NA_real_)
+  expect_error(.validate_fpc(df, "fpc"), class = "mypkg_error_fpc_na")
+})
+```
+
+---
+
+## Dual pattern for constructor errors
+
+```r
+test_that("as_survey() rejects weight column with zero values", {
+  df <- data.frame(x = 1:5, w = c(1, 0, 1, 1, 1))
+
+  # 1. Typed class check — verifies the right error class is thrown
+  expect_error(
+    as_survey(df, weights = w),
+    class = "surveycore_error_weights_nonpositive"
+  )
+
+  # 2. Snapshot — verifies the CLI message text has not changed
+  expect_snapshot(error = TRUE, as_survey(df, weights = w))
+})
+```
+
+Layer 1 (S7 class validators, `R/00-s7-classes.R`) uses `class=` only — no
+snapshot — because those messages are not CLI-formatted:
+
+```r
+test_that("survey_taylor validator rejects missing weights column in @variables", {
+  expect_error(
+    survey_taylor(data = data.frame(x = 1), variables = list(weights = NULL)),
+    class = "surveycore_error_weights_column_absent"
+  )
+})
+```
+
+---
+
+## Warning capture pattern
+
+```r
+test_that("my_fn() warns and still returns an object for single-row data", {
+  d1 <- data.frame(x = 1, w = 1)
+
+  expect_warning(
+    result <- my_fn(d1, weights = w),
+    class = "mypkg_warning_single_row"
+  )
+
+  expect_true(inherits(result, "my_class"))
+})
+```
+
+Do **not** use `withCallingHandlers()` or `tryCatch()` in tests.
+
+---
+
+## Test data examples
+
+### Generator usage
+
+```r
+df <- make_survey_data(n = 200, n_psu = 20, n_strata = 4, seed = 123)
+d  <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc)
+test_invariants(d)
+```
+
+### Edge case data: inline, never via generator parameters
+
+```r
+# Correct — inline, self-documenting
+test_that("my_fn() rejects data with 0 rows", {
+  empty_df <- data.frame(x = numeric(0), w = numeric(0))
+  expect_error(my_fn(empty_df, weights = w), class = "mypkg_error_empty_data")
+})
+
+# Wrong
+df <- make_pkg_data(edge = "empty", seed = 1)  # don't do this
+```
+
+### `skip_if_not_installed()` — block-level
+
+```r
+# Correct — block-level
+test_that("estimates match reference package [numerical]", {
+  skip_if_not_installed("ref_pkg")
+  # ...
+})
+
+test_that("constructor creates correct class", {
+  # runs even without ref_pkg installed
+  d <- my_fn(data, weights = w)
+  expect_true(inherits(d, "my_class"))
+})
+
+# Wrong — skips the entire file
+skip_if_not_installed("ref_pkg")  # at top of file
+```
+
+---
+
+## surveycore numerical validation example
+
+```r
+test_that("Taylor variance matches survey::svymean for NHANES [numerical]", {
+  skip_if_not_installed("survey")
+  d_sc <- as_survey(nhanes_2017, ids = sdmvpsu, weights = wtmec2yr, strata = sdmvstra)
+  d_sv <- survey::svydesign(
+    ids = ~sdmvpsu, weights = ~wtmec2yr, strata = ~sdmvstra,
+    data = nhanes_2017, nest = TRUE
+  )
+  sc_est <- get_means(d_sc, bpxsy1)
+  sv_est <- survey::svymean(~bpxsy1, d_sv, na.rm = TRUE)
+  expect_equal(sc_est$mean, coef(sv_est)[["bpxsy1"]], tolerance = 1e-10)
+  expect_equal(sc_est$se,   SE(sv_est)[["bpxsy1"]],   tolerance = 1e-8)
+})
+```
+
+Constructor test with invariants first:
+
+```r
+test_that("as_survey() creates a survey_taylor object for stratified design", {
+  d <- as_survey(nhanes_2017, ids = sdmvpsu, weights = wtmec2yr, strata = sdmvstra)
+  test_invariants(d)   # always first
+  expect_true(S7::inherits(d, survey_taylor))
+  expect_equal(d@variables$strata, "sdmvstra")
+})
+```
+
+---
+
+## surveycore test file section templates
+
+### `test-constructors.R`
+```
+# 1. Happy paths (one block per design type per constructor)
+# 2. Error paths (one block per error-messages.md row)
+# 3. Edge cases (1-row data, NAs in outcomes, single stratum, etc.)
+# 4. Tidy-select interface (bare names, c(), everything(), etc.)
+# 5. Roundtrip (as_survey() |> update_design() returns valid object)
+```
+
+### `test-validators.R`
+```
+# 1. Happy paths (validators return invisible(TRUE) on valid input)
+# 2. Error paths (Layer 2 validators; each error class covered)
+# 3. Direct tests for branches unreachable via constructors
+```
+
+### `test-variance-estimation.R`
+```
+# Block 1: Taylor series — nhanes_2017
+#   skip_if_not_installed("survey")
+#   One test per estimand: mean, total, proportion
+#   Tolerance: 1e-10 (point), 1e-8 (SE)
+
+# Block 2: BRR replicates — acs_pums_wy
+#   skip_if_not_installed("survey")
+#   One test per estimand
+
+# Block 3: Two-phase — synthetic (make_survey_data(design = "twophase"))
+#   skip_if_not_installed("survey")
+#   One test per estimand
+```
+
+### Snapshot updating
+
+To update snapshots after an intentional message change:
+
+```r
+testthat::snapshot_review()  # review and approve each diff individually
+```
+
+Never run `testthat::snapshot_accept()` blindly. Each snapshot change must
+be reviewed. Snapshots live in `tests/testthat/_snaps/` and are committed.

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,10 +1,7 @@
 # surveycore Code Style Guide
 
-**Version:** 1.0
-**Created:** February 2025
+**Version:** 1.1
 **Status:** Decided — do not re-litigate without updating this document
-
----
 
 ## Quick Reference
 
@@ -28,268 +25,58 @@
 | Warning classes | `class=` on every `cli_warn()` too |
 | Message language | Declarative for `"x"`/`"i"` bullets; imperative for `"v"` bullet |
 
----
+## General R style
 
-## 1. General R Style
+- `<-` for all assignments; `=` only for function arguments.
+- Run `air::format_package()` before opening a PR; reformat-only commits stay
+  separate from functional changes.
 
-### Indentation
-**2 spaces** per indent level. No tabs. Matches rlang, tidyselect, cli, and S7 source.
+## S7 patterns
 
-```r
-# Correct
-survey_taylor <- S7::new_class(
-  "survey_taylor",
-  parent = survey_base,
-  validator = function(self) {
-    if (is.null(self@variables$weights)) {
-      cli::cli_abort("...")
-    }
-  }
-)
+- `@data` and `@metadata` have exported accessors (`survey_data()`,
+  `survey_metadata()`); all other properties use `@` directly in internal
+  code. Never show `@` in user-facing docs or examples.
+- Method files: `00-s7-classes.R` holds class definitions + validators only;
+  print/summary methods in `04-methods-print.R`; conversion methods in
+  `05-methods-conversion.R`. Every method registration carries a comment
+  pointing to the class definition file.
+- Membership tests: always `S7::S7_inherits(x, ClassObject)` with the class
+  object — never a string (`inherits(x, "name")`) and never S4 `is()`.
+- Every constructor initializes ALL `@variables` keys (`ids`, `weights`,
+  `strata`, `fpc`, `nest`, `probs_provided`), using `NULL` for "not
+  specified". Code relies on `is.null(x@variables$key)` checks.
+- `@groups` is RESERVED for Phase 0.5: never read, write, or branch on it in
+  Phase 0 code.
 
-# Wrong
-survey_taylor <- S7::new_class(
-    "survey_taylor",           # 4-space indent
-    parent = survey_base,
-```
+## Errors and warnings
 
-### Line length
-**80 characters** maximum. Enforced by `air` and `lintr`.
-
-For long function signatures, break after the opening `(` and align arguments:
-```r
-# Good — break after (
-as_survey <- function(
-  data,
-  ids = NULL,
-  probs = NULL,
-  weights = NULL,
-  strata = NULL,
-  fpc = NULL,
-  nest = FALSE
-) {
-
-# Also good for short signatures — keep on one line if under 80 chars
-set_var_label <- function(x, var, label) {
-```
-
-For long `cli_abort()` calls, break the named vector across lines:
-```r
-cli::cli_abort(
-  c(
-    "x" = "Weight column {.field {weights_var}} must be numeric.",
-    "i" = "Got class {.cls {class(wt_col)}}.",
-    "v" = "Use {.code as.numeric({.field {weights_var}})} to convert."
-  ),
-  class = "surveycore_error_weights_not_numeric"
-)
-```
-
-### Auto-formatter
-Use **`air`** (Posit's R formatter) for all formatting. Run on save or before committing.
-
-```r
-# Install
-pak::pak("posit-dev/air")
-```
-
-Do not manually adjust spacing after running `air`. If `air` output looks wrong, there's a syntax problem — don't work around it.
-
-### Pipe operator
-**Native `|>` only.** `%>%` is never used. Enforced by `lintr::pipe_consistency_linter("native")`.
-
-```r
-# Correct
-survey_obj |>
-  set_var_label(age, "Age in years") |>
-  set_var_label(income, "Annual income")
-
-# Wrong
-survey_obj %>%
-  set_var_label(age, "Age in years")
-```
-
-### Assignment operator
-**`<-`** for all assignments. `=` is reserved for function arguments only.
-
-```r
-# Correct
-weights_var <- names(weights_cols)
-design <- survey_taylor(data = data, variables = variables)
-
-# Wrong
-weights_var = names(weights_cols)
-```
-
----
-
-## 2. S7-Specific Patterns
-
-### Property access
-Use **`@` directly** everywhere in internal code. Do not create accessor functions for most properties — the class structure is part of the documented API.
-
-**Exception:** `@data` and `@metadata` have thin accessor functions to protect against raw manipulation and provide a stable name if internal structure changes:
-
-```r
-# Accessor functions (defined in 07-utils.R, exported)
-survey_data     <- function(x) x@data
-survey_metadata <- function(x) x@metadata
-
-# Internal code always uses @ directly
-wt_col <- x@data[[x@variables$weights]]
-n_labels <- length(x@metadata@variable_labels)
-```
-
-Do **not** expose `@` in user-facing documentation or examples. Show only function calls.
-
-### S7 method file organization
-Methods are **grouped by type** in dedicated files, not co-located with class definitions:
-
-| File | Contents |
-|------|----------|
-| `00-s7-classes.R` | Class definitions + S7 validators only |
-| `04-methods-print.R` | `S7::method(print, ...)` and `S7::method(summary, ...)` for all classes |
-| `05-methods-conversion.R` | `as_svydesign()`, `from_svydesign()`, `as_tbl_svy()`, `from_tbl_svy()` |
-
-Every method registration in `04-methods-print.R` and `05-methods-conversion.R` must include a comment pointing to the class definition:
-
-```r
-# Class defined in R/00-s7-classes.R
-S7::method(print, survey_taylor) <- function(x, n = 10, ...) {
-  ...
-}
-```
-
-### Class membership testing
-Always use **`S7::S7_inherits(x, ClassName)`** with the class object — never a string.
-
-```r
-# Correct — class object; rename caught at load time
-if (!S7::S7_inherits(phase1, survey_taylor)) {
-  cli::cli_abort(...)
-}
-
-# Wrong — string; rename silently breaks the check
-if (!inherits(phase1, "survey_taylor")) {
-  cli::cli_abort(...)
-}
-
-# Also wrong — S4 idiom in an S7 codebase
-if (!is(phase1, "survey_taylor")) {
-  cli::cli_abort(...)
-}
-```
-
-### `@variables` list: all keys always present
-Every constructor must initialize **all** `@variables` keys, even if their value is `NULL`. Never leave a key absent from the list.
-
-```r
-# Correct — all keys present
-variables <- list(
-  ids             = NULL,    # NULL means "not specified"
-  weights         = weights_var,
-  strata          = NULL,
-  fpc             = NULL,
-  nest            = nest,
-  probs_provided  = FALSE
-)
-
-# Wrong — missing keys
-variables <- list(
-  weights = weights_var,
-  nest    = nest
-  # ids, strata, fpc absent — ambiguous: "not specified" or "forgot"?
-)
-```
-
-Code throughout the codebase checks `is.null(x@variables$strata)` — this only works reliably when keys are always present.
-
-### `@groups` property (Phase 0)
-`@groups` is **RESERVED for Phase 0.5**. In Phase 0:
-- Never read from `@groups` in validators, methods, or constructors
-- Never write to `@groups` (it is always `character(0)`)
-- Never branch on `length(x@groups) > 0` — that check belongs to Phase 0.5 methods
-
----
-
-## 3. Error & Warning Conventions
-
-### `cli_abort()` structure
-Standard three-bullet structure:
+Standard structure — `class=` is required on EVERY `cli_abort()` and
+`cli_warn()` call, no exceptions:
 
 ```r
 cli::cli_abort(
   c(
-    "x" = "What went wrong (declarative).",      # Always present
-    "i" = "Context or diagnosis.",                # Usually present
-    "v" = "How to fix it (imperative)."           # When fixable
+    "x" = "What went wrong (declarative).",      # always present
+    "i" = "Context or diagnosis.",                # usually present
+    "v" = "How to fix it (imperative)."           # when fixable
   ),
-  class = "surveycore_error_{condition}"          # ALWAYS required
+  class = "surveycore_error_{condition}"
 )
 ```
 
-- `"x"` — What is wrong. Subject is the object/argument, not the user. Active voice.
-- `"i"` — Why, or what was found. Provide actual values with `{.val}` / `{.field}` / `{.cls}`.
-- `"v"` — The fix. Imperative: `"Use {.fn as.numeric}..."`. Only include when actionable.
-
-```r
-# Good
-cli::cli_abort(
-  c(
-    "x" = "{.arg fpc} column {.field {fpc_var}} contains {sum(is.na(fpc_col))} NA value(s).",
-    "i" = "FPC must be fully observed for finite population correction.",
-    "v" = "Remove rows with missing FPC or set {.arg fpc = NULL} to omit the correction."
-  ),
-  class = "surveycore_error_fpc_na"
-)
-
-# Bad — no class, no context
-cli::cli_abort("FPC has NAs")
-```
-
-### `cli_warn()` structure
-Same structure and same `class=` requirement:
-
-```r
-cli::cli_warn(
-  c(
-    "!" = "What triggered the warning.",
-    "i" = "Why this matters.",
-    "i" = "What to do if this is unexpected."
-  ),
-  class = "surveycore_warning_{condition}"    # ALWAYS required
-)
-```
-
-### Error and warning classes
-`class=` is **required on every `cli_abort()` and `cli_warn()` call** — no exceptions.
-
-The canonical list of all classes is in `plans/error-messages.md`. When adding a new error or warning:
-1. Add a row to `plans/error-messages.md` first
-2. Use the class name from that table in the code
-3. Add a corresponding `expect_error(class = ...)` test
-
-Class naming convention:
-- Errors: `"surveycore_error_{snake_case_condition}"`
-- Warnings: `"surveycore_warning_{snake_case_condition}"`
-
-```r
-# Error class examples
-"surveycore_error_not_data_frame"
-"surveycore_error_weights_nonpositive"
-"surveycore_error_subset_degenerate"
-
-# Warning class examples
-"surveycore_warning_srs_no_weights"
-"surveycore_warning_single_stratum"
-"surveycore_warning_psu_multi_strata"
-```
+- Class naming: `surveycore_error_{snake_case_condition}` /
+  `surveycore_warning_{snake_case_condition}`.
+- The canonical class list is `plans/error-messages.md`. Adding a new error:
+  add the table row there first, use that class in code, add an
+  `expect_error(class = ...)` test.
+- Register: `"x"` declarative with the object as subject; `"i"` declarative
+  with the system as subject; `"v"` imperative. Never address the user
+  ("You must...").
 
 ### cli inline markup
-Use the appropriate markup type consistently:
 
-| What you're showing | Markup | Renders as |
-|---------------------|--------|------------|
+| Showing | Markup | Renders as |
+|---------|--------|------------|
 | Function argument | `{.arg weights}` | `weights` |
 | Column / variable name | `{.field {var}}` | `var` |
 | Function name | `{.fn as_survey}` | `as_survey()` |
@@ -297,19 +84,10 @@ Use the appropriate markup type consistently:
 | A value | `{.val "brr"}` | `"brr"` |
 | A class name | `{.cls survey_taylor}` | `<survey_taylor>` |
 
-### Message language register
-- **`"x"` bullets** — declarative, object as subject: `"Weight column {.field wt} is not numeric."`
-- **`"i"` bullets** — declarative, system as subject: `"Got class {.cls {class(wt_col)}}."`
-- **`"v"` bullets** — imperative: `"Use {.fn as.numeric} to convert."` or `"Set {.arg fpc = NULL} to skip FPC."`
-- Never `"You must..."` or `"You provided..."` — the user is never addressed directly
+## Function design
 
-For the full inline markup reference (50+ classes, pluralization, progress bars, theming), see the `cli` skill in `.claude/skills/cli/`.
+Return visibility:
 
----
-
-## 4. Function Design
-
-### Return value visibility
 | Function type | Return |
 |---------------|--------|
 | Setters: `set_var_label()`, `set_variable_labels()`, `update_design()` | `invisible(x)` |
@@ -318,160 +96,35 @@ For the full inline markup reference (50+ classes, pluralization, progress bars,
 | Print/summary: `S7::method(print, ...)` | `invisible(x)` |
 | Validators (internal): `.validate_weights()` etc. | `invisible(TRUE)` on success |
 
-```r
-# Setter — always invisible
-set_var_label.survey_base <- function(x, var, label) {
-  var_name <- rlang::as_name(rlang::enquo(var))
-  x@metadata@variable_labels[[var_name]] <- label
-  invisible(x)
-}
+Argument order precedence:
 
-# Getter — always visible
-extract_var_label.survey_base <- function(x, var) {
-  var_name <- rlang::as_name(rlang::enquo(var))
-  x@metadata@variable_labels[[var_name]]
-}
-```
-
-### Argument order
-**Required before optional. Object/data always first. NSE/tidy-select before scalar. `...` last.**
-
-Full precedence:
-1. `x` / `data` — the survey object or data frame (always mandatory, always first)
-2. Required NSE/tidy-select arguments (bare names the user must provide)
-3. Required scalar arguments (non-NSE arguments with no default)
-4. Optional NSE/tidy-select arguments (`ids = NULL`, `weights = NULL`, etc.)
-5. Optional scalar control arguments (`nest = FALSE`, `mse = TRUE`, `validate = TRUE`)
+1. `x` / `data` — always mandatory, always first
+2. Required NSE/tidy-select arguments
+3. Required scalar arguments
+4. Optional NSE/tidy-select arguments (`ids = NULL`, ...)
+5. Optional scalar control arguments (`nest = FALSE`, ...)
 6. `...`
-7. **Named-only control args** — optional args that callers MUST supply by
-   name go after `...`. R's argument-matching rule forces named supply for
-   any parameter after `...`, which is the tidyverse idiom for control
-   flags like `.id`, `.on_missing`, `group`, `names_to`, `values_to`.
-   Examples: `get_freqs(design, x, ..., group, names_to, values_to, variance)`;
-   `get_means(coll, y, ..., .id = ".survey", .on_missing = "error")`.
+7. Named-only control args after `...` (`.id`, `.on_missing`, `group`, ...)
 
-```r
-# as_survey_rep: data (1), weights (2, required), repweights (2, required),
-#                type (3, required scalar), then optional scalars
-as_survey_rep <- function(
-  data,
-  weights,
-  repweights,
-  type = c("JK1", "JK2", "JKn", "BRR", "Fay", "bootstrap", ...),
-  scale = NULL,
-  rscales = NULL,
-  fpc = NULL,
-  fpctype = c("fraction", "correction"),
-  mse = TRUE
-)
-
-# set_var_label: x (1), var (2, required NSE), label (3, required scalar)
-set_var_label <- function(x, var, label)
-```
-
-### Dispatch rule
-**One rule: who owns the generic?**
+Dispatch — one rule: who owns the generic?
 
 | Situation | Use |
 |-----------|-----|
-| Extending an existing generic (`print`, `summary`, `format`, `rename`, `filter`, `select`, etc.) | `S7::method(generic, class) <- function(...) { }` |
-| Creating a new generic owned by surveycore (`set_var_label`, `as_survey`, `extract_var_label`, `update_design`, etc.) | Plain function + `S7::S7_inherits()` for type validation |
+| Extending an existing generic (`print`, `summary`, `filter`, ...) | `S7::method(generic, class) <- function(...) { }` |
+| New generic owned by surveycore (`set_var_label`, `as_survey`, ...) | Plain function + `S7::S7_inherits()` type check |
 
-**Important:** S3 dispatch does NOT work for S7 objects. S7 uses namespaced class names
-(`"surveycore::survey_base"`). `UseMethod()` would look for a method named
-`set_var_label.surveycore::survey_base`, which is not a legal R function name.
-Use a plain function with explicit `S7::S7_inherits()` type checking instead.
+**S3 dispatch does NOT work for S7 objects.** S7 uses namespaced class names
+(`"surveycore::survey_base"`); `UseMethod()` would look for a method named
+`set_var_label.surveycore::survey_base`, which is not a legal R function
+name. Use a plain function with explicit `S7::S7_inherits()` type checking
+instead.
 
-```r
-# CORRECT — extending print (existing generic)
-S7::method(print, survey_taylor) <- function(x, n = 10, ...) { ... }
-
-# CORRECT — new surveycore-owned generic
-# Plain function; S7::S7_inherits() validates the type explicitly.
-set_var_label <- function(x, var, label) {
-  if (!S7::S7_inherits(x, survey_base)) {
-    cli::cli_abort(
-      c("x" = "{.arg x} must be a survey design object."),
-      class = "surveycore_error_not_survey_object"
-    )
-  }
-  # implementation
-}
-
-# WRONG — UseMethod() cannot find name.surveycore::survey_base methods
-set_var_label <- function(x, var, label) UseMethod("set_var_label")
-set_var_label.survey_base <- function(x, var, label) { ... }  # never dispatched
-
-# WRONG — S3 dispatch silently ignored for S7 objects when generic is S7-aware
-print.survey_taylor <- function(x, n = 10, ...) { ... }   # never dispatched
-summary.survey_taylor <- function(object, ...) { ... }    # never dispatched
-```
-
-### Internal helper placement
-| Helper used in... | Lives in... |
-|-------------------|-------------|
-| Exactly 1 source file | Defined at the top of that file, before its first call site |
-| 2 or more source files | `R/07-utils.R` |
-
-All internal helpers are **not exported** and prefixed with `.`:
-
-```r
-# In R/03-constructors.R — used only by as_survey()
-.check_probs_weights_consistency <- function(probs_var, weights_var, data, tol = 1e-6) {
-  ...
-}
-
-# In R/07-utils.R — used by constructors AND update_design()
-.get_design_vars_flat <- function(design) {
-  c(
-    design@variables$ids,
-    design@variables$weights,
-    design@variables$strata,
-    design@variables$fpc
-  )
-}
-```
-
-When a single-use inline helper grows a second call site, promote it to `07-utils.R` in the same PR that adds the second call.
+Internal helpers: not exported, `.`-prefixed. Defined at the top of the one
+file that uses them; promoted to `R/07-utils.R` in the same PR that adds a
+second call site.
 
 ---
-
-## 5. Tooling Configuration
-
-### `.lintr` (in package root)
-```yaml
-linters: linters_with_defaults(
-  line_length_linter(80),
-  pipe_consistency_linter("native"),
-  object_name_linter("snake_case"),
-  assignment_linter()
-)
-exclusions: list("data-raw")
-```
-
-### `.editorconfig` (in package root)
-```ini
-root = true
-
-[*.R]
-indent_style = space
-indent_size = 2
-end_of_line = lf
-charset = utf-8
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[*.{md,yaml,yml}]
-indent_size = 2
-```
-
-### `air` setup
-```r
-# Format the entire package
-air::format_package()
-
-# Format a single file (or use the RStudio/Positron addin)
-air::format_file("R/03-constructors.R")
-```
-
-Run `air::format_package()` before opening a PR. Do not commit `air`-reformatted files in the same commit as functional changes — reformat first, then make the change.
+Worked examples and rationale: `.claude/references/code-style-detail.md`.
+Read it when writing new code covered by these rules and the correct
+application is not obvious from the tables above. Tooling configs (`.lintr`,
+`.editorconfig`) are in the package root — read them there.

--- a/.claude/rules/engineering-preferences.md
+++ b/.claude/rules/engineering-preferences.md
@@ -1,85 +1,25 @@
 # Engineering Preferences
 
-**Version:** 1.0
-**Created:** February 2026
+**Version:** 1.1
 **Status:** Decided — applies to all surveyverse packages
 
-These are meta-principles that govern every implementation decision across
-all phases. When in doubt about an approach, use this list as the tiebreaker.
-They are listed in priority order.
+Meta-principles that govern every implementation decision, in priority
+order. Use as the tiebreaker when in doubt about an approach.
+
+1. **DRY — flag repetition aggressively.** Duplicated logic is a bug waiting
+   to happen. Extract shared helpers; consolidate repeated validation; do
+   not defer DRY violations to "later".
+2. **Well-tested — more tests is better.** Missing coverage is always a
+   problem; over-tested code is not. 98%+ line coverage is the floor.
+3. **Engineered enough — not under, not over.** Flag missing edge-case
+   handling AND premature abstraction. The current spec determines the right
+   level, not hypothetical future needs.
+4. **Handle more edge cases, not fewer.** All-NA inputs, zero-weight rows,
+   single-level groups, and empty domains appear in real survey data.
+5. **Explicit over clever.** Prefer the longer explicit way: class objects
+   in `S7_inherits()`, named error classes, documented assumptions.
 
 ---
-
-## 1. DRY — flag repetition aggressively
-
-Duplicated logic is a bug waiting to happen. If two functions do the same
-thing, they should share a helper. If two spec sections describe the same
-behavior, one should reference the other.
-
-- Repeated patterns in 2+ functions → extract a shared internal helper
-- Repeated validation logic → consolidate into a single validator
-- Repeated test setup → move to `helper-*.R`
-
-Do not defer DRY violations as "we can clean this up later." Surface them
-during spec review, not after the code is written.
-
-## 2. Well-tested — more tests is better
-
-Missing test coverage is always a problem. Over-tested code is not.
-
-- When unsure whether an edge case needs a test, write the test
-- Never suggest removing coverage to hit a deadline
-- 98%+ line coverage is the floor, not the target
-- Every error class gets a test; every edge case in the spec gets a test
-
-## 3. Engineered enough — not under, not over
-
-Flag both failure modes:
-
-**Under-engineered** (fragile, hacky):
-- Missing edge case handling
-- Contracts that don't specify behavior at the boundaries
-- Validation that only checks the happy path
-
-**Over-engineered** (premature abstraction, unnecessary complexity):
-- Abstraction layers that don't yet have two real call sites
-- Generalization for hypothetical future requirements not in the roadmap
-- Clever solutions when a straightforward one works fine
-
-The right amount of engineering is determined by what's in the current spec,
-not by what might be needed in a later phase.
-
-## 4. Handle more edge cases, not fewer
-
-When deciding whether to handle an edge case, err on the side of handling it.
-
-- All-NA inputs, zero-weight rows, single-level groups, empty domains — these
-  are not hypothetical; they appear in real survey data
-- "That probably won't happen" is not a reason to skip an edge case
-- Thoughtfulness > speed: a slower implementation that handles edge cases
-  correctly is always preferred
-
-## 5. Explicit over clever
-
-When there are two ways to do something — a clever short way and a longer
-explicit way — choose explicit.
-
-- `S7::inherits(x, ClassName)` not `inherits(x, "survey_taylor")`
-- Named error classes on every `cli_abort()`, not bare messages
-- Spell out behavior in the spec rather than relying on "the reader will infer"
-- Document assumptions rather than leaving them implicit
-
----
-
-## How to apply these during review
-
-When evaluating a spec, implementation, or PR:
-
-1. Read through with DRY as the first lens — find repetition before anything else
-2. Check every error condition and edge case in the spec against the test plan
-3. For each design decision, ask: is this the right level of abstraction for
-   what's actually needed now?
-4. For each boundary condition mentioned in the spec, ask: is the behavior
-   fully specified, or is it left implicit?
-5. For any "shortcut" in the implementation plan, ask: does this skip something
-   that will need to be added back later anyway?
+Sub-points and the review checklist:
+`.claude/references/code-style-detail.md` §Engineering preferences — read it
+when reviewing a spec, plan, or PR against these principles.

--- a/.claude/rules/github-strategy.md
+++ b/.claude/rules/github-strategy.md
@@ -1,9 +1,7 @@
 # surveycore GitHub Strategy
 
-**Version:** 2.0
+**Version:** 2.1
 **Status:** Decided — do not re-litigate without updating this document
-
----
 
 ## Quick Reference
 
@@ -18,11 +16,9 @@
 | CI | R-CMD-check required on `main` and `develop`; all PRs |
 | Release workflow | Use `/merge-main` |
 
----
+## Workflow tiers
 
-## Workflow Tiers
-
-Choose the tier based on change size. When in doubt, go one tier higher.
+Choose by change size. When in doubt, go one tier higher.
 
 | Tier | When to use | Workflow |
 |------|-------------|----------|
@@ -31,31 +27,7 @@ Choose the tier based on change size. When in doubt, go one tier higher.
 | **3 — Direct** | Clear bug fixes localized to 1–2 functions, test additions, roxygen changes | branch → `/r-implement` → `/commit-and-pr` |
 | **0 — Commit** | Typos, comments, `.gitignore`, README tweaks | direct commit to `develop` (no branch) |
 
-### Worked Examples
-
-Use these to calibrate. When in doubt about a tier, find the closest example below.
-
-**Tier 1 — New exported function `get_contrasts()`**
-New API surface, behavior not fully specified, multiple design choices (contrast coding, CI method, interaction with domain estimation). → spec → implementation plan → `/r-implement`
-
-**Tier 1 — Adding `method =` to `get_quantiles()` for interpolation strategy**
-Multiple valid approaches exist in the survey literature (linear, Type 7, Woodruff). Correct behavior is genuinely undecided until it's specified. Feels like "one argument" but it's actually a behavioral commitment. → Tier 1, not Tier 2.
-
-**Tier 2 — Adding `variance =` argument to `get_means()`**
-Behavior is obvious: let the caller pick Taylor vs. replicate variance when both are available. But the approach isn't: how does it interact with `survey_twophase`, what's the default, what error fires when the requested method isn't supported? Write an implementation plan to settle these before touching code. → implementation plan → `/r-implement`
-
-**Tier 2 → Tier 3 boundary — Adding `na.rm =` to `get_freqs()`**
-One new argument, behavior obvious (`TRUE` drops NA cells). But wiring it through all design paths and deciding whether NA gets its own frequency row or disappears entirely isn't obvious. → Tier 2 (plan first), not Tier 3.
-
-**Tier 3 — `get_means()` returns wrong SE when `nest = TRUE` is omitted on NHANES data**
-Clear bug, localized to the variance calculation in `R/variance-taylor.R`. The correct behavior is known (match `survey::svymean`). Fix the logic, add a regression test. → branch → `/r-implement` → `/commit-and-pr`
-
-**Tier 0 — Fix a typo in the `@param fpc` description**
-One-word change in roxygen comment. No branch, no PR needed. → direct commit to `develop`
-
----
-
-## Branching Model
+## Branching model
 
 ```
 main          ← always stable; every commit is a tagged release
@@ -68,8 +40,6 @@ hotfix/*      ← urgent fixes only; branch from main
 
 Feature branches always cut from `develop` and merge back to `develop`.
 Never open a feature PR directly against `main`.
-
-Hotfixes branch from `main`, merge to `main`, then also merge to `develop` to stay in sync.
 
 ### What gets a branch vs. direct push
 
@@ -84,9 +54,7 @@ Hotfixes branch from `main`, merge to `main`, then also merge to `develop` to st
 | `.Rbuildignore` / `.gitignore` | No |
 | Version bump + NEWS.md (release prep) | Direct commit to `develop` |
 
----
-
-## Branch Naming
+## Branch naming
 
 Format: `{type}/{short-description}`
 
@@ -100,13 +68,9 @@ Format: `{type}/{short-description}`
 | `chore/` | `develop` | Maintenance (CI config, build tooling) |
 | `refactor/` | `develop` | Internal restructuring, no behavioral change |
 
----
+## Commit format (Conventional Commits)
 
-## Commit Format (Conventional Commits)
-
-```
-{type}({scope}): {short description}
-```
+`{type}({scope}): {short description}`
 
 | Type | Use for |
 |------|---------|
@@ -117,48 +81,20 @@ Format: `{type}/{short-description}`
 | `chore` | CI config, DESCRIPTION, NAMESPACE, build tooling |
 | `refactor` | Internal restructuring with no behavioral change |
 
-Scopes: `classes`, `constructors`, `metadata`, `validators`, `variance`, `analysis`, `utils`
+Scopes: `classes`, `constructors`, `metadata`, `validators`, `variance`,
+`analysis`, `utils`
 
-Squash merge commit = one conventional commit summarizing the whole PR:
-```
-feat(analysis): implement survey_glm() with Wald confidence intervals (#42)
-```
+## Merge strategy and versioning
 
----
-
-## Merge Strategy
-
-**Feature → develop:** Squash and merge. `develop` history = one squash commit per
-feature PR.
-
-**Develop → main (releases only):** Regular merge. `main` history = one merge commit per
-release, plus the feature-level squash commits from develop. This avoids the SHA
-divergence that squash merges create between the two branches.
-
-GitHub settings: allow both squash merges and merge commits; auto-delete head branches.
+- **Feature → develop:** squash merge; the squash commit is one conventional
+  commit summarizing the PR, e.g.
+  `feat(analysis): implement survey_glm() with Wald confidence intervals (#42)`.
+- **Develop → main (releases only):** regular merge — avoids SHA divergence
+  between the branches.
+- Versions: `X.Y.Z.9000` during development on `develop`; `X.Y.Z` on `main`
+  after release. Releases via `/merge-main`.
 
 ---
-
-## Versioning
-
-| Context | Format | Example |
-|---------|--------|---------|
-| Active development on `develop` | `X.Y.Z.9000` | `0.3.0.9000` |
-| Released on `main` | `X.Y.Z` | `0.3.0` |
-
-| Tag | Milestone |
-|-----|-----------|
-| `v0.1.0` | Phase 0 complete — core infrastructure |
-| `v0.2.0` | Phase 0.5 complete — surveytidy |
-| `v0.3.0` | Phase 1 complete — estimation functions |
-| `v0.4.0` | Phase 2 complete — regression |
-| `v1.0.0` | Stable API, CRAN submission |
-
----
-
-## Release Preparation
-
-Use `/merge-main`. It handles: NEWS.md update → version bump → `devtools::check()` →
-PR `develop` → `main` → tag → post-release `.9000` bump.
-
-PR template for feature PRs lives in `.github/PULL_REQUEST_TEMPLATE.md`.
+Worked tier examples (which tier for which change) and release detail:
+`.claude/references/github-strategy-detail.md`. Read it when choosing a tier
+for a borderline change or preparing a release.

--- a/.claude/rules/r-package-conventions.md
+++ b/.claude/rules/r-package-conventions.md
@@ -1,12 +1,10 @@
 # R Package Conventions (Surveyverse)
 
-**Version:** 1.0
-**Created:** February 2025
+**Version:** 1.1
 **Status:** Decided — applies to all surveyverse packages
 
-This document covers conventions that apply to **all surveyverse R packages**. For package-specific examples and details, see the local conventions file in each package (e.g., `surveycore-conventions.md`).
-
----
+For package-specific details, see the local conventions file in each package
+(e.g., `surveycore-conventions.md`).
 
 ## Quick Reference
 
@@ -24,274 +22,44 @@ This document covers conventions that apply to **all surveyverse R packages**. F
 | `@examples` | All runnable — no `\dontrun{}` |
 | Version pinning | Minimum versions only (e.g., `cli (>= 3.6.0)`) |
 
----
+## Documentation (roxygen2)
 
-## 1. Documentation (Roxygen2)
+- `@param` verbosity is proportional to how non-obvious the argument is.
+  Always fuller treatment for: arguments that interact with other arguments,
+  non-obvious `NULL` behavior, multiple interpretations, or value
+  constraints.
+- `@return` required on every export; terse is fine for obvious cases.
+- `@examples` must run during `R CMD check`. No `\dontrun{}` except genuine
+  external resources; slow examples get a smaller inline dataset instead.
+- Group exports with `@family` (see package-specific conventions for the
+  family names).
+- Internal helpers: obvious one-liners get no roxygen; complex helpers get
+  `@keywords internal` + `@noRd`.
 
-### `@param` verbosity: variable by complexity
+## NAMESPACE and exports
 
-Write `@param` descriptions proportional to how non-obvious the argument is.
+- Call all external package functions with `::`. No `@importFrom` anywhere.
+- Export user-facing functions and S7 class objects (`#' @export`).
+  `.`-prefixed helpers and internal generics stay unexported.
+- No re-exports (no pipe, no tidyselect helpers).
+- `NAMESPACE` is a build artifact — never edit by hand; every entry comes
+  from a roxygen2 tag.
 
-**Terse** (one sentence) for simple, self-evident arguments:
-```r
-#' @param data A data.frame.
-#' @param label A character string.
-#' @param ... Additional arguments (currently unused).
-```
+## Package check hygiene
 
-**Fuller** for arguments with non-obvious behavior, constraints, or interactions:
-```r
-#' @param weights <[`tidy-select`][tidyselect::language]> Column(s) for
-#'   survey weights. If multiple columns, they are combined. Cannot contain
-#'   `NA`. Default `NULL` (uniform weights).
-```
-
-Arguments that **always** get fuller treatment:
-- Any argument that interacts with another argument (mutual exclusion, dependency)
-- Arguments where `NULL` has non-obvious behavior
-- Arguments that accept multiple interpretations
-- Arguments with valid value constraints
-
-### `@return` required on all exports
-
-Every exported function must have `@return`. Write terse returns for obvious cases:
-
-```r
-#' @return A survey design object.
-#' @return A data.frame of results.
-#' @return A character string, or `NULL` if not set.
-#' @return The modified object, invisibly.
-```
-
-### `@examples`: all runnable
-
-Every example must run successfully during `R CMD check`. Do not use `\dontrun{}` except for examples that genuinely require external resources (e.g., live database connection).
-
-If an example is slow, use a smaller inline dataset instead of `\dontrun{}`:
-
-```r
-#' @examples
-#' # Small inline example (preferred)
-#' df <- data.frame(id = 1:10, y = rnorm(10))
-#' result <- my_function(df)
-```
-
-### `@family` grouping
-
-Organize exported functions into families using `@family`:
-
-```r
-#' @family constructors
-as_survey <- function(...) { ... }
-
-#' @family selectors
-select <- function(...) { ... }
-```
-
-See package-specific conventions for exact family definitions.
-
-### Internal function documentation
-
-| Helper complexity | Documentation |
-|-------------------|---------------|
-| Obvious one-liner | No roxygen at all |
-| Complex enough to need explanation | `@keywords internal` + `@noRd` |
-
-```r
-# One-liner — no roxygen needed
-.get_col <- function(x, col) x[[col]]
-
-# Complex helper — document but suppress .Rd
-#' Validate survey design structure
-#'
-#' @param x A survey design object.
-#' @return Invisibly, `TRUE` on success (errors otherwise).
-#' @keywords internal
-#' @noRd
-.validate_design <- function(x) { ... }
-```
+- All PRs pass `R CMD check` with 0 errors, 0 warnings, ≤2 notes.
+- Pre-approved notes (do not block): `no visible binding for global
+  variable 'X'` (tidy-select bare names) and `checking CRAN incoming
+  feasibility`. Any other note blocks the PR.
+- Do NOT suppress NSE notes with `utils::globalVariables()` or `.data$var`
+  rewrites — accept the pre-approved note and move on.
+- Local: `devtools::check()` (no `--as-cran`). CI uses
+  `--as-cran --no-manual`. Switch locally only in Phase 3 (Polish).
+- Run `devtools::document()` before committing roxygen changes; commit
+  NAMESPACE and `man/` in sync with source.
+- `Imports` entries carry minimum-version lower bounds; never exact pins.
 
 ---
-
-## 2. NAMESPACE & Exports
-
-### Export policy: user-facing functions + S7 classes
-
-Both **user-facing functions** and **S7 class objects** are exported. S7 classes are part of the documented API.
-
-```r
-# User-facing function — export with @export
-#' @export
-my_function <- function(...) { ... }
-
-# S7 class — export with @export
-#' @export
-my_class <- S7::new_class("my_class", ...)
-```
-
-Unexported:
-- All `.`-prefixed helpers (`.internal_fn()`)
-- Internal S7 generics not part of public API
-
-### `::` everywhere — no `@importFrom`
-
-Call all external package functions with `::`. No `@importFrom` in any source file.
-
-```r
-# Correct
-result <- rlang::enquo(x)
-cli::cli_abort("message", class = "error_class")
-
-# Wrong
-result <- enquo(x)           # requires @importFrom rlang enquo
-cli_abort("message")         # requires @importFrom cli cli_abort
-```
-
-**Why:** Maximally explicit about function origins. Namespace lookup overhead is negligible for R code (not the bottleneck).
-
-### No re-exports
-
-Do not re-export the pipe, tidyselect helpers, or other utility functions. Users who need them have tidyverse/rlang loaded.
-
-```r
-# Wrong — don't do this
-#' @importFrom magrittr %>%
-#' @export
-`%>%` <- magrittr::`%>%`
-```
-
-### `NAMESPACE` is never manually edited
-
-`NAMESPACE` carries the `# Generated by roxygen2: do not edit by hand` header. It is a build artifact.
-
-**Every export, import, and S3 method registration must come from a roxygen2 tag.**
-
-If roxygen2 can't express something, find a roxygen2 solution — do not work around it with manual edits.
-
----
-
-## 3. Package Check Hygiene
-
-### `R CMD check` targets
-
-**All PRs must pass with:**
-- 0 errors
-- 0 warnings
-- ≤2 notes (see approved notes below)
-
-### Pre-approved notes
-
-These two notes are acceptable and do not block merging:
-
-| Note | Why it appears | Why it's accepted |
-|------|----------------|-------------------|
-| `no visible binding for global variable 'X'` | Tidy-select bare names | Universal in tidy packages |
-| `checking CRAN incoming feasibility` | Package not on CRAN yet | Informational only |
-
-Any other note is treated as a bug and blocks the PR.
-
-### NSE "no visible binding" notes: accept, don't suppress
-
-Do not suppress NSE notes with `utils::globalVariables()`. Do not change examples to use `.data$var` syntax.
-
-The note is pre-approved. Accept it and move on.
-
-### `devtools::check()` cadence
-
-**Local development:**
-```r
-devtools::check()  # Fast feedback, no --as-cran flag
-```
-
-**CI (GitHub Actions):**
-```yaml
-args: 'c("--as-cran", "--no-manual")'
-```
-
-Switch to `--as-cran` locally only in Phase 3 (Polish) when CRAN submission is imminent.
-
-### `devtools::document()` cadence
-
-Run `devtools::document()` **before committing** any file that changes roxygen2 content:
-
-```r
-# Before committing changes to R/03-functions.R
-devtools::document()
-git add NAMESPACE man/my_function.Rd
-git commit -m "docs(functions): update roxygen"
-```
-
-NAMESPACE and `man/` files are committed to version control and must be in sync with source.
-
-### Minimum version pinning
-
-Specify **lower bounds** for all `Imports` dependencies. Set the bound to the oldest version where the required feature exists.
-
-```r
-Imports:
-    cli (>= 3.6.0),        # cli_abort() with class= argument
-    rlang (>= 1.1.0),      # rlang::check_required()
-    S7 (>= 0.1.0)          # S7 class system
-Suggests:
-    testthat (>= 3.0.0)
-```
-
-Do NOT use exact version pins (`==`). They are rejected by CRAN and too fragile.
-
----
-
-## 4. Package Metadata
-
-### DESCRIPTION fields
-
-All surveyverse packages include:
-
-```
-Package: surveyXXX
-Title: [Descriptive title matching the package role]
-Version: 0.0.0.9000
-Authors@R: person("Jacob", "Dennen", role = c("aut", "cre"), email = "...")
-Description: [1-2 sentence description of what the package does]
-License: GPL-3
-Encoding: UTF-8
-Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.x.x
-```
-
-### Package documentation (surveypkg-package.R)
-
-Every surveyverse package has a documented entry point:
-
-```r
-#' surveytidy: dplyr/tidyr verbs for survey objects
-#'
-#' @description
-#' surveytidy provides dplyr and tidyr verbs that work with survey design objects
-#' from surveycore, allowing...
-#'
-#' @section Key Functions:
-#' - [filter()] — domain-aware filtering
-#' - [select()] — column selection
-#' - [mutate()] — add/modify variables
-#'
-#' @section Documentation:
-#' For ecosystem architecture, see [the ecosystem guide](../survey-standards/ECOSYSTEM.md).
-#'
-#' @keywords internal
-#' "_PACKAGE"
-```
-
----
-
-## Summary for All Packages
-
-**Do this in every surveyverse package:**
-1. Use `::` for all external package calls (no `@importFrom`)
-2. Never manually edit `NAMESPACE` — use roxygen2
-3. Run `devtools::document()` before committing code with roxygen changes
-4. Run `devtools::check()` before opening PRs
-5. Write `@return` on every exported function
-6. Keep `@examples` runnable (no `\dontrun{}`)
-7. Export user-facing functions and S7 classes only
-
-**For package-specific details**, see the local conventions file in each package.
+Worked examples (roxygen blocks, DESCRIPTION template, package-doc
+template, import style): `.claude/references/r-package-detail.md`. Read it
+when writing docs or package metadata and the format is not obvious.

--- a/.claude/rules/surveycore-conventions.md
+++ b/.claude/rules/surveycore-conventions.md
@@ -1,14 +1,8 @@
 # surveycore R Package Conventions
 
-**Version:** 1.0
-**Created:** February 2025
-**Status:** Detailed examples and guidance specific to surveycore
-
-This document extends the **generic R package conventions** (in `../survey-standards/.claude/rules/r-package-conventions.md`) with surveycore-specific examples and detailed guidance.
-
-**Read the generic conventions first, then this document for context.**
-
----
+**Version:** 1.1
+**Status:** Decided — extends `r-package-conventions.md` with
+surveycore-specific rules. Read that file first.
 
 ## Quick Reference (surveycore-specific)
 
@@ -21,202 +15,38 @@ This document extends the **generic R package conventions** (in `../survey-stand
 | Setters return | Always `invisible(x)` | `set_var_label()`, `set_variable_labels()` |
 | Getters return | Always visible | `extract_var_label()`, `extract_val_labels()` |
 
----
+## Naming
 
-## 1. Documentation Examples for surveycore
-
-### `@param` for survey-specific arguments
-
-Survey-specific arguments like `nest`, `fpc`, and `type` need fuller documentation because they have non-obvious behavior:
-
-```r
-#' Create a Taylor series survey design
-#'
-#' @param data A data.frame containing survey data.
-#'
-#' @param ids <[`tidy-select`][tidyselect::language]> Primary sampling unit IDs.
-#'   Use bare column names (e.g., `psu`, or `c(psu1, psu2)` for multiple levels).
-#'   Default `NULL` (assumed SRS within strata).
-#'
-#' @param weights <[`tidy-select`][tidyselect::language]> Column(s) for survey
-#'   weights. If multiple columns specified, they are multiplied together.
-#'   Cannot contain `NA` or non-positive values. Default `NULL` (uniform weights).
-#'
-#' @param strata <[`tidy-select`][tidyselect::language]> Stratum IDs.
-#'   Use bare column names (e.g., `strata`). Default `NULL` (no stratification).
-#'
-#' @param fpc <[`tidy-select`][tidyselect::language]> Finite population
-#'   correction column. Supply either:
-#'   - An integer column with population size (e.g., stratum population)
-#'   - A numeric column (0-1) with sampling fraction
-#'   Cannot contain `NA`. If `NULL`, design assumes sampling from infinite
-#'   population. Default `NULL`.
-#'
-#' @param nest Logical. If `TRUE`, PSU IDs are treated as nested within strata —
-#'   i.e., the same PSU ID value in two different strata refers to two distinct
-#'   PSUs. Set `nest = TRUE` when PSU IDs are not globally unique (e.g., NHANES
-#'   uses IDs 1–30 within each stratum). Requires `strata` to be specified.
-#'   Default `FALSE`.
-#'
-#' @examples
-#' # Stratified cluster design with FPC (NHANES)
-#' d <- as_survey(
-#'   nhanes_2017,
-#'   ids = sdmvpsu,
-#'   weights = wtmec2yr,
-#'   strata = sdmvstra,
-#'   fpc = NULL,  # Assume infinite population
-#'   nest = TRUE  # PSU IDs are nested within strata
-#' )
-#'
-#' # Simple random sample with custom weights
-#' df <- data.frame(id = 1:100, y = rnorm(100), w = runif(100, 0.5, 2))
-#' d <- as_survey(df, weights = w)
-#'
-#' # Two-level cluster design (schools -> students)
-#' d <- as_survey(
-#'   schools_data,
-#'   ids = c(school_id, student_id),
-#'   weights = sampling_weight
-#' )
-```
-
-### `@return` for survey objects
-
-```r
-#' @return A `survey_taylor` object — a complete survey design specification
-#'   ready for variance estimation via Taylor series linearization.
-#'   See [survey_taylor] for structure.
-```
-
-### `@seealso`: constructors only
-
-Only the three constructors (`as_survey()`, `as_survey_rep()`, `as_survey_twophase()`) have `@seealso`:
-
-```r
-#' @seealso
-#'   [as_survey_rep()] for replicate-weight designs,
-#'   [as_survey_twophase()] for two-phase designs,
-#'   [update_design()] to modify an existing design,
-#'   [extract_var_label()] to retrieve variable labels
-```
-
-Getters, setters, validators, and other functions do **not** carry `@seealso`.
-
----
-
-## 2. Naming Conventions (surveycore-specific)
-
-### Class names
-- **S7 classes**: `survey_base`, `survey_taylor`, `survey_replicate`, `survey_twophase`, `survey_metadata`
-- **Result classes**: Built on tibble: `survey_mean`, `survey_total`, `survey_freq`, `survey_quantiles`, etc.
-
-### Function families
-Use these `@family` groups:
-
-```r
-#' @family constructors
-as_survey <- function(...) { ... }
-
-#' @family metadata
-extract_var_label <- function(...) { ... }
-
-#' @family validators
-.validate_weights <- function(...) { ... }
-
-#' @family conversion
-as_svydesign <- function(...) { ... }
-```
-
-### Naming patterns
+- S7 classes: `survey_base`, `survey_taylor`, `survey_replicate`,
+  `survey_twophase`, `survey_metadata`. Result classes built on tibble:
+  `survey_mean`, `survey_total`, `survey_freq`, `survey_quantiles`, etc.
 
 | Category | Pattern | Example |
 |----------|---------|---------|
 | Analysis functions | `get_*` | `get_means()`, `get_totals()`, `get_freqs()` |
 | Metadata extractors | `extract_*` | `extract_var_label()`, `extract_val_labels()` |
-| Metadata setters (single) | `set_*` | `set_var_label()`, `set_variable_labels()` |
+| Metadata setters (single) | `set_*` | `set_var_label()` |
 | Metadata setters (plural) | `set_*` (also accept vector) | `set_variable_labels()` |
 | Internal helpers | prefix `.` | `.validate_weights()`, `.resolve_tidy_select()` |
 
----
+`@family` groups: `constructors`, `metadata`, `validators`, `conversion`.
 
-## 3. Return Value Visibility (surveycore-specific)
+## Export policy
 
-Return visibility rules are defined in `code-style.md §4` (the return value visibility table).
-The surveycore-specific additions in the Quick Reference above (setters → `invisible(x)`,
-getters → visible) are the same rules applied to surveycore's naming conventions.
+- Export: constructors, `extract_*()`, `set_*()`, `get_*()`, S7 classes,
+  and utilities (`update_design()`, `as_svydesign()`, `from_svydesign()`).
+- Do NOT export: `.`-prefixed validators and helpers, internal S7 generics,
+  vendored variance code.
 
----
+## `haven` handling
 
-## 4. Export Policy (surveycore-specific)
-
-### What to export
-- All constructors: `as_survey()`, `as_survey_rep()`, `as_survey_twophase()`
-- All getter functions: `extract_*()` family
-- All setter functions: `set_*()` family (return invisibly)
-- All analysis functions: `get_*()` family
-- All S7 classes: `survey_base`, `survey_taylor`, etc.
-- Utility functions: `update_design()`, `as_svydesign()`, `from_svydesign()`, etc.
-
-### What NOT to export
-- All validator functions: `.validate_weights()`, `.validate_ids()`, etc. (internal only)
-- Internal helpers: `.resolve_tidy_select()`, `.check_*()`, etc.
-- Internal S7 generics: not part of public API
-- Internal variance code: vendored from survey package
-
-```r
-# Export with @export
-#' @export
-extract_var_label <- function(x, var) { ... }
-
-# Do NOT export (no @export tag)
-.validate_weights <- function(weights) { ... }
-```
+`haven` is in `Suggests`, not `Imports`. At runtime extract label attributes
+with base R — `attr(col, "label", exact = TRUE)` and
+`attr(col, "labels", exact = TRUE)` — never `haven::var_label()`. `haven` is
+only used in `data-raw/` scripts to read `.xpt` files.
 
 ---
-
-## 5. `haven` Package Handling
-
-`haven` is in `Suggests`, not `Imports`. Use base R to extract label attributes:
-
-```r
-# Correct — no haven needed at runtime
-var_label <- attr(col, "label", exact = TRUE)
-val_labels <- attr(col, "labels", exact = TRUE)
-
-# Wrong — requires haven
-var_label <- haven::var_label(col)
-val_labels <- haven::val_labels(col)
-```
-
-`haven` is only needed in `data-raw/` scripts (to read `.xpt` files). At runtime, surveycore extracts label attributes directly.
-
----
-
-## 6. Documentation Checklist for surveycore
-
-Before committing any roxygen2 changes:
-
-- [ ] `devtools::document()` has been run
-- [ ] `NAMESPACE` file has been updated
-- [ ] All exported functions have `@return`
-- [ ] All `@examples` are runnable
-- [ ] Internal helpers have `@keywords internal` + `@noRd` if needed
-- [ ] `@family` tags are correct
-- [ ] Constructor functions have `@seealso`
-- [ ] No `@importFrom` tags anywhere
-- [ ] All external calls use `::`
-- [ ] `R CMD check` passes with 0 errors, 0 warnings, ≤2 notes
-
----
-
-## Reference
-
-**Generic conventions (all packages):**
-`../survey-standards/.claude/rules/r-package-conventions.md`
-
-**surveycore architecture:**
-`CLAUDE.md` in this directory
-
-**Planning & specifications:**
-`plans/` directory in this repository
+Worked documentation examples (survey-specific `@param` blocks, `@seealso`
+format, the pre-commit documentation checklist):
+`.claude/references/r-package-detail.md` §surveycore documentation examples.
+Read it when documenting constructors or survey-specific arguments.

--- a/.claude/rules/testing-standards.md
+++ b/.claude/rules/testing-standards.md
@@ -1,14 +1,10 @@
 # Surveyverse Testing Standards
 
-**Version:** 1.1
-**Created:** February 2025
+**Version:** 1.2
 **Status:** Decided — applies to all surveyverse packages
 
-For package-specific testing conventions (file mappings, invariant checkers,
-data generators, numerical tolerances), see the `testing-{package}.md` rule
-in each package's `.claude/rules/` directory.
-
----
+For package-specific testing conventions, see the `testing-{package}.md`
+rule in each package's `.claude/rules/` directory.
 
 ## Quick Reference
 
@@ -30,186 +26,38 @@ in each package's `.claude/rules/` directory.
 | Edge case data | Inline in tests; never add edge case parameters to a data generator |
 | `skip_if_not_installed` | Block-level, inside affected `test_that()` blocks |
 
----
+## Structure
 
-## 1. Test Structure
+- Naming: `R/my-thing.R` → `tests/testthat/test-my-thing.R`.
+- Each `test_that()` description is a present-tense assertion naming ONE
+  observable behavior ("rejects data frames with 0 rows"), never a vague
+  category ("validates input").
+- Flat `test_that()` only — no `describe()` nesting.
 
-### Test file granularity
-Every source file in `R/` has a corresponding test file in `tests/testthat/`.
-One-to-one is the floor — large source files may split into multiple test files
-if it improves clarity.
+## Coverage
 
-Naming convention: `R/my-thing.R` → `tests/testthat/test-my-thing.R`
+- 98%+ line coverage is the target; CI blocks PRs below 95%.
+- `# nocov` requires an explanatory comment on the preceding line.
+  Acceptable: defensive branches unreachable via the public API,
+  platform-specific paths, documented non-goals. Unacceptable: covering for
+  missing tests, or errors that "feel hard to trigger" — find the trigger.
+- Every exported function has tests in all three categories: happy path,
+  every typed error class, and edge cases (boundaries, NAs, empty inputs,
+  single-row inputs).
+- Test private helpers indirectly via the public API; direct tests only when
+  coverage cannot be achieved indirectly AND the behavior is material.
 
-### One behavior per `test_that()` block
-Each `test_that()` description names one observable behavior. The description
-is a present-tense assertion, not a vague category.
+## Assertions
 
-```r
-# Correct — specific, present-tense assertion
-test_that("my_fn() rejects data frames with 0 rows", { ... })
-test_that("my_fn() assigns a default weight when none is given", { ... })
-
-# Wrong — vague category
-test_that("my_fn() validates input", { ... })
-test_that("weights work", { ... })
-```
-
-### No `describe()` blocks
-Use flat `test_that()` throughout. Do not nest `test_that()` inside
-`describe()`. The test file name already provides the grouping context.
-
-```r
-# Correct
-test_that("my_class stores the x property", { ... })
-test_that("my_class stores the y property", { ... })
-
-# Wrong
-describe("my_class properties", {
-  test_that("stores x", { ... })
-})
-```
-
----
-
-## 2. What to Test
-
-### Coverage target
-**98%+ line coverage** is the project target. PRs that drop coverage below
-**95%** are blocked by CI.
-
-Lines excluded from coverage are marked with `# nocov` and require an
-explanatory comment on the preceding line:
-
-```r
-# nocov start
-# Defensive: this branch is unreachable via any public function.
-# Tested implicitly by all constructor tests.
-if (is.null(x@data)) {
-  cli::cli_abort("Internal error: @data is NULL", class = "mypkg_error_internal")
-}
-# nocov end
-```
-
-Acceptable `# nocov` categories:
-- Defensive branches for conditions impossible via public API
-- Platform-specific paths (e.g., Windows-only file encoding)
-- Explicit non-goals documented in the package specification
-
-Unacceptable `# nocov` use:
-- Covering for missing tests — add the test instead
-- Error messages that "feel hard to trigger" — find the trigger and test it
-
-### Three mandatory test categories
-Every exported function must have tests in all three categories:
-
-**1. Happy path** — normal inputs, expected behavior:
-```r
-test_that("my_fn() creates the right class for standard input", {
-  result <- my_fn(data, weights = w)
-  expect_true(inherits(result, "my_class"))
-})
-```
-
-**2. Error paths** — every typed error class from the package's error table:
-```r
-test_that("my_fn() rejects non-data-frame input", {
-  expect_snapshot(error = TRUE, my_fn(list(x = 1)))
-  expect_error(my_fn(list(x = 1)), class = "mypkg_error_not_data_frame")
-})
-```
-
-**3. Edge cases** — boundary conditions, NAs, empty inputs, single-row inputs:
-```r
-test_that("my_fn() warns for single-row data", {
-  single_row <- data.frame(x = 1, w = 1)
-  expect_warning(
-    my_fn(single_row, weights = w),
-    class = "mypkg_warning_single_row"
-  )
-})
-```
-
-### Testing private functions
-Default to **indirect testing** — exercise private helpers via the public
-functions that call them. Only write direct tests for a private function when
-coverage cannot be achieved indirectly AND the behavior is material.
-
-```r
-# Indirect (preferred) — .validate_weights() tested via the public API
-test_that("my_fn() rejects non-positive weights", {
-  df <- data.frame(x = 1:5, w = c(1, 0, 1, 1, 1))
-  expect_error(my_fn(df, weights = w), class = "mypkg_error_weights_nonpositive")
-})
-
-# Direct (only when necessary)
-test_that(".validate_fpc() rejects NA in fpc column [direct]", {
-  df <- data.frame(y = 1, fpc = NA_real_)
-  expect_error(.validate_fpc(df, "fpc"), class = "mypkg_error_fpc_na")
-})
-```
-
----
-
-## 3. Assertions
-
-### Constructor error testing: dual pattern
-User-facing input validation errors require two assertions:
-
-```r
-test_that("my_fn() rejects weight column with zero values", {
-  df <- data.frame(x = 1:5, w = c(1, 0, 1, 1, 1))
-
-  # 1. Typed class check — verifies the right error class is thrown
-  expect_error(
-    my_fn(df, weights = w),
-    class = "mypkg_error_weights_nonpositive"
-  )
-
-  # 2. Snapshot — verifies the CLI message text has not changed
-  expect_snapshot(error = TRUE, my_fn(df, weights = w))
-})
-```
-
-Structural/invariant errors (e.g., S7 class validators) use `class=` only —
-no snapshot — because those messages are not CLI-formatted. See each package's
-testing rule for which validation layers use which pattern.
-
-### Snapshots: blocking and updating
-Snapshot failures block PRs. They are not auto-updated — they represent
-deliberate decisions about error message text.
-
-To update snapshots after an intentional message change:
-```r
-testthat::snapshot_review()  # review and approve each diff individually
-```
-
-Never run `testthat::snapshot_accept()` blindly. Each snapshot change must
-be reviewed.
-
-Snapshots live in `tests/testthat/_snaps/`. They are committed to version
-control.
-
-### Warning capture pattern
-Use `expect_warning()` wrapping the call. Capture the return value separately
-if you need to assert on it:
-
-```r
-test_that("my_fn() warns and still returns an object for single-row data", {
-  d1 <- data.frame(x = 1, w = 1)
-
-  expect_warning(
-    result <- my_fn(d1, weights = w),
-    class = "mypkg_warning_single_row"
-  )
-
-  expect_true(inherits(result, "my_class"))
-})
-```
-
-Do **not** use `withCallingHandlers()` or `tryCatch()` in tests.
-
-### `expect_identical()` vs `expect_equal()`
+- User-facing constructor errors: dual pattern —
+  `expect_error(class = ...)` PLUS `expect_snapshot(error = TRUE, ...)`.
+- Structural/invariant errors (S7 class validators): `class=` only, no
+  snapshot.
+- Snapshot failures block PRs. Update only via `testthat::snapshot_review()`
+  with each diff reviewed; never blind `snapshot_accept()`. Snapshots live
+  in `tests/testthat/_snaps/` and are committed.
+- Warnings: `expect_warning(result <- fn(...), class = ...)`; never
+  `withCallingHandlers()` or `tryCatch()` in tests.
 
 | Use `expect_identical()` for... | Use `expect_equal()` for... |
 |---------------------------------|-----------------------------|
@@ -218,69 +66,19 @@ Do **not** use `withCallingHandlers()` or `tryCatch()` in tests.
 | Exact string/integer property values | Any calculated numeric result |
 | List structure (keys present/absent) | Weights, proportions, estimates |
 
+## Test data
+
+- Each package defines a synthetic generator in `tests/testthat/helper-*.R`:
+  accepts `seed =`, returns a plain data structure, produces realistic
+  variation (unequal sizes, imbalanced groups). Use it for all unit tests.
+- Real datasets ONLY for numerical validation against a reference
+  implementation, in a dedicated test file.
+- Edge cases needing specific atypical values are constructed inline in the
+  test — never added as generator parameters.
+- `skip_if_not_installed()` goes inside the `test_that()` block that needs
+  it, never at file level.
+
 ---
-
-## 4. Test Data
-
-### Package-specific data generators
-Each package defines a synthetic data generator in `tests/testthat/helper-*.R`
-for creating realistic test inputs. Use it for all unit tests that need a
-domain object. Do not use real datasets in tests that don't need their specific
-properties.
-
-The generator must:
-- Accept a `seed =` argument for reproducibility
-- Return a plain data structure (not yet wrapped in a domain object)
-- Produce realistic variation (unequal sizes, varying values, imbalanced groups)
-
-```r
-# Usage pattern — create data, then construct the domain object
-df <- make_pkg_data(n = 200, seed = 123)
-obj <- my_constructor(df, ...)
-```
-
-### Real datasets
-Use real datasets only for numerical validation tests — comparing package
-outputs against a reference implementation. These belong in a dedicated test
-file. Never use a real dataset just for convenience when synthetic data works.
-
-### Edge case data: inline
-Edge cases requiring specific, atypical values are constructed inline in the
-test. Do not add special-case parameters to the data generator.
-
-```r
-# Correct — inline, self-documenting
-test_that("my_fn() rejects data with 0 rows", {
-  empty_df <- data.frame(x = numeric(0), w = numeric(0))
-  expect_error(my_fn(empty_df, weights = w), class = "mypkg_error_empty_data")
-})
-
-# Wrong
-df <- make_pkg_data(edge = "empty", seed = 1)  # don't do this
-```
-
-The rule: if the edge case needs exact specific values to trigger, write those
-values directly. Data generators produce typical inputs; edge cases are
-by definition atypical.
-
-### `skip_if_not_installed()` — block-level, not file-level
-Place `skip_if_not_installed()` inside the `test_that()` block that actually
-requires the external package. Do not put a file-level skip at the top of a
-test file — other blocks in the same file may not need it.
-
-```r
-# Correct — block-level
-test_that("estimates match reference package [numerical]", {
-  skip_if_not_installed("ref_pkg")
-  # ...
-})
-
-test_that("constructor creates correct class", {
-  # runs even without ref_pkg installed
-  d <- my_fn(data, weights = w)
-  expect_true(inherits(d, "my_class"))
-})
-
-# Wrong — skips the entire file
-skip_if_not_installed("ref_pkg")  # at top of file
-```
+Worked examples (category examples, dual pattern, warning capture, nocov,
+skip placement): `.claude/references/testing-detail.md`. Read it when
+writing a new test file and the pattern is not obvious from these rules.

--- a/.claude/rules/testing-surveycore.md
+++ b/.claude/rules/testing-surveycore.md
@@ -1,13 +1,8 @@
 # surveycore Testing: Package-Specific Standards
 
-**Version:** 1.0
-**Created:** February 2025
-**Status:** Decided — do not re-litigate without updating this document
-
-Extends [testing-standards.md](testing-standards.md). Read that document
-first; this file covers only what is specific to surveycore.
-
----
+**Version:** 1.1
+**Status:** Decided — extends `testing-standards.md`; read that first. This
+file covers only what is specific to surveycore.
 
 ## Quick Reference
 
@@ -20,12 +15,11 @@ first; this file covers only what is specific to surveycore.
 | Synthetic data | `make_survey_data(seed = N)` in `helper-test-data.R` |
 | Real data | `nhanes_2017`, `acs_pums_wy` for numerical validation only |
 
----
-
 ## File mapping
 
-Core source-to-test mapping. Analysis files (`R/analysis-*.R`) follow the same
-one-to-one convention — `R/analysis-means.R` → `tests/testthat/test-analysis-means.R`, etc.
+Core source-to-test mapping. Analysis files (`R/analysis-*.R`) follow the
+same one-to-one convention — `R/analysis-means.R` →
+`tests/testthat/test-analysis-means.R`, etc.
 
 | Source file | Test file |
 |-------------|-----------|
@@ -41,25 +35,15 @@ one-to-one convention — `R/analysis-means.R` → `tests/testthat/test-analysis
 | `R/utils.R` | `tests/testthat/test-utils.R` |
 | `R/update-design.R` | `tests/testthat/test-update-design.R` |
 
----
-
 ## `test_invariants()` — required in every constructor test
 
 Every `test_that()` block that creates a survey object via `as_survey()`,
-`as_survey_rep()`, or `as_survey_twophase()` must call `test_invariants(design)`
+`as_survey_rep()`, or `as_survey_twophase()` calls `test_invariants(design)`
 as its **first** assertion.
 
-```r
-test_that("as_survey() creates a survey_taylor object for stratified design", {
-  d <- as_survey(nhanes_2017, ids = sdmvpsu, weights = wtmec2yr, strata = sdmvstra)
-  test_invariants(d)   # always first
-  expect_true(S7::inherits(d, survey_taylor))
-  expect_equal(d@variables$strata, "sdmvstra")
-})
-```
-
-`test_invariants()` is defined in `tests/testthat/helper-test-data.R` — read it
-there for the current source. It asserts all five formal Phase 0 invariants:
+`test_invariants()` is defined in `tests/testthat/helper-test-data.R` — read
+it there for the current source. It asserts all five formal Phase 0
+invariants:
 
 1. `@data` is a data.frame
 2. `@data` has >= 1 row
@@ -67,45 +51,17 @@ there for the current source. It asserts all five formal Phase 0 invariants:
 4. Named design columns exist in `@data`
 5. `@metadata` is a `survey_metadata` object
 
----
-
 ## S7 error testing layers
 
-surveycore has two validation layers with different testing requirements:
-
-**Layer 1 — S7 class validators** (`R/00-s7-classes.R`): structural invariants
-enforced by the S7 system. Messages are not CLI-formatted. Test with `class=`
-only — no snapshot.
-
-```r
-test_that("survey_taylor validator rejects missing weights column in @variables", {
-  expect_error(
-    survey_taylor(data = data.frame(x = 1), variables = list(weights = NULL)),
-    class = "surveycore_error_weights_column_absent"
-  )
-})
-```
-
-**Layer 3 — Constructor input validation** (`R/03-constructors.R`): user-facing
-errors from `cli::cli_abort()`. Test with the dual pattern.
-
-```r
-test_that("as_survey() rejects weight column with zero values", {
-  df <- data.frame(x = 1:5, w = c(1, 0, 1, 1, 1))
-
-  expect_error(
-    as_survey(df, weights = w),
-    class = "surveycore_error_weights_nonpositive"
-  )
-  expect_snapshot(error = TRUE, as_survey(df, weights = w))
-})
-```
-
----
+- **Layer 1 — S7 class validators** (`R/00-s7-classes.R`): structural
+  invariants; messages not CLI-formatted. Test with `class=` only.
+- **Layer 3 — Constructor input validation** (`R/03-constructors.R`):
+  user-facing `cli::cli_abort()` errors. Test with the dual pattern
+  (`class=` + snapshot).
 
 ## `make_survey_data()` — synthetic data generator
 
-Defined in `tests/testthat/helper-test-data.R`. Use for all unit tests that
+Defined in `tests/testthat/helper-test-data.R`; use for all unit tests that
 need a survey design object.
 
 ```r
@@ -124,12 +80,6 @@ Data properties: PSU sizes vary (Poisson), weights vary (lognormal), strata
 sizes imbalanced. Returns a plain `data.frame` with columns `psu`, `strata`,
 `fpc`, `wt`, `y1`, `y2`, `y3`; replicate designs add `repwt_1`...`repwt_R`.
 
-```r
-df <- make_survey_data(n = 200, n_psu = 20, n_strata = 4, seed = 123)
-d  <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc)
-test_invariants(d)
-```
-
 **Data policy:**
 
 | Test type | Data source |
@@ -137,8 +87,6 @@ test_invariants(d)
 | Unit tests (class, properties, error conditions) | `make_survey_data()` |
 | Numerical accuracy vs. `survey` package | `nhanes_2017`, `acs_pums_wy` |
 | Label/metadata roundtrip tests | `make_survey_data(with_labels = TRUE)` |
-
----
 
 ## Variance estimation numerical tolerances
 
@@ -151,58 +99,13 @@ the `survey` package.
 | SE / variance | `1e-8` |
 | CI bounds | `1e-6` |
 
-```r
-test_that("Taylor variance matches survey::svymean for NHANES [numerical]", {
-  skip_if_not_installed("survey")
-  d_sc <- as_survey(nhanes_2017, ids = sdmvpsu, weights = wtmec2yr, strata = sdmvstra)
-  d_sv <- survey::svydesign(
-    ids = ~sdmvpsu, weights = ~wtmec2yr, strata = ~sdmvstra,
-    data = nhanes_2017, nest = TRUE
-  )
-  sc_est <- get_means(d_sc, bpxsy1)
-  sv_est <- survey::svymean(~bpxsy1, d_sv, na.rm = TRUE)
-  expect_equal(sc_est$mean, coef(sv_est)[["bpxsy1"]], tolerance = 1e-10)
-  expect_equal(sc_est$se,   SE(sv_est)[["bpxsy1"]],   tolerance = 1e-8)
-})
-```
-
 Packages requiring `skip_if_not_installed()`:
 - `survey` — numerical comparison tests in `test-variance-estimation.R`
 - `srvyr` — conversion roundtrip tests in `test-conversion.R`
 - `haven` — metadata roundtrip tests (prefer `with_labels = TRUE` when possible)
 
 ---
-
-## Test file section templates
-
-### `test-constructors.R`
-```
-# 1. Happy paths (one block per design type per constructor)
-# 2. Error paths (one block per error-messages.md row)
-# 3. Edge cases (1-row data, NAs in outcomes, single stratum, etc.)
-# 4. Tidy-select interface (bare names, c(), everything(), etc.)
-# 5. Roundtrip (as_survey() |> update_design() returns valid object)
-```
-
-### `test-validators.R`
-```
-# 1. Happy paths (validators return invisible(TRUE) on valid input)
-# 2. Error paths (Layer 2 validators; each error class covered)
-# 3. Direct tests for branches unreachable via constructors
-```
-
-### `test-variance-estimation.R`
-```
-# Block 1: Taylor series — nhanes_2017
-#   skip_if_not_installed("survey")
-#   One test per estimand: mean, total, proportion
-#   Tolerance: 1e-10 (point), 1e-8 (SE)
-
-# Block 2: BRR replicates — acs_pums_wy
-#   skip_if_not_installed("survey")
-#   One test per estimand
-
-# Block 3: Two-phase — synthetic (make_survey_data(design = "twophase"))
-#   skip_if_not_installed("survey")
-#   One test per estimand
-```
+Worked examples (invariants-first test, layer examples, numerical
+comparison, test-file section templates):
+`.claude/references/testing-detail.md`. Read it when writing a new
+surveycore test file.

--- a/.claude/scripts/run-gates.sh
+++ b/.claude/scripts/run-gates.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Run all surveycore validation gates in order, log full output per gate,
+# and print one compact summary. Built for the tester agent: ONE background
+# call, one summary read, zero polling turns.
+#
+# Usage:
+#   bash .claude/scripts/run-gates.sh <log-dir> [--skip-pkgdown] [--baseline]
+#
+#   --skip-pkgdown  Skip gate 6. Allowed ONLY under the skip conditions in
+#                   r-package-profile.md (never when NAMESPACE changes).
+#   --baseline      Run only gates 2 (tests) and 7 (coverage). For the
+#                   orchestrator's Before-column capture on a clean tree.
+#
+# Exit code 0 = all gates PASS. The summary names the log file of any FAIL.
+# Gate definitions live in r-package-profile.md §Validation commands.
+
+set -u
+LOGDIR="${1:?usage: run-gates.sh <log-dir> [--skip-pkgdown] [--baseline]}"
+shift || true
+SKIP_PKGDOWN=0
+BASELINE=0
+for a in "$@"; do
+  case "$a" in
+    --skip-pkgdown) SKIP_PKGDOWN=1 ;;
+    --baseline)     BASELINE=1 ;;
+  esac
+done
+mkdir -p "$LOGDIR"
+
+SUMMARY=""
+OVERALL=0
+
+row() { SUMMARY="${SUMMARY}${1}\n"; }
+
+fail_gate() { # name logfile note
+  row "| $1 | FAIL | $3 — read $2 |"
+  OVERALL=1
+}
+
+pass_gate() { # name note
+  row "| $1 | PASS | $2 |"
+}
+
+# --- Gate 2: devtools::test() ------------------------------------------
+gate_test() {
+  local log="$LOGDIR/gate-2-test.log"
+  NOT_CRAN=true Rscript -e 'devtools::test()' > "$log" 2>&1
+  local line
+  line=$(grep -E '\[ FAIL [0-9]+' "$log" | tail -1)
+  local nfail
+  nfail=$(printf '%s' "$line" | sed -E 's/.*FAIL ([0-9]+).*/\1/')
+  if [ -n "$line" ] && [ "$nfail" = "0" ]; then
+    pass_gate "devtools::test()" "$line"
+  else
+    fail_gate "devtools::test()" "$log" "${line:-no result line found}"
+  fi
+}
+
+# --- Gate 7: coverage ----------------------------------------------------
+gate_covr() {
+  local log="$LOGDIR/gate-7-covr.log"
+  Rscript -e 'cat(sprintf("COVERAGE_PCT=%.2f\n", covr::percent_coverage(covr::package_coverage())))' > "$log" 2>&1
+  local pct
+  pct=$(grep -oE 'COVERAGE_PCT=[0-9.]+' "$log" | tail -1 | cut -d= -f2)
+  if [ -z "$pct" ]; then
+    fail_gate "covr" "$log" "coverage did not run"
+  elif awk "BEGIN{exit !($pct >= 95)}"; then
+    pass_gate "covr" "${pct}%"
+  else
+    fail_gate "covr" "$log" "coverage ${pct}% is below the 95% floor"
+  fi
+}
+
+if [ "$BASELINE" = "1" ]; then
+  gate_test
+  gate_covr
+else
+  # --- Gate 1: document() + drift check --------------------------------
+  log="$LOGDIR/gate-1-document.log"
+  Rscript -e 'devtools::document()' > "$log" 2>&1
+  if git diff --quiet -- NAMESPACE man/ 2>>"$log"; then
+    pass_gate "devtools::document()" "no NAMESPACE/man drift"
+  else
+    git diff --stat -- NAMESPACE man/ >> "$log" 2>&1
+    fail_gate "devtools::document()" "$log" "NAMESPACE/man drift (builder forgot document())"
+  fi
+
+  gate_test
+
+  # --- Gate 3: run_examples() ------------------------------------------
+  log="$LOGDIR/gate-3-examples.log"
+  if NOT_CRAN=true Rscript -e 'devtools::run_examples()' > "$log" 2>&1; then
+    pass_gate "run_examples()" "all examples ran"
+  else
+    fail_gate "run_examples()" "$log" "example error"
+  fi
+
+  # --- Gate 4: R CMD build ----------------------------------------------
+  log="$LOGDIR/gate-4-build.log"
+  rm -f ./*.tar.gz
+  if R CMD build . > "$log" 2>&1 && ls ./*.tar.gz >/dev/null 2>&1; then
+    TARBALL=$(ls -t ./*.tar.gz | head -1)
+    pass_gate "R CMD build" "$TARBALL"
+  else
+    TARBALL=""
+    fail_gate "R CMD build" "$log" "no tarball produced"
+  fi
+
+  # --- Gate 5: R CMD check --as-cran ------------------------------------
+  log="$LOGDIR/gate-5-check.log"
+  if [ -n "$TARBALL" ]; then
+    R CMD check --as-cran "$TARBALL" > "$log" 2>&1
+    CHECKDIR=$(ls -dt ./*.Rcheck 2>/dev/null | head -1)
+    [ -n "$CHECKDIR" ] && cp "$CHECKDIR/00check.log" "$LOGDIR/gate-5-00check.log" 2>/dev/null
+    status_line=$(grep -E '^Status:' "$log" | tail -1)
+    if printf '%s' "$status_line" | grep -qE 'ERROR|WARNING'; then
+      fail_gate "R CMD check --as-cran" "$LOGDIR/gate-5-00check.log" "$status_line"
+    else
+      pass_gate "R CMD check --as-cran" "${status_line:-Status line missing — verify log} (NOTEs need review per pre-approved list)"
+    fi
+    [ -n "$CHECKDIR" ] && rm -rf "$CHECKDIR"
+    rm -f "$TARBALL"
+  else
+    fail_gate "R CMD check --as-cran" "$LOGDIR/gate-4-build.log" "skipped — build failed"
+  fi
+
+  # --- Gate 6: pkgdown ----------------------------------------------------
+  if [ "$SKIP_PKGDOWN" = "1" ]; then
+    row "| pkgdown | SKIPPED | scope (log skip reason in audit.md) |"
+  else
+    log="$LOGDIR/gate-6-pkgdown.log"
+    if Rscript -e 'pkgdown::build_site(preview = FALSE)' > "$log" 2>&1; then
+      pass_gate "pkgdown" "site built"
+    else
+      fail_gate "pkgdown" "$log" "site build error"
+    fi
+  fi
+
+  gate_covr
+fi
+
+echo ""
+echo "## Gate summary"
+echo "| Gate | Result | Notes |"
+echo "|---|---|---|"
+printf "%b" "$SUMMARY"
+echo ""
+echo "Tree: $(git rev-parse 'HEAD^{tree}')"
+echo "Logs: $LOGDIR"
+[ "$OVERALL" = "0" ] && echo "ALL GATES PASS" || echo "GATE FAILURE(S) — read only the named log(s)"
+exit $OVERALL

--- a/.claude/scripts/usage-profile.py
+++ b/.claude/scripts/usage-profile.py
@@ -1,0 +1,64 @@
+# Usage profiler for Claude Code session transcripts.
+# Sums token usage (input, cache create, cache read, output) per model,
+# for the main session and every subagent, and prints per-turn averages.
+#
+# Usage:
+#   python .claude/scripts/usage-profile.py <projects-dir> <session-id>
+# Example:
+#   python .claude/scripts/usage-profile.py \
+#     "C:/Users/jdennen/.claude/projects/C--Users-jdennen-surveycore" \
+#     1f696918-6044-42e3-a12a-6832e45296dc
+#
+# Find the session id: newest .jsonl file in the projects dir for the
+# directory you ran the session in.
+
+import json, sys, glob, os, collections
+
+def scan(path):
+    stats = collections.defaultdict(collections.Counter)
+    turns = collections.Counter()
+    for line in open(path, encoding='utf-8', errors='replace'):
+        try:
+            rec = json.loads(line)
+        except Exception:
+            continue
+        msg = rec.get('message') or {}
+        usage = msg.get('usage')
+        if not usage:
+            continue
+        model = msg.get('model', '?')
+        c = stats[model]
+        c['input'] += usage.get('input_tokens', 0)
+        c['cache_create'] += usage.get('cache_creation_input_tokens', 0)
+        c['cache_read'] += usage.get('cache_read_input_tokens', 0)
+        c['output'] += usage.get('output_tokens', 0)
+        turns[model] += 1
+    return stats, turns
+
+def show(label, stats, turns):
+    print(f"\n== {label} ==")
+    for model, c in stats.items():
+        if model == '<synthetic>':
+            continue
+        n = turns[model]
+        avg_ctx = (c['cache_read'] + c['cache_create'] + c['input']) // max(n, 1)
+        print(f"  {model}  turns={n}  avg_context/turn={avg_ctx:,}")
+        for k in ('input', 'cache_create', 'cache_read', 'output'):
+            print(f"    {k:12} {c[k]:>12,}")
+
+base, sess = sys.argv[1], sys.argv[2]
+s, t = scan(os.path.join(base, sess + '.jsonl'))
+show('MAIN ' + sess, s, t)
+
+total = collections.defaultdict(collections.Counter)
+tturns = collections.Counter()
+for m, c in s.items():
+    total[m].update(c); tturns[m] += t[m]
+
+for f in sorted(glob.glob(os.path.join(base, sess, 'subagents', 'agent-*.jsonl'))):
+    s2, t2 = scan(f)
+    show('SUB ' + os.path.basename(f), s2, t2)
+    for m, c in s2.items():
+        total[m].update(c); tturns[m] += t2[m]
+
+show('TOTAL', total, tturns)

--- a/.claude/skills/pipeline-implement/SKILL.md
+++ b/.claude/skills/pipeline-implement/SKILL.md
@@ -73,6 +73,8 @@ Dispatch 5 Explore subagents in parallel:
 4. **Spec Coverage lens** — does the union of all PR acceptance criteria cover every item in `spec.md §Function contracts`? Are any contract items unscheduled?
 5. **File Completeness lens** — does the union of all write surfaces include every file implied by the spec (source, tests, NAMESPACE, man/, NEWS.md)? Are any files missing?
 
+Pass `model: "sonnet"` on every lens dispatch — lens agents scan a document against one named criterion and do not need the session model.
+
 Aggregate into `plan-review.md` with verdict PASS / FAIL / NEEDS-DECISION per
 `.claude/skills/pipeline-shared/references/signals.md §Review verdicts`.
 

--- a/.claude/skills/pipeline-implement/SKILL.md
+++ b/.claude/skills/pipeline-implement/SKILL.md
@@ -63,6 +63,21 @@ Dispatch `planner`:
 > - Acceptance criteria are observable outcomes (test names, metric values), not implementation hints
 > - Write surfaces of concurrent PRs do not overlap
 
+## Review-loop budget (applies to Stages 2 and 3)
+
+Measured cost of unbounded loops: one feature ran 7 review passes (~$300
+API-equivalent). These rules cap the loop:
+
+1. **Maximum 3 passes** per review stage. If findings remain open after
+   pass 3, HOLD — ask the user instead of running pass 4.
+2. **Pass 1 is the only full-panel pass** (all lenses, whole document).
+3. **Passes 2+ are delta passes**: at most 2 Explore agents. They review
+   ONLY the sections changed by the resolver (the resolver lists changed
+   section headings at the top of its response) plus the specific findings
+   they verify. They do not re-read the whole document.
+4. **Early exit**: a pass whose findings require no change to the artifact
+   ends the loop — the verdict is PASS.
+
 ## Stage 2 — Plan review
 
 Dispatch 5 Explore subagents in parallel:
@@ -83,7 +98,7 @@ Aggregate into `plan-review.md` with verdict PASS / FAIL / NEEDS-DECISION per
 BIG mode (>8 findings) or SMALL mode (≤8), per
 `.claude/skills/spec-workflow/references/stage-4-resolve.md`.
 
-Loop until plan-review.md verdict=PASS.
+Loop until plan-review.md verdict=PASS. Respect the Review-loop budget above.
 
 ## Stage 4 — Freeze
 

--- a/.claude/skills/pipeline-shared/references/artifact-schemas.md
+++ b/.claude/skills/pipeline-shared/references/artifact-schemas.md
@@ -121,7 +121,6 @@ No test cases. No tolerances. No references to test-spec.md.
 - [ ] devtools::test() all pass
 - [ ] devtools::run_examples() all pass
 - [ ] R CMD check --as-cran (0 err, 0 warn, notes reviewed)
-- [ ] pkgcheck PASS
 - [ ] pkgdown::build_site() clean
 - [ ] covr::package_coverage() ≥ 95% (target 98%)
 - [ ] CRAN cookbook scan clean (see r-package-profile.md)
@@ -196,10 +195,11 @@ Builder does NOT write about test results here. Builder's local unit tests run; 
 |---|---|---|
 | devtools::test() | PASS/FAIL | {summary} |
 | R CMD check --as-cran | PASS/FAIL | {errors, warnings, notes} |
-| pkgcheck | PASS/FAIL | {standards violated} |
 | pkgdown | PASS/FAIL | {errored pages} |
 | covr | {%} | {drop vs baseline} |
 | CRAN cookbook scan | PASS/FAIL | {violations} |
+
+Tree: {git tree hash at gate time — `git rev-parse 'HEAD^{tree}'`}
 
 ## BLOCKs (if any)
 (See signals.md BLOCK schema)

--- a/.claude/skills/pipeline-shared/references/r-package-profile.md
+++ b/.claude/skills/pipeline-shared/references/r-package-profile.md
@@ -15,6 +15,16 @@ R-specific commands, gates, and CRAN-compliance rules. The tester agent runs the
 | 7 | `Rscript -e "pkgdown::build_site(preview = FALSE)"` | site builds, no errored pages | BLOCK (unless PR surface is tests-only) |
 | 8 | `Rscript -e "covr::package_coverage()"` | ≥ 95% (target 98%) | BLOCK if drop below 95%; HOLD if 95–98% and dropped vs baseline |
 
+## Output discipline (all gates)
+
+Redirect every gate's full output to `{workspace-run-dir}/logs/gate-{N}.log`.
+Bring into context ONLY:
+- `tail -25` of the log, and
+- `grep -E "FAIL|ERROR|WARNING|NOTE"` of the log.
+
+Record each log path in `audit.md` §Profile gates. Read a full log only when
+diagnosing that gate's failure.
+
 ### pkgdown skip condition
 
 pkgdown build is slow (2–5 min). Tester MAY skip gate 7 when the PR's write surface does not touch:

--- a/.claude/skills/pipeline-shared/references/r-package-profile.md
+++ b/.claude/skills/pipeline-shared/references/r-package-profile.md
@@ -11,9 +11,8 @@ R-specific commands, gates, and CRAN-compliance rules. The tester agent runs the
 | 3 | `Rscript -e "devtools::run_examples()"` | all `@examples` run clean | BLOCK (examples use unloaded Imports or broken syntax) |
 | 4 | `R CMD build . 2>&1` | tarball produced | BLOCK (build failure) |
 | 5 | `R CMD check --as-cran <tarball> 2>&1` | 0 ERRORs, 0 WARNINGs; NOTEs reviewed | BLOCK on ERROR/WARNING |
-| 6 | `Rscript -e "pkgcheck::pkgcheck()"` | rOpenSci standards pass | BLOCK |
-| 7 | `Rscript -e "pkgdown::build_site(preview = FALSE)"` | site builds, no errored pages | BLOCK (unless PR surface is tests-only) |
-| 8 | `Rscript -e "covr::package_coverage()"` | ≥ 95% (target 98%) | BLOCK if drop below 95%; HOLD if 95–98% and dropped vs baseline |
+| 6 | `Rscript -e "pkgdown::build_site(preview = FALSE)"` | site builds, no errored pages | BLOCK (unless PR surface is tests-only) |
+| 7 | `Rscript -e "covr::package_coverage()"` | ≥ 95% (target 98%) | BLOCK if drop below 95%; HOLD if 95–98% and dropped vs baseline |
 
 ## Output discipline (all gates)
 
@@ -27,7 +26,7 @@ diagnosing that gate's failure.
 
 ### pkgdown skip condition
 
-pkgdown build is slow (2–5 min). Tester MAY skip gate 7 when the PR's write surface does not touch:
+pkgdown build is slow (2–5 min). Tester MAY skip gate 6 when the PR's write surface does not touch:
 - `R/` (any source file)
 - `vignettes/`
 - `README.Rmd`, `README.md`

--- a/.claude/skills/pipeline-shared/references/r-package-profile.md
+++ b/.claude/skills/pipeline-shared/references/r-package-profile.md
@@ -14,6 +14,15 @@ R-specific commands, gates, and CRAN-compliance rules. The tester agent runs the
 | 6 | `Rscript -e "pkgdown::build_site(preview = FALSE)"` | site builds, no errored pages | BLOCK (unless PR surface is tests-only) |
 | 7 | `Rscript -e "covr::package_coverage()"` | ≥ 95% (target 98%) | BLOCK if drop below 95%; HOLD if 95–98% and dropped vs baseline |
 
+### Canonical runner
+
+Run the whole table with ONE background command:
+`bash .claude/scripts/run-gates.sh <log-dir> [--skip-pkgdown]`. It logs
+each gate to `<log-dir>`, prints one summary table plus a `Tree:` hash,
+and exits 0 only when every gate passes. `--baseline` mode (gates 2 and 7
+only) captures Before-column numbers on a clean tree. Never run the gates
+one command at a time.
+
 ## Output discipline (all gates)
 
 Redirect every gate's full output to `{workspace-run-dir}/logs/gate-{N}.log`.

--- a/.claude/skills/pipeline-shared/references/signals.md
+++ b/.claude/skills/pipeline-shared/references/signals.md
@@ -45,7 +45,6 @@ Write to `decisions.md` AND return to leader:
 - A numerical test failed outside tolerance
 - A named error class test failed (wrong class thrown, or no error thrown)
 - `R CMD check --as-cran` has ERROR or WARNING
-- `pkgcheck` FAIL
 - `pkgdown::build_site()` errored
 - Coverage dropped below 95%
 

--- a/.claude/skills/pipeline-ship/SKILL.md
+++ b/.claude/skills/pipeline-ship/SKILL.md
@@ -103,7 +103,7 @@ For each PR in the batch, dispatch `builder` agent with `isolation: "worktree"`:
 > Write surface: {exact files from plan}
 > Tasks: {tasks from plan}
 > Acceptance criteria: {from plan}
-> Read: .claude/agents/builder.md, .claude/rules/, r-package-profile.md
+> Read: .claude/agents/builder.md, r-package-profile.md (rules auto-load — do not re-read .claude/rules/)
 > DO NOT read test-spec.md. DO NOT read any other PR's implementation.md.
 
 Each builder returns `implementation.md` with the PR's write surface changes merged back via the worktree protocol.
@@ -144,7 +144,7 @@ For each PR with audit verdict=PASS, dispatch `reviewer`:
 
 > PR: {number} — {slug}
 > All artifacts: spec.md, test-spec.md, implementation.md, audit.md, comprehension.md (if present)
-> Read: .claude/agents/reviewer.md, ALL references from pipeline-shared
+> Read: .claude/agents/reviewer.md, plus signals.md, artifact-schemas.md, and r-package-profile.md from pipeline-shared/references
 
 Reviewer returns `review.md` with verdict PASS / BLOCK / STOP.
 

--- a/.claude/skills/pipeline-ship/SKILL.md
+++ b/.claude/skills/pipeline-ship/SKILL.md
@@ -133,7 +133,13 @@ Each tester returns `audit.md` with verdict PASS or BLOCK.
 If an audit returns BLOCK:
 
 1. Increment BLOCK counter for that PR
-2. If counter < 3: re-dispatch builder for that PR with the BLOCK body (NOT the full audit.md, NOT test-spec.md) per signals.md
+2. If counter < 3: send the BLOCK body (NOT the full audit.md, NOT
+   test-spec.md, per signals.md) to the SAME builder agent via SendMessage —
+   it keeps its context and warm cache. The message MUST state: "Your
+   worktree was merged back and removed. Work in the main checkout at
+   {path}; run `git status` there before editing." Dispatch a fresh builder
+   only if the original agent is no longer available (e.g., session
+   restart), passing the BLOCK body in the dispatch prompt.
 3. If counter = 3: emit HOLD classification `repeated-block`; pause the pipeline for user decision (limit defined in signals.md §BLOCK)
 
 ### 2d. Dispatch reviewer (sequential per PR, after its audit passes)

--- a/.claude/skills/pipeline-ship/SKILL.md
+++ b/.claude/skills/pipeline-ship/SKILL.md
@@ -164,6 +164,13 @@ Tell the user: "Reviewer returned for PR {N} ({slug}) — verdict: {PASS/BLOCK/S
 
 ### 2e.5. Pre-PR gate
 
+Skip check first: read `Tree:` from this PR's `audit.md` and compare to
+`git rev-parse 'HEAD^{tree}'` on the feature branch. If they match, the
+tester already ran these gates on this exact tree — skip the rerun and
+proceed to the shipper (log "pre-PR gate: SKIPPED — tree unchanged since
+audit"). If they differ (or `audit.md` has no `Tree:` line), run the gate
+as below.
+
 Before dispatching the shipper, run on the feature branch:
 
 ```bash

--- a/.claude/skills/pipeline-simplified/SKILL.md
+++ b/.claude/skills/pipeline-simplified/SKILL.md
@@ -104,7 +104,7 @@ Dispatch `tester` agent:
 > Read: .claude/agents/tester.md, r-package-profile.md
 > Validate that:
 > 1. Each acceptance criterion from request.md holds
-> 2. All profile gates pass (devtools::test, run_examples, R CMD check --as-cran, pkgcheck, pkgdown if in scope, covr)
+> 2. All profile gates pass (devtools::test, run_examples, R CMD check --as-cran, pkgdown if in scope, covr)
 > 3. CRAN cookbook scan is clean on the modified files
 > 4. No regression in tests that were passing before the PR
 > Write audit.md with verdict PASS or BLOCK.

--- a/.claude/skills/pipeline-simplified/SKILL.md
+++ b/.claude/skills/pipeline-simplified/SKILL.md
@@ -78,6 +78,12 @@ Dispatch `planner` with simplified prompt:
 > - Expected validation outcome (which tests should still pass, which new assertion)
 > Do NOT write spec.md, test-spec.md, or implementation-plan.md. Do NOT run comprehension protocol.
 
+**In the same turn as the planner dispatch**, start the baseline capture in
+the background (the tree is still clean — builder has not run):
+`bash .claude/scripts/run-gates.sh {workspace-run-dir}/logs-baseline --baseline`
+with `run_in_background: true`. Its summary is the tester's Before column.
+Do not wait for it here; collect the result before dispatching the tester.
+
 On return, verify `request.md` has all four sections. Append `PLANNED` to `status.md`.
 
 ## Step 2 — Pipelines complete (builder + tester)
@@ -90,7 +96,7 @@ Dispatch `builder` agent WITHOUT worktree isolation (small change; overhead not 
 > Request: {path to request.md}
 > Write surface: {files from request.md}
 > Acceptance criteria: {from request.md}
-> Read: .claude/agents/builder.md, .claude/rules/, r-package-profile.md (§Builder compliance rules only)
+> Read: .claude/agents/builder.md, r-package-profile.md (§Builder compliance rules only). Rules auto-load — do not re-read .claude/rules/.
 > Exception: you MAY read test code in tests/testthat/ in case you need to update a test alongside the code. Pipeline isolation is relaxed for simplified workflow.
 
 Builder implements, updates docs if needed, writes `implementation.md`.
@@ -101,6 +107,7 @@ Dispatch `tester` agent:
 
 > Simplified workflow.
 > Request: {path to request.md with acceptance criteria}
+> Baseline results: {summary from the background baseline capture}
 > Read: .claude/agents/tester.md, r-package-profile.md
 > Validate that:
 > 1. Each acceptance criterion from request.md holds

--- a/.claude/skills/pipeline-spec/SKILL.md
+++ b/.claude/skills/pipeline-spec/SKILL.md
@@ -174,7 +174,9 @@ protocol. Self-assess applicability using the Trigger Condition in that file.
 
 If applicable, dispatch 5–6 Explore subagents in parallel (one per lens),
 collecting results into `methods-review.md` in the run directory. Include
-Lens 6 (Literature Cross-Check) if `comprehension.md` exists.
+Lens 6 (Literature Cross-Check) if `comprehension.md` exists. Pass
+`model: "sonnet"` on every lens dispatch — lens agents scan a document
+against one named criterion and do not need the session model.
 
 Aggregate findings into a verdict — PASS / FAIL / NEEDS-DECISION — per
 `.claude/skills/pipeline-shared/references/signals.md §Review verdicts`.
@@ -198,7 +200,9 @@ Loop until `methods-review.md` verdict = PASS.
 
 Read `.claude/skills/spec-workflow/references/stage-3-review.md` for the full protocol.
 
-Dispatch 6 Explore subagents in parallel (one per lens). Aggregate into
+Dispatch 6 Explore subagents in parallel (one per lens). Pass
+`model: "sonnet"` on every lens dispatch — lens agents scan a document
+against one named criterion and do not need the session model. Aggregate into
 `spec-review.md` in the run directory. Verdict rules: signals.md §Review
 verdicts.
 

--- a/.claude/skills/pipeline-spec/SKILL.md
+++ b/.claude/skills/pipeline-spec/SKILL.md
@@ -167,6 +167,21 @@ Dispatch `planner`:
 On return, verify both artifacts exist and contain all required sections
 (mechanical check — not a quality review). Append `DRAFT` to `status.md`.
 
+## Review-loop budget (applies to Stages 2/2r and 3/3r)
+
+Measured cost of unbounded loops: one feature ran 7 review passes (~$300
+API-equivalent). These rules cap the loop:
+
+1. **Maximum 3 passes** per review stage. If findings remain open after
+   pass 3, HOLD — ask the user instead of running pass 4.
+2. **Pass 1 is the only full-panel pass** (all lenses, whole document).
+3. **Passes 2+ are delta passes**: at most 2 Explore agents. They review
+   ONLY the sections changed by the resolver (the resolver lists changed
+   section headings at the top of its response) plus the specific findings
+   they verify. They do not re-read the whole document.
+4. **Early exit**: a pass whose findings require no change to the artifact
+   ends the loop — the verdict is PASS.
+
 ## Stage 2 — Methods review
 
 Read `.claude/skills/spec-workflow/references/stage-2-methods-review.md` for the full
@@ -194,7 +209,8 @@ Two modes:
 - **JUDGMENT_CALL per-issue**: Ask user via `AskUserQuestion`, one at a time.
   Record resolution in `decisions.md`. Apply fix. Mini-pass affected lens.
 
-Loop until `methods-review.md` verdict = PASS.
+Loop until `methods-review.md` verdict = PASS. Respect the Review-loop
+budget above.
 
 ## Stage 3 — Spec review
 
@@ -213,7 +229,7 @@ Read `.claude/skills/spec-workflow/references/stage-4-resolve.md` for the full p
 for this stage.)
 
 Use BIG mode (>8 findings) or SMALL mode (≤8 findings). Loop until
-`spec-review.md` verdict = PASS.
+`spec-review.md` verdict = PASS. Respect the Review-loop budget above.
 
 ## Stage 4 — Freeze & advance
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,3 +82,4 @@ its own exported API, so this rarely bites — but keep it in mind.
 - `plans/error-messages.md` — canonical error/warning class names and CLI message templates
 - `archive/` — completed phase docs, one directory per shipped feature (spec, impl plan, decisions); `ls archive/` lists them and `git log` has the PR numbers
 - `.claude/rules/` — code style, testing standards, R package conventions, GitHub strategy
+- `.claude/references/` — worked examples and rationale moved out of `.claude/rules/`; read when a rule's application is unclear

--- a/changelog/chore-reduce-pipeline-token-usage.md
+++ b/changelog/chore-reduce-pipeline-token-usage.md
@@ -1,0 +1,33 @@
+# chore(pipeline): reduce token usage of the pipeline skill family
+
+**Date**: 2026-08-22
+**Branch**: JDenn0514/reduce-token-usage
+**Phase**: Tooling (no package code)
+
+## Changes
+
+- Run the tester and shipper agents, and all review-lens Explore dispatches, on Sonnet; builder, planner, and reviewer keep the session model
+- Cap review loops at 3 passes: pass 1 is the only full-panel pass, later passes are 2-agent delta passes with an early exit
+- Slim the always-loaded rules from 1,822 to 652 lines; move worked examples to four on-demand files in `.claude/references/`
+- Stop agents and dispatch prompts from re-reading auto-loaded rules
+- Cap builder full-suite runs at 2 per PR; route all gate output through log files with filtered summaries
+- Continue the SAME builder agent on tester BLOCK instead of dispatching a fresh one
+- Remove the pkgcheck gate everywhere; skip the duplicate pre-PR gate rerun when the audit's tree hash matches
+- Add `.claude/scripts/run-gates.sh` — all validation gates in one background command with per-gate logs and one summary table
+- Ban tester sleep-poll loops and pre-PR-state reconstruction; pipeline-simplified now captures the baseline in the background and passes it to the tester
+- Add `.claude/scripts/usage-profile.py` for before/after session measurement
+
+Validated on two live pipeline-simplified runs (PRs #155, #156): tester went
+from 683 turns / 92M cache-read tokens to 45 turns / 1.4M; a full
+plan-build-test-ship cycle now costs ~6x less than the original configuration.
+
+## Files Modified
+
+- `.claude/agents/{builder,tester,reviewer,shipper,planner}.md` — model tiering, gate batching, discipline rules
+- `.claude/skills/pipeline-{spec,implement,ship,simplified}/SKILL.md` — review caps, dispatch slimming, tree-hash skip, baseline capture
+- `.claude/skills/pipeline-shared/references/{r-package-profile,artifact-schemas,signals}.md` — gate table, canonical runner, audit schema
+- `.claude/rules/*.md` (all 7) — slimmed to decision tables with pointers
+- `.claude/references/{code-style,github-strategy,r-package,testing}-detail.md` — new on-demand example files
+- `.claude/scripts/{run-gates.sh,usage-profile.py}` — new tooling
+- `CLAUDE.md`, `.gitattributes` — pointer line; LF for shell scripts
+- `plans/spec-reduce-token-usage.md`, `plans/implementation-plan-reduce-token-usage.md` — planning docs

--- a/plans/implementation-plan-reduce-token-usage.md
+++ b/plans/implementation-plan-reduce-token-usage.md
@@ -1,0 +1,420 @@
+# Reduce Token Usage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `plans/spec-reduce-token-usage.md` — cut weighted token usage of the pipeline skills by 50–70% with no loss of output quality.
+
+**Architecture:** All changes are markdown edits to `.claude/` configuration files. No R code changes. Five groups: model tiering (A), review-loop caps (B), rules slimming with on-demand references (C), test-run and output discipline (D), gate deduplication (E).
+
+**Tech Stack:** Claude Code agent/skill markdown files. Verification is by `grep` and `wc -l`, not by a test suite.
+
+## Global Constraints
+
+- No rule may be deleted — only moved to a reference file or deduplicated (spec §2C).
+- Moved content must be reachable via a pointer that states when to read it.
+- Never use `@file` syntax in pointers (it force-loads the file). Use plain paths.
+- On-demand reference files go in `.claude/references/` (NOT `.claude/rules/`, which auto-loads).
+- `builder`, `planner`, `reviewer` agents keep the session model — no `model:` key.
+- Always-loaded total (CLAUDE.md + `.claude/rules/*.md`) target: ≤ 700 lines (currently 1,822).
+- Commit after each task with the given Conventional Commit message. This branch: `JDenn0514/reduce-token-usage`.
+
+---
+
+### Task 1: Model tiering (Group A)
+
+**Files:**
+- Modify: `.claude/agents/tester.md:1-5` (frontmatter)
+- Modify: `.claude/agents/shipper.md:1-5` (frontmatter), `.claude/agents/shipper.md:78`
+- Modify: `.claude/skills/pipeline-spec/SKILL.md` (Stage 2, Stage 3 dispatch text)
+- Modify: `.claude/skills/pipeline-implement/SKILL.md` (Stage 2 dispatch text)
+
+**Interfaces:**
+- Produces: `model: sonnet` frontmatter key consumed by the Claude Code agent loader; dispatch instructions consumed by orchestrator sessions.
+
+- [ ] **Step 1: Add `model: sonnet` to tester frontmatter**
+
+In `.claude/agents/tester.md`, change the frontmatter to:
+
+```yaml
+---
+name: tester
+description: Validates a merged PR against test-spec.md. Receives only the test-spec, never spec.md or implementation.md. Runs all profile gates. Enforces Tolerance Integrity. Writes audit.md with verdict PASS or BLOCK. Dispatched by pipeline-ship and pipeline-simplified.
+tools: Read, Grep, Glob, Write, Bash
+model: sonnet
+---
+```
+
+- [ ] **Step 2: Add `model: sonnet` to shipper frontmatter; fix stale attribution**
+
+Same edit pattern in `.claude/agents/shipper.md` (add `model: sonnet` after `tools:`).
+Also on line 78, replace `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>` with `Co-Authored-By: Claude <noreply@anthropic.com>` (model-agnostic — the agent may run on any model).
+
+- [ ] **Step 3: Review-lens dispatches use sonnet**
+
+In `.claude/skills/pipeline-spec/SKILL.md`:
+- Stage 2, the line "If applicable, dispatch 5–6 Explore subagents in parallel (one per lens)" → append: "Pass `model: "sonnet"` on every lens dispatch — lens agents scan a document against one named criterion and do not need the session model."
+- Stage 3, the line "Dispatch 6 Explore subagents in parallel (one per lens)." → append the same sentence.
+
+In `.claude/skills/pipeline-implement/SKILL.md` Stage 2, after "Dispatch 5 Explore subagents in parallel:" add the same sentence as a note under the lens list.
+
+- [ ] **Step 4: Verify**
+
+```bash
+grep -l "model: sonnet" .claude/agents/tester.md .claude/agents/shipper.md
+grep -c 'model: "sonnet"' .claude/skills/pipeline-spec/SKILL.md   # expect 2
+grep -c 'model: "sonnet"' .claude/skills/pipeline-implement/SKILL.md  # expect 1
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude/agents/tester.md .claude/agents/shipper.md .claude/skills/pipeline-spec/SKILL.md .claude/skills/pipeline-implement/SKILL.md
+git commit -m "chore(pipeline): run tester, shipper, and review lenses on sonnet"
+```
+
+---
+
+### Task 2: Review-loop convergence caps (Group B)
+
+**Files:**
+- Modify: `.claude/skills/pipeline-spec/SKILL.md` (Stage 2r, Stage 3r)
+- Modify: `.claude/skills/pipeline-implement/SKILL.md` (Stage 3)
+
+**Interfaces:**
+- Produces: a "Review-loop budget" block reused verbatim in both files.
+
+- [ ] **Step 1: Add the budget block to pipeline-spec**
+
+In `.claude/skills/pipeline-spec/SKILL.md`, insert a new section immediately before "## Stage 2 — Methods review":
+
+```markdown
+## Review-loop budget (applies to Stages 2/2r and 3/3r)
+
+Measured cost of unbounded loops: one feature ran 7 review passes (~$300
+API-equivalent). These rules cap the loop:
+
+1. **Maximum 3 passes** per review stage. If findings remain open after
+   pass 3, HOLD — ask the user instead of running pass 4.
+2. **Pass 1 is the only full-panel pass** (all lenses, whole document).
+3. **Passes 2+ are delta passes**: at most 2 Explore agents. They review
+   ONLY the sections changed by the resolver (the resolver lists changed
+   section headings at the top of its response) plus the specific findings
+   they verify. They do not re-read the whole document.
+4. **Early exit**: a pass whose findings require no change to the artifact
+   ends the loop — the verdict is PASS.
+```
+
+Then in Stage 2r and Stage 3r, append to each "Loop until ... verdict = PASS" line: "Respect the Review-loop budget above."
+
+- [ ] **Step 2: Add the same budget to pipeline-implement**
+
+In `.claude/skills/pipeline-implement/SKILL.md`, insert the same block (retitled "## Review-loop budget (applies to Stages 2 and 3)") before "## Stage 2 — Plan review", and append "Respect the Review-loop budget above." to the Stage 3 loop line.
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -c "Maximum 3 passes" .claude/skills/pipeline-spec/SKILL.md .claude/skills/pipeline-implement/SKILL.md  # expect 1 each
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/pipeline-spec/SKILL.md .claude/skills/pipeline-implement/SKILL.md
+git commit -m "chore(pipeline): cap review loops at 3 passes with delta passes"
+```
+
+---
+
+### Task 3: Slim the rules files (Group C, part 1)
+
+**Files:**
+- Create: `.claude/references/code-style-detail.md`
+- Create: `.claude/references/github-strategy-detail.md`
+- Create: `.claude/references/r-package-detail.md`
+- Create: `.claude/references/testing-detail.md`
+- Modify: all 7 files in `.claude/rules/`
+- Modify: `CLAUDE.md` (add one pointer line)
+
+**Interfaces:**
+- Produces: 4 reference files whose paths are cited by pointers in the slimmed rules files and by agent defs in Task 4. Exact paths above — Task 4 depends on them.
+
+**Method for every file:** the slim version keeps its Quick Reference table and any rule NOT derivable from that table, as compact prose (no code blocks unless listed below). Everything moved lands in the named reference file under a heading matching its original section name. Each slim file ends with:
+
+```markdown
+---
+Worked examples and rationale: `.claude/references/{name}.md`. Read it when
+writing new code covered by these rules and the correct application is not
+obvious from the tables above.
+```
+
+- [ ] **Step 1: Slim `code-style.md` (477 → ~140 lines) → `code-style-detail.md`**
+
+Keep inline:
+- Quick Reference table (unchanged).
+- §2: accessor exception for `@data`/`@metadata` (2 lines); method file-org table; the rule "always `S7::S7_inherits(x, ClassObject)`, never a string, never `is()`" (2 lines); `@variables` all-keys rule (2 lines, no code); `@groups` reserved rule (3 bullets).
+- §3: ONE compact `cli_abort()` example (the three-bullet structure with `class=`); the class naming convention lines; the cli inline markup table; the message-register bullets (4 lines).
+- §4: return-visibility table; argument-order numbered list (compressed to 7 one-liners); dispatch table + this warning kept verbatim: "S3 dispatch does NOT work for S7 objects... Use a plain function with explicit `S7::S7_inherits()` type checking instead."; helper placement table.
+
+Move to `code-style-detail.md`: §1 code examples (indentation, line length, long-signature breaks), auto-formatter/air setup, §2 wrong/right code examples, §3 good/bad error examples and the `cli_warn()` block, §4 full code examples, §5 Tooling Configuration (.lintr, .editorconfig, air commands).
+
+- [ ] **Step 2: Slim `engineering-preferences.md` (84 → ~25 lines)**
+
+Keep: the 5 principles, each as its heading plus its first sentence (e.g., "1. DRY — flag repetition aggressively. Duplicated logic is a bug waiting to happen."). Move to `code-style-detail.md` under "## Engineering preferences — detail": the sub-bullets and the "How to apply these during review" section.
+
+- [ ] **Step 3: Slim `github-strategy.md` (164 → ~70 lines) → `github-strategy-detail.md`**
+
+Keep: Quick Reference; Workflow Tiers table; branching diagram (7 lines); branch-vs-direct table; Branch Naming table; Commit Format table + scopes line; Merge Strategy (2 sentences); Versioning tables; "Use `/merge-main`" line.
+Move: Worked Examples section (all 6), Release Preparation detail.
+
+- [ ] **Step 4: Slim `r-package-conventions.md` (297 → ~80 lines) → `r-package-detail.md`**
+
+Keep: Quick Reference; §1 rules as one-liners (param verbosity rule, @return required, @examples runnable, @family, internal-docs table); §2 export policy bullets + ":: everywhere, no @importFrom" + "NAMESPACE never edited by hand"; §3 check targets + pre-approved NOTEs table + "accept NSE notes, don't suppress" + document()/check() cadence + min-version pinning rule.
+Move: all roxygen code examples, DESCRIPTION template, package-documentation template. Delete §Summary (duplicates the Quick Reference — dedup, not a move).
+
+- [ ] **Step 5: Slim `surveycore-conventions.md` (222 → ~55 lines) → `r-package-detail.md`**
+
+Keep: Quick Reference; naming-pattern tables (class names, function families, naming patterns); haven rule (attr-based extraction, 3 lines); export/not-export lists as two compact lines.
+Move (into `r-package-detail.md` under "## surveycore documentation examples"): the long `@param` examples, `@return` example, `@seealso` block. Delete §3 (already a pointer to code-style) and the Documentation Checklist (duplicates r-package-conventions content — dedup).
+
+- [ ] **Step 6: Slim `testing-standards.md` (286 → ~90 lines) → `testing-detail.md`**
+
+Keep: Quick Reference; granularity + one-behavior + no-describe rules (one line each, keep the good/bad description example pair as 4 short lines); coverage target + nocov acceptable/unacceptable bullets; the three mandatory categories (names + one-line each); dual-pattern rule (2 lines, no code); snapshot update rules (3 lines); warning-capture rule (2 lines); identical-vs-equal table; data-generator requirement bullets; edge-case-inline rule (2 lines); skip block-level rule (2 lines).
+Move: all multi-line code examples.
+
+- [ ] **Step 7: Slim `testing-surveycore.md` (208 → ~90 lines) → `testing-detail.md`**
+
+Keep: Quick Reference; file-mapping table; `test_invariants()` first-assertion rule + the 5 invariant names (already slimmed upstream — keep as is); Layer 1 vs Layer 3 rules (2 lines each, no code); `make_survey_data()` signature block + data-policy table; tolerance table.
+Move (under "## surveycore test templates"): the code examples and the test-file section templates.
+
+- [ ] **Step 8: Add pointer line to CLAUDE.md**
+
+In `CLAUDE.md` §Reference Documents, add:
+`- `.claude/references/` — worked examples and rationale moved out of `.claude/rules/`; read when a rule's application is unclear`
+
+- [ ] **Step 9: Verify — line budget and content preservation**
+
+```bash
+wc -l CLAUDE.md .claude/rules/*.md | tail -1        # total ≤ 700
+# spot-check moved content survived (one distinctive phrase per reference file):
+grep -l "pipe_consistency_linter" .claude/references/code-style-detail.md
+grep -l "get_contrasts" .claude/references/github-strategy-detail.md
+grep -l "wtmec2yr" .claude/references/r-package-detail.md
+grep -l "snapshot_review" .claude/references/testing-detail.md
+# every slim rules file points at its reference:
+grep -L "claude/references/" .claude/rules/*.md     # expect empty output
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add .claude/rules/ .claude/references/ CLAUDE.md
+git commit -m "chore(rules): slim always-loaded rules to tables; move examples to .claude/references"
+```
+
+---
+
+### Task 4: Agent defs stop re-reading rules (Group C, part 2)
+
+**Files:**
+- Modify: `.claude/agents/builder.md:16` (Receives list)
+- Modify: `.claude/agents/tester.md:15` (Receives list)
+- Modify: `.claude/agents/reviewer.md:20-21` (Receives list)
+- Modify: `.claude/skills/pipeline-ship/SKILL.md` (§2a and §2d dispatch prompts)
+
+**Interfaces:**
+- Consumes: reference file paths created in Task 3.
+
+- [ ] **Step 1: builder.md**
+
+Replace the Receives bullet "`.claude/rules/` — code style, testing standards, R package conventions" with:
+
+```markdown
+- Project rules (CLAUDE.md + `.claude/rules/`) auto-load into your context — do NOT re-read them. When a rule's application is unclear, read `.claude/references/code-style-detail.md` or `.claude/references/r-package-detail.md` for worked examples.
+```
+
+- [ ] **Step 2: tester.md**
+
+Replace the Receives bullet "`.claude/rules/` — testing standards" with the same sentence, pointing at `.claude/references/testing-detail.md`.
+
+- [ ] **Step 3: reviewer.md**
+
+Replace the two Receives bullets "`.claude/rules/`" and "`skills/pipeline-shared/references/` (all files)" with:
+
+```markdown
+- Project rules auto-load into your context — do NOT re-read `.claude/rules/`.
+- `skills/pipeline-shared/references/signals.md`, `artifact-schemas.md`, and `r-package-profile.md` — the only shared references you need (verdict schemas, tolerance defaults, gate skip rules).
+```
+
+- [ ] **Step 4: pipeline-ship dispatch prompts**
+
+In `.claude/skills/pipeline-ship/SKILL.md`:
+- §2a builder dispatch prompt: change `> Read: .claude/agents/builder.md, .claude/rules/, r-package-profile.md` to `> Read: .claude/agents/builder.md, r-package-profile.md (rules auto-load — do not re-read .claude/rules/)`.
+- §2d reviewer dispatch prompt: change `> Read: .claude/agents/reviewer.md, ALL references from pipeline-shared` to `> Read: .claude/agents/reviewer.md, plus signals.md, artifact-schemas.md, and r-package-profile.md from pipeline-shared/references`.
+
+- [ ] **Step 5: Verify**
+
+```bash
+grep -n "do NOT re-read" .claude/agents/builder.md .claude/agents/tester.md .claude/agents/reviewer.md  # 1 hit each
+grep -n "ALL references" .claude/skills/pipeline-ship/SKILL.md  # expect empty
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .claude/agents/builder.md .claude/agents/tester.md .claude/agents/reviewer.md .claude/skills/pipeline-ship/SKILL.md
+git commit -m "chore(agents): stop re-reading auto-loaded rules; point at on-demand references"
+```
+
+---
+
+### Task 5: Test-run and output discipline (Group D)
+
+**Files:**
+- Modify: `.claude/agents/builder.md` (Step 2 TDD loop)
+- Modify: `.claude/skills/pipeline-shared/references/r-package-profile.md` (new section)
+- Modify: `.claude/agents/tester.md:56` (capture-output line)
+- Modify: `.claude/skills/pipeline-ship/SKILL.md` (§2c BLOCK handling)
+
+- [ ] **Step 1: builder full-suite budget**
+
+In `.claude/agents/builder.md`, after the Step 2 TDD loop list, add:
+
+```markdown
+### Full-suite budget
+
+Iterate with `devtools::test(filter = "{pattern}")` on the test files you
+touch. Run the FULL suite (`devtools::test()` with no filter) at most twice
+per PR: once before writing `implementation.md`, and once after a BLOCK fix.
+Measured cost of ignoring this: one builder ran the full suite ~10 times in
+one PR. Redirect full-suite output to a log file and read only the tail:
+
+    Rscript -e 'devtools::test()' > .test-full.log 2>&1
+    tail -25 .test-full.log
+    grep -E "^(FAIL|Failure|Error)" .test-full.log
+
+Delete `.test-full.log` before committing.
+```
+
+- [ ] **Step 2: gate output discipline in r-package-profile.md**
+
+After the Validation commands table, add:
+
+```markdown
+## Output discipline (all gates)
+
+Redirect every gate's full output to `{workspace-run-dir}/logs/gate-{N}.log`.
+Bring into context ONLY:
+- `tail -25` of the log, and
+- `grep -E "FAIL|ERROR|WARNING|NOTE" ` of the log.
+
+Record each log path in `audit.md` §Profile gates. Read a full log only when
+diagnosing that gate's failure.
+```
+
+- [ ] **Step 3: tester capture line**
+
+In `.claude/agents/tester.md`, replace "Capture full output of each command. Summaries go in `audit.md`; full logs stay in the workspace directory for forensics." with "Follow `r-package-profile.md` §Output discipline: full output to workspace log files; only the filtered summary enters context. Summaries go in `audit.md` with log paths."
+
+- [ ] **Step 4: BLOCK continues the same builder**
+
+In `.claude/skills/pipeline-ship/SKILL.md` §2c, replace item 2 ("If counter ≤ 3: re-dispatch builder for that PR with the BLOCK body...") with:
+
+```markdown
+2. If counter ≤ 3: send the BLOCK body (NOT the full audit.md, NOT
+   test-spec.md, per signals.md) to the SAME builder agent via SendMessage —
+   it keeps its context and warm cache. Dispatch a fresh builder only if the
+   original agent is no longer available (e.g., session restart), passing the
+   BLOCK body in the dispatch prompt.
+```
+
+- [ ] **Step 5: Verify**
+
+```bash
+grep -c "Full-suite budget" .claude/agents/builder.md          # 1
+grep -c "Output discipline" .claude/skills/pipeline-shared/references/r-package-profile.md  # ≥1
+grep -c "SAME builder agent" .claude/skills/pipeline-ship/SKILL.md  # 1
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .claude/agents/builder.md .claude/agents/tester.md .claude/skills/pipeline-shared/references/r-package-profile.md .claude/skills/pipeline-ship/SKILL.md
+git commit -m "chore(pipeline): cap full-suite runs, filter gate output, reuse builder on BLOCK"
+```
+
+---
+
+### Task 6: Gate deduplication (Group E)
+
+**Files:**
+- Modify: `.claude/skills/pipeline-shared/references/r-package-profile.md` (remove pkgcheck gate; renumber)
+- Modify: `.claude/agents/tester.md` (gate list; tree hash)
+- Modify: `.claude/skills/pipeline-ship/SKILL.md` (§2e.5 tree-hash skip)
+- Modify: `.claude/skills/pipeline-shared/references/artifact-schemas.md` (audit.md schema: tree-hash line)
+
+- [ ] **Step 1: Remove pkgcheck everywhere it is a gate**
+
+- `r-package-profile.md`: delete table row 6 (`pkgcheck::pkgcheck()`); renumber rows 7→6 (pkgdown) and 8→7 (covr); update "gate 7" in the pkgdown skip condition to "gate 6".
+- `.claude/agents/tester.md` Step 1: delete the `pkgcheck::pkgcheck()` line; renumber 7→6, 8→7.
+- User decision 2026-08-21: pkgcheck removed entirely — not moved to release. (`.claude/agents/shipper.md:147` already ignores pkgcheck in CI; leave it.)
+
+- [ ] **Step 2: Tester records the tree hash**
+
+In `.claude/agents/tester.md` Step 1, after the gate list add: "After the last gate, record `git rev-parse 'HEAD^{tree}'` in `audit.md` §Profile gates as `Tree: {hash}` — the pre-PR gate uses it to skip duplicate reruns."
+
+In `artifact-schemas.md`, find the audit.md schema's Profile gates section and add the line `Tree: {git tree hash at gate time}` to the required fields.
+
+- [ ] **Step 3: pre-PR gate skip in pipeline-ship**
+
+In `.claude/skills/pipeline-ship/SKILL.md` §2e.5, before the command block add:
+
+```markdown
+Skip check first: read `Tree:` from this PR's `audit.md` and compare to
+`git rev-parse 'HEAD^{tree}'` on the feature branch. If they match, the
+tester already ran these gates on this exact tree — skip the rerun and
+proceed to the shipper (log "pre-PR gate: SKIPPED — tree unchanged since
+audit"). If they differ (or `audit.md` has no `Tree:` line), run the gate
+as below.
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+grep -rn "pkgcheck" .claude/skills/pipeline-shared/references/r-package-profile.md .claude/agents/tester.md  # expect no gate rows; profile may retain zero mentions
+grep -c "Tree:" .claude/agents/tester.md .claude/skills/pipeline-ship/SKILL.md  # ≥1 each
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude/skills/pipeline-shared/references/r-package-profile.md .claude/agents/tester.md .claude/skills/pipeline-ship/SKILL.md .claude/skills/pipeline-shared/references/artifact-schemas.md
+git commit -m "chore(pipeline): drop pkgcheck gate; skip duplicate pre-PR rerun via tree hash"
+```
+
+---
+
+### Task 7: Final verification sweep
+
+**Files:** none created — checks only.
+
+- [ ] **Step 1: Line budget**
+
+```bash
+wc -l CLAUDE.md .claude/rules/*.md | tail -1   # total ≤ 700
+```
+
+- [ ] **Step 2: No dangling references**
+
+```bash
+grep -rn "pkgcheck" .claude/agents/ .claude/skills/pipeline-* | grep -v "NOT a required check"  # expect empty
+grep -rn "Read: .claude/rules" .claude/agents/    # expect empty
+grep -rn "@\.claude" .claude/                     # no @-force-load links; expect empty
+```
+
+- [ ] **Step 3: Spec cross-check**
+
+Re-read `plans/spec-reduce-token-usage.md` §2. Confirm every numbered item in Groups A–E maps to a completed task step. Confirm §3 ("What does not change") still holds: builder/planner/reviewer have no `model:` key; isolation rules untouched; tolerances untouched.
+
+- [ ] **Step 4: Commit any fixes, then report**
+
+Report to user: per-file line counts before/after, and the validation procedure from spec §4 (run one small pipeline change, profile with `usage_profile.py`, compare).

--- a/plans/implementation-plan-reduce-token-usage.md
+++ b/plans/implementation-plan-reduce-token-usage.md
@@ -31,7 +31,7 @@
 **Interfaces:**
 - Produces: `model: sonnet` frontmatter key consumed by the Claude Code agent loader; dispatch instructions consumed by orchestrator sessions.
 
-- [ ] **Step 1: Add `model: sonnet` to tester frontmatter**
+- [x] **Step 1: Add `model: sonnet` to tester frontmatter**
 
 In `.claude/agents/tester.md`, change the frontmatter to:
 
@@ -44,12 +44,12 @@ model: sonnet
 ---
 ```
 
-- [ ] **Step 2: Add `model: sonnet` to shipper frontmatter; fix stale attribution**
+- [x] **Step 2: Add `model: sonnet` to shipper frontmatter; fix stale attribution**
 
 Same edit pattern in `.claude/agents/shipper.md` (add `model: sonnet` after `tools:`).
 Also on line 78, replace `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>` with `Co-Authored-By: Claude <noreply@anthropic.com>` (model-agnostic — the agent may run on any model).
 
-- [ ] **Step 3: Review-lens dispatches use sonnet**
+- [x] **Step 3: Review-lens dispatches use sonnet**
 
 In `.claude/skills/pipeline-spec/SKILL.md`:
 - Stage 2, the line "If applicable, dispatch 5–6 Explore subagents in parallel (one per lens)" → append: "Pass `model: "sonnet"` on every lens dispatch — lens agents scan a document against one named criterion and do not need the session model."
@@ -57,7 +57,7 @@ In `.claude/skills/pipeline-spec/SKILL.md`:
 
 In `.claude/skills/pipeline-implement/SKILL.md` Stage 2, after "Dispatch 5 Explore subagents in parallel:" add the same sentence as a note under the lens list.
 
-- [ ] **Step 4: Verify**
+- [x] **Step 4: Verify**
 
 ```bash
 grep -l "model: sonnet" .claude/agents/tester.md .claude/agents/shipper.md
@@ -65,7 +65,7 @@ grep -c 'model: "sonnet"' .claude/skills/pipeline-spec/SKILL.md   # expect 2
 grep -c 'model: "sonnet"' .claude/skills/pipeline-implement/SKILL.md  # expect 1
 ```
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add .claude/agents/tester.md .claude/agents/shipper.md .claude/skills/pipeline-spec/SKILL.md .claude/skills/pipeline-implement/SKILL.md
@@ -83,7 +83,7 @@ git commit -m "chore(pipeline): run tester, shipper, and review lenses on sonnet
 **Interfaces:**
 - Produces: a "Review-loop budget" block reused verbatim in both files.
 
-- [ ] **Step 1: Add the budget block to pipeline-spec**
+- [x] **Step 1: Add the budget block to pipeline-spec**
 
 In `.claude/skills/pipeline-spec/SKILL.md`, insert a new section immediately before "## Stage 2 — Methods review":
 
@@ -106,17 +106,17 @@ API-equivalent). These rules cap the loop:
 
 Then in Stage 2r and Stage 3r, append to each "Loop until ... verdict = PASS" line: "Respect the Review-loop budget above."
 
-- [ ] **Step 2: Add the same budget to pipeline-implement**
+- [x] **Step 2: Add the same budget to pipeline-implement**
 
 In `.claude/skills/pipeline-implement/SKILL.md`, insert the same block (retitled "## Review-loop budget (applies to Stages 2 and 3)") before "## Stage 2 — Plan review", and append "Respect the Review-loop budget above." to the Stage 3 loop line.
 
-- [ ] **Step 3: Verify**
+- [x] **Step 3: Verify**
 
 ```bash
 grep -c "Maximum 3 passes" .claude/skills/pipeline-spec/SKILL.md .claude/skills/pipeline-implement/SKILL.md  # expect 1 each
 ```
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add .claude/skills/pipeline-spec/SKILL.md .claude/skills/pipeline-implement/SKILL.md
@@ -147,7 +147,7 @@ writing new code covered by these rules and the correct application is not
 obvious from the tables above.
 ```
 
-- [ ] **Step 1: Slim `code-style.md` (477 → ~140 lines) → `code-style-detail.md`**
+- [x] **Step 1: Slim `code-style.md` (477 → ~140 lines) → `code-style-detail.md`**
 
 Keep inline:
 - Quick Reference table (unchanged).
@@ -157,41 +157,41 @@ Keep inline:
 
 Move to `code-style-detail.md`: §1 code examples (indentation, line length, long-signature breaks), auto-formatter/air setup, §2 wrong/right code examples, §3 good/bad error examples and the `cli_warn()` block, §4 full code examples, §5 Tooling Configuration (.lintr, .editorconfig, air commands).
 
-- [ ] **Step 2: Slim `engineering-preferences.md` (84 → ~25 lines)**
+- [x] **Step 2: Slim `engineering-preferences.md` (84 → ~25 lines)**
 
 Keep: the 5 principles, each as its heading plus its first sentence (e.g., "1. DRY — flag repetition aggressively. Duplicated logic is a bug waiting to happen."). Move to `code-style-detail.md` under "## Engineering preferences — detail": the sub-bullets and the "How to apply these during review" section.
 
-- [ ] **Step 3: Slim `github-strategy.md` (164 → ~70 lines) → `github-strategy-detail.md`**
+- [x] **Step 3: Slim `github-strategy.md` (164 → ~70 lines) → `github-strategy-detail.md`**
 
 Keep: Quick Reference; Workflow Tiers table; branching diagram (7 lines); branch-vs-direct table; Branch Naming table; Commit Format table + scopes line; Merge Strategy (2 sentences); Versioning tables; "Use `/merge-main`" line.
 Move: Worked Examples section (all 6), Release Preparation detail.
 
-- [ ] **Step 4: Slim `r-package-conventions.md` (297 → ~80 lines) → `r-package-detail.md`**
+- [x] **Step 4: Slim `r-package-conventions.md` (297 → ~80 lines) → `r-package-detail.md`**
 
 Keep: Quick Reference; §1 rules as one-liners (param verbosity rule, @return required, @examples runnable, @family, internal-docs table); §2 export policy bullets + ":: everywhere, no @importFrom" + "NAMESPACE never edited by hand"; §3 check targets + pre-approved NOTEs table + "accept NSE notes, don't suppress" + document()/check() cadence + min-version pinning rule.
 Move: all roxygen code examples, DESCRIPTION template, package-documentation template. Delete §Summary (duplicates the Quick Reference — dedup, not a move).
 
-- [ ] **Step 5: Slim `surveycore-conventions.md` (222 → ~55 lines) → `r-package-detail.md`**
+- [x] **Step 5: Slim `surveycore-conventions.md` (222 → ~55 lines) → `r-package-detail.md`**
 
 Keep: Quick Reference; naming-pattern tables (class names, function families, naming patterns); haven rule (attr-based extraction, 3 lines); export/not-export lists as two compact lines.
 Move (into `r-package-detail.md` under "## surveycore documentation examples"): the long `@param` examples, `@return` example, `@seealso` block. Delete §3 (already a pointer to code-style) and the Documentation Checklist (duplicates r-package-conventions content — dedup).
 
-- [ ] **Step 6: Slim `testing-standards.md` (286 → ~90 lines) → `testing-detail.md`**
+- [x] **Step 6: Slim `testing-standards.md` (286 → ~90 lines) → `testing-detail.md`**
 
 Keep: Quick Reference; granularity + one-behavior + no-describe rules (one line each, keep the good/bad description example pair as 4 short lines); coverage target + nocov acceptable/unacceptable bullets; the three mandatory categories (names + one-line each); dual-pattern rule (2 lines, no code); snapshot update rules (3 lines); warning-capture rule (2 lines); identical-vs-equal table; data-generator requirement bullets; edge-case-inline rule (2 lines); skip block-level rule (2 lines).
 Move: all multi-line code examples.
 
-- [ ] **Step 7: Slim `testing-surveycore.md` (208 → ~90 lines) → `testing-detail.md`**
+- [x] **Step 7: Slim `testing-surveycore.md` (208 → ~90 lines) → `testing-detail.md`**
 
 Keep: Quick Reference; file-mapping table; `test_invariants()` first-assertion rule + the 5 invariant names (already slimmed upstream — keep as is); Layer 1 vs Layer 3 rules (2 lines each, no code); `make_survey_data()` signature block + data-policy table; tolerance table.
 Move (under "## surveycore test templates"): the code examples and the test-file section templates.
 
-- [ ] **Step 8: Add pointer line to CLAUDE.md**
+- [x] **Step 8: Add pointer line to CLAUDE.md**
 
 In `CLAUDE.md` §Reference Documents, add:
 `- `.claude/references/` — worked examples and rationale moved out of `.claude/rules/`; read when a rule's application is unclear`
 
-- [ ] **Step 9: Verify — line budget and content preservation**
+- [x] **Step 9: Verify — line budget and content preservation**
 
 ```bash
 wc -l CLAUDE.md .claude/rules/*.md | tail -1        # total ≤ 700
@@ -204,7 +204,7 @@ grep -l "snapshot_review" .claude/references/testing-detail.md
 grep -L "claude/references/" .claude/rules/*.md     # expect empty output
 ```
 
-- [ ] **Step 10: Commit**
+- [x] **Step 10: Commit**
 
 ```bash
 git add .claude/rules/ .claude/references/ CLAUDE.md
@@ -224,7 +224,7 @@ git commit -m "chore(rules): slim always-loaded rules to tables; move examples t
 **Interfaces:**
 - Consumes: reference file paths created in Task 3.
 
-- [ ] **Step 1: builder.md**
+- [x] **Step 1: builder.md**
 
 Replace the Receives bullet "`.claude/rules/` — code style, testing standards, R package conventions" with:
 
@@ -232,11 +232,11 @@ Replace the Receives bullet "`.claude/rules/` — code style, testing standards,
 - Project rules (CLAUDE.md + `.claude/rules/`) auto-load into your context — do NOT re-read them. When a rule's application is unclear, read `.claude/references/code-style-detail.md` or `.claude/references/r-package-detail.md` for worked examples.
 ```
 
-- [ ] **Step 2: tester.md**
+- [x] **Step 2: tester.md**
 
 Replace the Receives bullet "`.claude/rules/` — testing standards" with the same sentence, pointing at `.claude/references/testing-detail.md`.
 
-- [ ] **Step 3: reviewer.md**
+- [x] **Step 3: reviewer.md**
 
 Replace the two Receives bullets "`.claude/rules/`" and "`skills/pipeline-shared/references/` (all files)" with:
 
@@ -245,20 +245,20 @@ Replace the two Receives bullets "`.claude/rules/`" and "`skills/pipeline-shared
 - `skills/pipeline-shared/references/signals.md`, `artifact-schemas.md`, and `r-package-profile.md` — the only shared references you need (verdict schemas, tolerance defaults, gate skip rules).
 ```
 
-- [ ] **Step 4: pipeline-ship dispatch prompts**
+- [x] **Step 4: pipeline-ship dispatch prompts**
 
 In `.claude/skills/pipeline-ship/SKILL.md`:
 - §2a builder dispatch prompt: change `> Read: .claude/agents/builder.md, .claude/rules/, r-package-profile.md` to `> Read: .claude/agents/builder.md, r-package-profile.md (rules auto-load — do not re-read .claude/rules/)`.
 - §2d reviewer dispatch prompt: change `> Read: .claude/agents/reviewer.md, ALL references from pipeline-shared` to `> Read: .claude/agents/reviewer.md, plus signals.md, artifact-schemas.md, and r-package-profile.md from pipeline-shared/references`.
 
-- [ ] **Step 5: Verify**
+- [x] **Step 5: Verify**
 
 ```bash
 grep -n "do NOT re-read" .claude/agents/builder.md .claude/agents/tester.md .claude/agents/reviewer.md  # 1 hit each
 grep -n "ALL references" .claude/skills/pipeline-ship/SKILL.md  # expect empty
 ```
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add .claude/agents/builder.md .claude/agents/tester.md .claude/agents/reviewer.md .claude/skills/pipeline-ship/SKILL.md
@@ -275,7 +275,7 @@ git commit -m "chore(agents): stop re-reading auto-loaded rules; point at on-dem
 - Modify: `.claude/agents/tester.md:56` (capture-output line)
 - Modify: `.claude/skills/pipeline-ship/SKILL.md` (§2c BLOCK handling)
 
-- [ ] **Step 1: builder full-suite budget**
+- [x] **Step 1: builder full-suite budget**
 
 In `.claude/agents/builder.md`, after the Step 2 TDD loop list, add:
 
@@ -295,7 +295,7 @@ one PR. Redirect full-suite output to a log file and read only the tail:
 Delete `.test-full.log` before committing.
 ```
 
-- [ ] **Step 2: gate output discipline in r-package-profile.md**
+- [x] **Step 2: gate output discipline in r-package-profile.md**
 
 After the Validation commands table, add:
 
@@ -311,11 +311,11 @@ Record each log path in `audit.md` §Profile gates. Read a full log only when
 diagnosing that gate's failure.
 ```
 
-- [ ] **Step 3: tester capture line**
+- [x] **Step 3: tester capture line**
 
 In `.claude/agents/tester.md`, replace "Capture full output of each command. Summaries go in `audit.md`; full logs stay in the workspace directory for forensics." with "Follow `r-package-profile.md` §Output discipline: full output to workspace log files; only the filtered summary enters context. Summaries go in `audit.md` with log paths."
 
-- [ ] **Step 4: BLOCK continues the same builder**
+- [x] **Step 4: BLOCK continues the same builder**
 
 In `.claude/skills/pipeline-ship/SKILL.md` §2c, replace item 2 ("If counter ≤ 3: re-dispatch builder for that PR with the BLOCK body...") with:
 
@@ -327,7 +327,7 @@ In `.claude/skills/pipeline-ship/SKILL.md` §2c, replace item 2 ("If counter ≤
    BLOCK body in the dispatch prompt.
 ```
 
-- [ ] **Step 5: Verify**
+- [x] **Step 5: Verify**
 
 ```bash
 grep -c "Full-suite budget" .claude/agents/builder.md          # 1
@@ -335,7 +335,7 @@ grep -c "Output discipline" .claude/skills/pipeline-shared/references/r-package-
 grep -c "SAME builder agent" .claude/skills/pipeline-ship/SKILL.md  # 1
 ```
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add .claude/agents/builder.md .claude/agents/tester.md .claude/skills/pipeline-shared/references/r-package-profile.md .claude/skills/pipeline-ship/SKILL.md
@@ -352,19 +352,19 @@ git commit -m "chore(pipeline): cap full-suite runs, filter gate output, reuse b
 - Modify: `.claude/skills/pipeline-ship/SKILL.md` (§2e.5 tree-hash skip)
 - Modify: `.claude/skills/pipeline-shared/references/artifact-schemas.md` (audit.md schema: tree-hash line)
 
-- [ ] **Step 1: Remove pkgcheck everywhere it is a gate**
+- [x] **Step 1: Remove pkgcheck everywhere it is a gate**
 
 - `r-package-profile.md`: delete table row 6 (`pkgcheck::pkgcheck()`); renumber rows 7→6 (pkgdown) and 8→7 (covr); update "gate 7" in the pkgdown skip condition to "gate 6".
 - `.claude/agents/tester.md` Step 1: delete the `pkgcheck::pkgcheck()` line; renumber 7→6, 8→7.
 - User decision 2026-08-21: pkgcheck removed entirely — not moved to release. (`.claude/agents/shipper.md:147` already ignores pkgcheck in CI; leave it.)
 
-- [ ] **Step 2: Tester records the tree hash**
+- [x] **Step 2: Tester records the tree hash**
 
 In `.claude/agents/tester.md` Step 1, after the gate list add: "After the last gate, record `git rev-parse 'HEAD^{tree}'` in `audit.md` §Profile gates as `Tree: {hash}` — the pre-PR gate uses it to skip duplicate reruns."
 
 In `artifact-schemas.md`, find the audit.md schema's Profile gates section and add the line `Tree: {git tree hash at gate time}` to the required fields.
 
-- [ ] **Step 3: pre-PR gate skip in pipeline-ship**
+- [x] **Step 3: pre-PR gate skip in pipeline-ship**
 
 In `.claude/skills/pipeline-ship/SKILL.md` §2e.5, before the command block add:
 
@@ -377,14 +377,14 @@ audit"). If they differ (or `audit.md` has no `Tree:` line), run the gate
 as below.
 ```
 
-- [ ] **Step 4: Verify**
+- [x] **Step 4: Verify**
 
 ```bash
 grep -rn "pkgcheck" .claude/skills/pipeline-shared/references/r-package-profile.md .claude/agents/tester.md  # expect no gate rows; profile may retain zero mentions
 grep -c "Tree:" .claude/agents/tester.md .claude/skills/pipeline-ship/SKILL.md  # ≥1 each
 ```
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add .claude/skills/pipeline-shared/references/r-package-profile.md .claude/agents/tester.md .claude/skills/pipeline-ship/SKILL.md .claude/skills/pipeline-shared/references/artifact-schemas.md
@@ -397,13 +397,13 @@ git commit -m "chore(pipeline): drop pkgcheck gate; skip duplicate pre-PR rerun 
 
 **Files:** none created — checks only.
 
-- [ ] **Step 1: Line budget**
+- [x] **Step 1: Line budget**
 
 ```bash
 wc -l CLAUDE.md .claude/rules/*.md | tail -1   # total ≤ 700
 ```
 
-- [ ] **Step 2: No dangling references**
+- [x] **Step 2: No dangling references**
 
 ```bash
 grep -rn "pkgcheck" .claude/agents/ .claude/skills/pipeline-* | grep -v "NOT a required check"  # expect empty
@@ -411,10 +411,10 @@ grep -rn "Read: .claude/rules" .claude/agents/    # expect empty
 grep -rn "@\.claude" .claude/                     # no @-force-load links; expect empty
 ```
 
-- [ ] **Step 3: Spec cross-check**
+- [x] **Step 3: Spec cross-check**
 
 Re-read `plans/spec-reduce-token-usage.md` §2. Confirm every numbered item in Groups A–E maps to a completed task step. Confirm §3 ("What does not change") still holds: builder/planner/reviewer have no `model:` key; isolation rules untouched; tolerances untouched.
 
-- [ ] **Step 4: Commit any fixes, then report**
+- [x] **Step 4: Commit any fixes, then report**
 
 Report to user: per-file line counts before/after, and the validation procedure from spec §4 (run one small pipeline change, profile with `usage_profile.py`, compare).

--- a/plans/spec-reduce-token-usage.md
+++ b/plans/spec-reduce-token-usage.md
@@ -1,0 +1,139 @@
+# Spec: Reduce token usage of the pipeline skills
+
+**Date:** 2026-08-21
+**Status:** Approved by user (design review 2026-08-21)
+**Scope:** `.claude/agents/`, `.claude/skills/pipeline-*`, `.claude/rules/`, `CLAUDE.md`
+**Goal:** Cut weighted token usage per feature by 50–70% with no loss of output quality.
+
+---
+
+## 1. Measured baseline
+
+Source: session transcripts for the dataset-metadata feature (2026-08-19 to 2026-08-21),
+five sessions, main loop + subagents.
+
+| Metric | Value |
+|---|---|
+| Model turns | ~2,300 |
+| Cache-read tokens | ~250M |
+| Cache-write tokens | ~18M |
+| Output tokens | ~2.4M |
+| API-equivalent cost | ~$890 |
+
+Cost drivers, ranked:
+
+1. **Review-loop multiplication.** Plan review ran 7 passes. Each pass dispatched ~5
+   fresh Explore agents plus a planner resolver. One session (29 subagents) ≈ $300
+   equivalent.
+2. **Fixed entry fee per subagent.** CLAUDE.md + all 7 rules files (~3,400 lines,
+   ~30k tokens) auto-load into every dispatch. Agent defs then instruct a second
+   read of `.claude/rules/`. Estimated ~70M of the 250M cache reads.
+3. **Repeated heavyweight validation.** One builder ran the full test suite ~10
+   times (150 turns at ~170k context each). Tester runs 8 gates; the pre-PR gate
+   reruns 2 of them; GitHub CI reruns all of them.
+4. **Top-tier model everywhere.** All agents, including mechanical roles, ran on
+   Opus-class models.
+
+## 2. Changes
+
+### Group A — Model tiering
+
+| File | Change |
+|---|---|
+| `.claude/agents/tester.md` | Add `model: sonnet` to frontmatter |
+| `.claude/agents/shipper.md` | Add `model: sonnet` to frontmatter |
+| `.claude/skills/pipeline-spec/SKILL.md` | Review-lens Explore dispatches pass `model: sonnet` |
+| `.claude/skills/pipeline-implement/SKILL.md` | Same for plan-review Explore dispatches |
+
+`builder`, `planner`, `reviewer` keep the session model (no frontmatter change).
+
+Rationale: tester and shipper execute written checklists (gates, git mechanics).
+Review-lens agents scan documents against one named criterion. None of these
+need the top tier. Officially supported via the `model:` frontmatter key.
+
+### Group B — Convergence caps on review loops
+
+Applies to `pipeline-spec` and `pipeline-implement` SKILL.md files.
+
+1. Hard cap: **3 review passes** per artifact. On findings after pass 3, HOLD and
+   ask the user instead of running pass 4.
+2. Pass 1 is the only full-panel pass (all lenses, whole document).
+3. Pass 2+ are **delta passes**: at most 2 agents, and they review only the
+   sections changed since the previous pass (the resolver lists changed sections).
+4. Early exit: a pass whose findings require no change to the artifact ends
+   the loop.
+
+### Group C — Cut the fixed entry fee
+
+1. **Slim the 7 rules files** from ~3,400 to ~1,000 always-loaded lines:
+   - Keep in each file: the Quick Reference table plus rules not derivable
+     from it.
+   - Move worked examples, long code blocks, and "why" prose to
+     `.claude/rules/references/{topic}.md` files, loaded only on demand.
+   - Remove content duplicated between files (e.g., return-value visibility is
+     stated in both `code-style.md` and `surveycore-conventions.md`); one source
+     of truth, others point to it.
+   - Remove content the agent can read from the repo itself (`.lintr`,
+     `.editorconfig` contents).
+2. **Point, do not re-read**: agent defs (`builder.md`, `tester.md`,
+   `reviewer.md`) drop the "Read: .claude/rules/" instruction. The rules
+   auto-load; a second read doubles the cost. Each agent def instead names the
+   on-demand reference files relevant to its role and when to read them.
+3. **CLAUDE.md**: no structural change (already 101 lines).
+
+Constraint: no rule may be deleted, only moved or deduplicated. A rule that
+moves to a reference file must be reachable via an explicit pointer that states
+when to read it.
+
+### Group D — Test-run and output discipline
+
+1. `builder.md`: iterate with `devtools::test(filter = "<file>")` on the touched
+   test files. Run the full suite at most twice per PR: once before handoff,
+   once after a BLOCK fix.
+2. `r-package-profile.md`: every gate command writes full output to a log file
+   under the run workspace and returns a filtered summary to context
+   (`tail`/`grep` for `FAIL|ERROR|WARNING` and the results line). The full log
+   path is recorded in `audit.md` for diagnosis.
+3. `pipeline-ship/SKILL.md` BLOCK handling: on tester BLOCK, **continue the same
+   builder agent** (SendMessage with the BLOCK body) instead of dispatching a
+   fresh builder. A fresh dispatch is used only if the original agent is gone.
+   Cap unchanged: 3 cycles, then HOLD.
+
+### Group E — Gate deduplication
+
+1. **Remove `pkgcheck::pkgcheck()` entirely** (gate 6 in
+   `r-package-profile.md`). User decision 2026-08-21: not submitting to
+   rOpenSci; the check is not needed. Renumber the remaining gates.
+2. **Skip the duplicate pre-PR rerun** in `pipeline-ship` Step 2e.5: the tester
+   records `git rev-parse HEAD^{tree}` in `audit.md`. If the tree hash at the
+   pre-PR gate matches the audit's hash, skip the rerun (it already passed on
+   this exact tree). If the hash differs, run the gate as today.
+3. Baseline check, post-merge regression check, and GitHub CI are unchanged.
+
+## 3. What does not change
+
+- builder, planner, reviewer stay on the session model.
+- Every remaining gate still runs at least once per PR; CI remains the backstop.
+- The builder/tester information isolation model (spec vs test-spec) is untouched.
+- Snapshot rules, tolerances, and coverage floors are untouched.
+- No R source or test file changes.
+
+## 4. Validation
+
+1. After implementation, run the pipeline on one small real change
+   (Tier 3-sized).
+2. Profile its transcripts with the same script
+   (scratchpad `usage_profile.py`) and compare per-stage turns, cache reads,
+   cache writes, and output tokens against Section 1.
+3. Check `/usage` attribution after the run.
+4. Success: ≥50% reduction in weighted usage; all gates pass; review verdicts
+   unchanged in kind (no quality regression the reviewer or CI catches).
+
+## 5. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Sonnet tester misjudges a borderline gate result | Gates are pass/fail commands; reviewer (top model) still cross-checks audit vs implementation |
+| Delta review passes miss a regression in unchanged sections | Pass 1 is always full-panel; reviewer reads all artifacts at ship time |
+| A moved rule stops being followed | Pointers name the trigger condition; validation run watches for style violations in the PR diff |
+| Tree-hash skip misses an environment-only change | Hash mismatch forces the rerun; CI still runs everything |

--- a/plans/spec-reduce-token-usage.md
+++ b/plans/spec-reduce-token-usage.md
@@ -99,6 +99,20 @@ when to read it.
    fresh builder. A fresh dispatch is used only if the original agent is gone.
    Cap unchanged: 3 cycles, then HOLD.
 
+**Added 2026-08-21 after validation** (the test run's tester spent 683
+turns polling — 60% of the run's cost):
+
+4. `.claude/scripts/run-gates.sh` runs all gates in ONE background
+   command, logs per gate, and prints one summary table plus the `Tree:`
+   hash. The tester starts it with `run_in_background` and waits for the
+   notification — `sleep`/`until` polling loops are banned in `tester.md`.
+5. The tester's Before column comes from baseline results passed in the
+   dispatch — reconstructing the pre-PR state is banned. `pipeline-simplified`
+   captures the baseline in the background (`--baseline` mode) while
+   planner-lite runs.
+6. Stale `.claude/rules/` re-read removed from `pipeline-simplified`'s
+   builder dispatch (missed by the Group C sweep).
+
 ### Group E — Gate deduplication
 
 1. **Remove `pkgcheck::pkgcheck()` entirely** (gate 6 in


### PR DESCRIPTION
## What

Cuts the weighted token cost of the pipeline skill family (~6x on a full plan→build→test→ship cycle) with no change to what gets verified — no R package code is touched.

## Changes

- **Model tiering** — tester, shipper, and review-lens Explore agents run on Sonnet; builder, planner, reviewer keep the session model
- **Review-loop caps** — max 3 passes; pass 1 full-panel, later passes 2-agent deltas with early exit
- **Rules slimming** — always-loaded rules cut 1,822 → 652 lines; worked examples moved to `.claude/references/` (on demand); agents no longer re-read auto-loaded rules
- **Run discipline** — builder full-suite budget (≤2/PR); all gate output through log files; BLOCK fixes continue the same builder agent
- **Gate dedup** — pkgcheck removed; pre-PR gate skipped when the audit's tree hash matches; `run-gates.sh` runs all gates in one background command

## Validation

Two live pipeline-simplified runs shipped PRs #155 and #156 on this config:
- Tester: 683 turns / 92M cache-read tokens → 45 turns / 1.4M (−93% / −98.5%)
- Builder context per turn: ~173k → ~48k tokens (−72%)
- Full cycle: ~$190 API-equivalent (old config, counterfactual) → ~$30

Spec and measured baseline: `plans/spec-reduce-token-usage.md`. Profiler: `.claude/scripts/usage-profile.py`.

## Checklist

- [x] Tests passing (`devtools::test()`)
- [x] R CMD check: 0 errors, 0 warnings (`devtools::check()`)
- [x] Roxygen docs — N/A (no R code changed)
- [x] `plans/error-messages.md` — N/A (no new errors/warnings)
- [x] `VENDORED.md` — N/A (no vendored code)
- [x] PR title is a valid Conventional Commit
- [x] PR targets `develop`, not `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)