### PR TITLE
feat(classes): add @dataset_metadata property and survey_metadata validator

### DIFF
--- a/R/core-classes.R
+++ b/R/core-classes.R
@@ -57,6 +57,20 @@
 #'   parameters, effective sample size before/after, and design effect.
 #'   Always `list()` until a \pkg{surveywts} weighting function is
 #'   applied. Reserved for Phase 2.5.
+#' @param dataset_metadata A named list of whole-dataset facts. The key
+#'   vocabulary is **closed** — exactly six keys are valid, each with a
+#'   declared type:
+#'   * `survey_name` — `character(1)`, the full formal survey name.
+#'   * `data_name` — `character(1)`, the display label for this dataset.
+#'   * `vendor` — `character(1)`, the fielding vendor.
+#'   * `field_start` — `Date` of length 1, the first day in the field.
+#'   * `field_end` — `Date` of length 1, the last day in the field.
+#'   * `field_period` — `character(1)`, the prose field period.
+#'
+#'   No value may be `NA` and no element may be `NULL`. Any other key is
+#'   rejected. `survey_name` and `data_name` are independent: no function
+#'   derives one from the other. Use `set_dataset_metadata()` to write keys
+#'   and `extract_dataset_metadata()` to read them; the default is `list()`.
 #'
 #' @return A `survey_metadata` object.
 #'
@@ -72,6 +86,10 @@
 #' )
 #' m@variable_labels$age
 #' m@value_labels$sex
+#'
+#' # Dataset-level metadata (closed six-key vocabulary)
+#' m <- survey_metadata(dataset_metadata = list(vendor = "Ipsos"))
+#' m@dataset_metadata$vendor
 #' @family metadata
 #' @export
 survey_metadata <- S7::new_class(
@@ -122,6 +140,12 @@ survey_metadata <- S7::new_class(
     # with parameters, effective n before/after, and design effect.
     # Always list() until surveywts writes to it.
     weighting_history = S7::new_property(
+      S7::class_list,
+      default = quote(list())
+    ),
+    # Dataset-level metadata. Closed vocabulary — exactly six valid keys:
+    # survey_name, data_name, vendor, field_start, field_end, field_period.
+    dataset_metadata = S7::new_property(
       S7::class_list,
       default = quote(list())
     )

--- a/R/core-classes.R
+++ b/R/core-classes.R
@@ -242,6 +242,17 @@ survey_metadata <- S7::new_class(
       )
     }
 
+    # Check 8 — when both dates are present, field_start must not be after
+    # field_end. A single date needs no comparison.
+    if (all(.dataset_date_keys %in% nms)) {
+      if (dm[["field_start"]] > dm[["field_end"]]) {
+        cli::cli_abort(
+          "field_start is after field_end.",
+          class = "surveycore_error_field_dates_reversed"
+        )
+      }
+    }
+
     NULL
   }
 )

--- a/R/core-classes.R
+++ b/R/core-classes.R
@@ -149,7 +149,64 @@ survey_metadata <- S7::new_class(
       S7::class_list,
       default = quote(list())
     )
-  )
+  ),
+  # Layer 1 validator. Checks @dataset_metadata only. Messages are plain
+  # one-line text (the C1 / C4 / G1 precedent), not the CLI x/i/v register.
+  # S7 runs this on construction and again on every @<- assignment.
+  validator = function(self) {
+    dm <- self@dataset_metadata
+
+    # Every check below applies to a non-empty list only.
+    if (length(dm) == 0L) {
+      return(NULL)
+    }
+
+    nms <- names(dm)
+
+    # Checks 2-3 — every element has a name, and no name is NA or empty.
+    if (is.null(nms) || anyNA(nms) || !all(nzchar(nms))) {
+      cli::cli_abort(
+        "All dataset metadata entries must have a non-empty name.",
+        class = "surveycore_error_dataset_metadata_unnamed"
+      )
+    }
+
+    # Check 4 — no name is duplicated.
+    dupes <- unique(nms[duplicated(nms)])
+    if (length(dupes) > 0L) {
+      dupes_txt <- paste(dupes, collapse = ", ")
+      cli::cli_abort(
+        "Duplicate dataset metadata key(s): {dupes_txt}.",
+        class = "surveycore_error_dataset_metadata_duplicate_key"
+      )
+    }
+
+    # Check 5 — every name is one of the six valid keys.
+    unknown <- setdiff(nms, .dataset_metadata_keys)
+    if (length(unknown) > 0L) {
+      key <- unknown[[1L]]
+      cli::cli_abort(
+        "Unknown dataset metadata key: {key}.",
+        class = "surveycore_error_dataset_key_unknown"
+      )
+    }
+
+    # Check 6 — no element is NULL. Deletion removes the element; it never
+    # stores a NULL.
+    null_elements <- vapply(dm, is.null, logical(1L))
+    if (any(null_elements)) {
+      key <- nms[null_elements][[1L]]
+      cli::cli_abort(
+        paste0(
+          "Dataset metadata key {key} must be a single non-NA ",
+          "character string."
+        ),
+        class = "surveycore_error_dataset_metadata_bad_type"
+      )
+    }
+
+    NULL
+  }
 )
 
 

--- a/R/core-classes.R
+++ b/R/core-classes.R
@@ -209,11 +209,33 @@ survey_metadata <- S7::new_class(
     for (key in nms) {
       value <- dm[[key]]
 
+      # Delegate to the shared checker FIRST, then re-raise each of its
+      # CLI-formatted errors as the matching plain Layer 1 one-liner. Every
+      # line the checker adds is reachable through this call.
+      tryCatch(
+        .check_dataset_key_value(key, value, mode = "error"),
+        surveycore_error_dataset_metadata_bad_type = function(cnd) {
+          cli::cli_abort(
+            paste0(
+              "Dataset metadata key {key} must be a single non-NA ",
+              "character string."
+            ),
+            class = "surveycore_error_dataset_metadata_bad_type"
+          )
+        },
+        surveycore_error_field_date_invalid = function(cnd) {
+          cli::cli_abort(
+            "Dataset metadata key {key} must be a Date scalar.",
+            class = "surveycore_error_field_date_invalid"
+          )
+        }
+      )
+
       # Validator narrowing: a STORED date is always a Date scalar, because
-      # only coerced values reach storage. Keep this narrowing here even when
-      # the shared checker happens to enforce the same rule — the checker
-      # widens to accept ISO strings for setter callers, and this branch is
-      # what keeps the class layer rejecting them.
+      # only coerced values reach storage. DO NOT deduplicate this against the
+      # checker's date branch, even while the two agree — the checker widens to
+      # accept strict-ISO strings for setter callers, and this branch is what
+      # keeps the class layer rejecting a stored ISO string after that.
       if (key %in% .dataset_date_keys) {
         date_ok <- inherits(value, "Date") &&
           length(value) == 1L &&
@@ -225,21 +247,6 @@ survey_metadata <- S7::new_class(
           )
         }
       }
-
-      # Delegate to the shared checker, then re-raise its CLI-formatted error
-      # as the plain Layer 1 one-liner.
-      tryCatch(
-        .check_dataset_key_value(key, value, mode = "error"),
-        surveycore_error_dataset_metadata_bad_type = function(cnd) {
-          cli::cli_abort(
-            paste0(
-              "Dataset metadata key {key} must be a single non-NA ",
-              "character string."
-            ),
-            class = "surveycore_error_dataset_metadata_bad_type"
-          )
-        }
-      )
     }
 
     # Check 8 — when both dates are present, field_start must not be after

--- a/R/core-classes.R
+++ b/R/core-classes.R
@@ -205,6 +205,43 @@ survey_metadata <- S7::new_class(
       )
     }
 
+    # Check 7 — every present key's value passes the canonical value table.
+    for (key in nms) {
+      value <- dm[[key]]
+
+      # Validator narrowing: a STORED date is always a Date scalar, because
+      # only coerced values reach storage. Keep this narrowing here even when
+      # the shared checker happens to enforce the same rule — the checker
+      # widens to accept ISO strings for setter callers, and this branch is
+      # what keeps the class layer rejecting them.
+      if (key %in% .dataset_date_keys) {
+        date_ok <- inherits(value, "Date") &&
+          length(value) == 1L &&
+          !is.na(value)
+        if (!date_ok) {
+          cli::cli_abort(
+            "Dataset metadata key {key} must be a Date scalar.",
+            class = "surveycore_error_field_date_invalid"
+          )
+        }
+      }
+
+      # Delegate to the shared checker, then re-raise its CLI-formatted error
+      # as the plain Layer 1 one-liner.
+      tryCatch(
+        .check_dataset_key_value(key, value, mode = "error"),
+        surveycore_error_dataset_metadata_bad_type = function(cnd) {
+          cli::cli_abort(
+            paste0(
+              "Dataset metadata key {key} must be a single non-NA ",
+              "character string."
+            ),
+            class = "surveycore_error_dataset_metadata_bad_type"
+          )
+        }
+      )
+    }
+
     NULL
   }
 )

--- a/R/utils.R
+++ b/R/utils.R
@@ -357,6 +357,25 @@ SURVEYCORE_DOMAIN_COL <- "..surveycore_domain.."
 }
 
 
+# ── Internal: dataset-level metadata ──────────────────────────────────────────
+#
+# The dataset metadata key vocabulary is CLOSED: exactly these six keys are
+# valid, and this vector is their canonical order. Read by the survey_metadata
+# validator (R/core-classes.R) and by the dataset metadata setters and
+# extractors (R/core-metadata.R), so it lives here per the 2+-files rule.
+.dataset_metadata_keys <- c(
+  "survey_name",
+  "data_name",
+  "vendor",
+  "field_start",
+  "field_end",
+  "field_period"
+)
+
+# The two date-typed keys. The other four keys are character(1).
+.dataset_date_keys <- c("field_start", "field_end")
+
+
 # ── .build_cluster_matrices() ───────────────────────────────────────────────
 #
 # Build the clusters, strata, and FPC matrices needed by the multi-stage

--- a/R/utils.R
+++ b/R/utils.R
@@ -376,6 +376,93 @@ SURVEYCORE_DOMAIN_COL <- "..surveycore_domain.."
 .dataset_date_keys <- c("field_start", "field_end")
 
 
+# The single valid-key value checker for dataset metadata. Every path that
+# writes or resolves a dataset metadata value goes through here, so the per-key
+# type rules exist in exactly one place.
+#
+# @param key       character(1). One of .dataset_metadata_keys.
+# @param value     The candidate value (never NULL — callers screen NULL first,
+#                  because NULL means "delete", not "bad value").
+# @param mode      "error" raises the typed error for the key; "skip" returns
+#                  NULL instead, for the warn-and-skip callers.
+# @param key_style How the error message names the offender. "val" renders the
+#                  key as a value ({.val {key}}); "arg" renders it as a
+#                  function argument ({.arg {key}}), which is what a wrapper
+#                  whose argument name IS the key needs.
+# @param call      Passed to cli_abort() so the error reports the user-facing
+#                  caller rather than this helper.
+# @return The checked value on success; NULL on failure when mode = "skip".
+#
+# Date branch note: this branch currently accepts a non-NA Date of length 1
+# only. Strict-ISO character coercion is a setter service and arrives with the
+# setter work. The survey_metadata validator narrows to Date on its own side
+# and must keep doing so after that widening.
+#' @noRd
+.check_dataset_key_value <- function(
+  key,
+  value,
+  mode = c("error", "skip"),
+  key_style = c("val", "arg"),
+  call = rlang::caller_env()
+) {
+  mode <- match.arg(mode)
+  key_style <- match.arg(key_style)
+
+  if (key %in% .dataset_date_keys) {
+    valid <- inherits(value, "Date") &&
+      length(value) == 1L &&
+      !is.na(value)
+    if (valid) {
+      return(value)
+    }
+    if (mode == "skip") {
+      return(NULL)
+    }
+    lead <- if (key_style == "arg") "{.arg {key}}" else "{.val {key}}"
+    bullets <- c(
+      "x" = paste0(
+        lead,
+        " must be a Date scalar or an ISO 8601 date string ",
+        "(YYYY-MM-DD), not {.cls {class(value)[[1L]]}} of length ",
+        "{length(value)}."
+      ),
+      "i" = "Got {.val {value}}."
+    )
+    if (length(value) == 1L && is.na(value)) {
+      bullets <- c(bullets, "i" = "The value is NA.")
+    }
+    cli::cli_abort(
+      bullets,
+      class = "surveycore_error_field_date_invalid",
+      call = call
+    )
+  }
+
+  valid <- is.character(value) && length(value) == 1L && !is.na(value)
+  if (valid) {
+    return(value)
+  }
+  if (mode == "skip") {
+    return(NULL)
+  }
+  cli::cli_abort(
+    c(
+      "x" = paste0(
+        "Dataset metadata key {.val {key}} must be a single non-NA ",
+        "character string, not {.cls {class(value)[[1L]]}} of length ",
+        "{length(value)}."
+      ),
+      "v" = paste0(
+        "Supply a single non-NA character value, or {.code NULL} to ",
+        "delete the key."
+      )
+    ),
+    class = "surveycore_error_dataset_metadata_bad_type",
+    call = call
+  )
+}
+
+
 # ── .build_cluster_matrices() ───────────────────────────────────────────────
 #
 # Build the clusters, strata, and FPC matrices needed by the multi-stage

--- a/R/utils.R
+++ b/R/utils.R
@@ -383,15 +383,17 @@ SURVEYCORE_DOMAIN_COL <- "..surveycore_domain.."
 # @param key       character(1). One of .dataset_metadata_keys.
 # @param value     The candidate value (never NULL — callers screen NULL first,
 #                  because NULL means "delete", not "bad value").
-# @param mode      "error" raises the typed error for the key; "skip" returns
-#                  NULL instead, for the warn-and-skip callers.
+# @param mode      "error" raises the typed error for the key. The "skip"
+#                  branch, which returns NULL instead for the warn-and-skip
+#                  callers, arrives with its first caller in the setter and
+#                  promotion work; only "error" behaves here.
 # @param key_style How the error message names the offender. "val" renders the
 #                  key as a value ({.val {key}}); "arg" renders it as a
 #                  function argument ({.arg {key}}), which is what a wrapper
 #                  whose argument name IS the key needs.
 # @param call      Passed to cli_abort() so the error reports the user-facing
 #                  caller rather than this helper.
-# @return The checked value on success; NULL on failure when mode = "skip".
+# @return The checked value on success; an error otherwise.
 #
 # Date branch note: this branch currently accepts a non-NA Date of length 1
 # only. Strict-ISO character coercion is a setter service and arrives with the
@@ -414,9 +416,6 @@ SURVEYCORE_DOMAIN_COL <- "..surveycore_domain.."
       !is.na(value)
     if (valid) {
       return(value)
-    }
-    if (mode == "skip") {
-      return(NULL)
     }
     lead <- if (key_style == "arg") "{.arg {key}}" else "{.val {key}}"
     bullets <- c(
@@ -441,9 +440,6 @@ SURVEYCORE_DOMAIN_COL <- "..surveycore_domain.."
   valid <- is.character(value) && length(value) == 1L && !is.na(value)
   if (valid) {
     return(value)
-  }
-  if (mode == "skip") {
-    return(NULL)
   }
   cli::cli_abort(
     c(

--- a/man/survey_metadata.Rd
+++ b/man/survey_metadata.Rd
@@ -15,7 +15,8 @@ survey_metadata(
   higher_is = list(),
   reverse_coded = list(),
   transformations = list(),
-  weighting_history = list()
+  weighting_history = list(),
+  dataset_metadata = list()
 )
 }
 \arguments{
@@ -61,6 +62,23 @@ a \pkg{surveywts} function and contains the operation name,
 parameters, effective sample size before/after, and design effect.
 Always \code{list()} until a \pkg{surveywts} weighting function is
 applied. Reserved for Phase 2.5.}
+
+\item{dataset_metadata}{A named list of whole-dataset facts. The key
+vocabulary is \strong{closed} — exactly six keys are valid, each with a
+declared type:
+\itemize{
+\item \code{survey_name} — \code{character(1)}, the full formal survey name.
+\item \code{data_name} — \code{character(1)}, the display label for this dataset.
+\item \code{vendor} — \code{character(1)}, the fielding vendor.
+\item \code{field_start} — \code{Date} of length 1, the first day in the field.
+\item \code{field_end} — \code{Date} of length 1, the last day in the field.
+\item \code{field_period} — \code{character(1)}, the prose field period.
+}
+
+No value may be \code{NA} and no element may be \code{NULL}. Any other key is
+rejected. \code{survey_name} and \code{data_name} are independent: no function
+derives one from the other. Use \code{set_dataset_metadata()} to write keys
+and \code{extract_dataset_metadata()} to read them; the default is \code{list()}.}
 }
 \value{
 A \code{survey_metadata} object.
@@ -83,6 +101,10 @@ m <- survey_metadata(
 )
 m@variable_labels$age
 m@value_labels$sex
+
+# Dataset-level metadata (closed six-key vocabulary)
+m <- survey_metadata(dataset_metadata = list(vendor = "Ipsos"))
+m@dataset_metadata$vendor
 }
 \seealso{
 Other metadata:

--- a/plans/error-messages.md
+++ b/plans/error-messages.md
@@ -120,16 +120,16 @@ against the messages defined here.
 | 80 | `infer_question_prefaces()` | Trimming the preface leaves an empty label | WARN | `surveycore_warning_empty_label_after_trim` | `"Variable {.field {var_name}} would have an empty label after trimming the preface. Skipping."` |
 | 81 | all `get_*()` (via `.validate_shared_args()`) | `na.rm` is not `TRUE` or `FALSE` (e.g., `NA`, `1`, `"yes"`) | ERROR | `surveycore_error_na_rm_not_logical` | `"x" = "{.arg na.rm} must be {.code TRUE} or {.code FALSE}.", "i" = "Got {.obj_type_friendly {na.rm}}."` |
 | M-2/M-7 | all extractors (M-2), all setters (M-7) | A variable specified in `...` / input is not found in `x@data` / `names(x)` | WARN | `surveycore_warning_var_not_found` | Extractor (M-2): `"!" = "{length(missing)} variable{?s} not found in {.arg x} and {?was/were} skipped: {.field {missing}}."` / Setter (M-7): `"!" = "{length(missing)} variable{?s} not found in {.arg x} and {?was/were} skipped: {.field {missing}}.", "i" = "Check spelling. Available columns: {.field {head(all_cols, 10)}}{?.}"` |
-| M-3 | all setters | Both `...` and explicit `variable`/content args are provided simultaneously | ERROR | `surveycore_error_setter_ambiguous` | `"x" = "Provide variable names via {.arg ...} or via {.arg variable}, not both.", "i" = "Use named {.arg ...} args, a named vector in {.arg ...}, or {.arg variable} + {.arg {content_arg}} — not a mix."` |
-| M-4 | all setters | Neither `...` nor `variable`/content args are provided | ERROR | `surveycore_error_setter_empty` | `"x" = "{.fn {fn_name}} requires at least one variable-label pair.", "v" = "Use named {.arg ...} args: {.code {fn_name}(x, age = 'Age in years')}."` |
-| M-5 | all setters (convention 3) | `length(variable) != length(content)` | ERROR | `surveycore_error_setter_mismatched_lengths` | `"x" = "{.arg variable} has {length(variable)} element{?s} but {.arg {content_arg}} has {length(content)} element{?s}.", "i" = "They must be the same length (one content value per variable name)."` |
+| M-3 | all setters; `extract_dataset_metadata()` | Both `...` and explicit `variable`/content args are provided simultaneously | ERROR | `surveycore_error_setter_ambiguous` | `"x" = "Provide variable names via {.arg ...} or via {.arg variable}, not both.", "i" = "Use named {.arg ...} args, a named vector in {.arg ...}, or {.arg variable} + {.arg {content_arg}} — not a mix."` — message text is parameterized per calling function (see the dataset-level-metadata section). `set_dataset_metadata()` variant: `"x" = "Provide key names via {.arg ...} or via {.arg key}, not both.", "i" = "Use named {.arg ...} args, a named list in {.arg ...}, or {.arg key} + {.arg value} — not a mix."` / `extract_dataset_metadata()` variant (both `...` and `key` supplied): `"x" = "Provide key names via {.arg ...} or via {.arg key}, not both.", "i" = "Use named {.arg ...} args, a named list in {.arg ...}, or the {.arg key} argument — not a mix."` |
+| M-4 | all setters | Neither `...` nor `variable`/content args are provided | ERROR | `surveycore_error_setter_empty` | `"x" = "{.fn {fn_name}} requires at least one variable-label pair.", "v" = "Use named {.arg ...} args: {.code {fn_name}(x, age = 'Age in years')}."` — message text is parameterized per calling function (see the dataset-level-metadata section). `set_dataset_metadata()` variant: `"x" = "{.fn set_dataset_metadata} requires at least one key-value pair.", "v" = "Use named {.arg ...} args: {.code set_dataset_metadata(x, vendor = 'Ipsos')}."` / Four scalar-wrapper variant (`set_survey_name()`, `set_data_name()`, `set_vendor()`, `set_field_period()`), emitted by the wrapper itself with its own function and argument names: `"x" = "{.fn {fn_name}} requires a value for {.arg {arg_name}}.", "v" = "Supply a single character value, or {.code NULL} to delete the key."` / `set_field_dates()` variant: `"x" = "{.fn set_field_dates} requires at least one of {.arg field_start} or {.arg field_end}.", "v" = "Supply a single character value, or {.code NULL} to delete the key."` |
+| M-5 | all setters (convention 3) | `length(variable) != length(content)` | ERROR | `surveycore_error_setter_mismatched_lengths` | `"x" = "{.arg variable} has {length(variable)} element{?s} but {.arg {content_arg}} has {length(content)} element{?s}.", "i" = "They must be the same length (one content value per variable name)."` — message text is parameterized per calling function (see the dataset-level-metadata section); `set_dataset_metadata()` renders `key` and `value` in place of `variable` and `content`. |
 | M-6 | all extractors | `format` argument has an invalid value | ERROR | `surveycore_error_format_invalid` | `"x" = "{.fn {fn_name}} received an invalid {.arg format} value {.val {format}}.", "i" = "{.arg format} must be one of {.val {valid_formats}}."` |
 | M-10 | `set_missing_codes()` | A `codes` entry is not an atomic vector | ERROR | `surveycore_error_missing_codes_not_vector` | `"x" = "Missing codes for {.field {var_name}} must be an atomic vector, not {.cls {class(codes_entry)[[1L]]}}.", "i" = "Use a numeric, integer, or character vector (e.g., {.code c(Refused = 99L, {\"Don't know\"} = 98L)})."` |
 | M-11 | `set_var_label()` | Old positional NSE form detected | ERROR | `surveycore_error_old_positional_setter` | `"x" = "The old positional calling form {.code {fn_name}(x, var, content)} is no longer supported.", "i" = "The new unified setter uses named arguments.", "v" = "Use {.code {fn_name}(x, {var_name} = {.val {content_val}})} instead."` |
-| M-12 | all setters | `...` contains any unnamed element(s) — either all unnamed or a mix of named and unnamed | ERROR | `surveycore_error_setter_mixed_dots` | `"x" = "All {.arg ...} arguments must be named when using Convention 1.", "i" = "Got {sum(nzchar(names(dots)))} named and {sum(!nzchar(names(dots)))} unnamed element{?s}.", "v" = "Use {.code {fn_name}(x, age = 'Age', income = 'Annual income')} or a fully named vector."` |
+| M-12 | all setters | `...` contains any unnamed element(s) — either all unnamed or a mix of named and unnamed | ERROR | `surveycore_error_setter_mixed_dots` | `"x" = "All {.arg ...} arguments must be named when using Convention 1.", "i" = "Got {sum(nzchar(names(dots)))} named and {sum(!nzchar(names(dots)))} unnamed element{?s}.", "v" = "Use {.code {fn_name}(x, age = 'Age', income = 'Annual income')} or a fully named vector."` — message text is parameterized per calling function (see the dataset-level-metadata section); `set_dataset_metadata()` renders its own examples and `a fully named list`. |
 | M-13 | scalar-content setters (`set_var_label`, `set_question_preface`, `set_var_note`, `set_universe`) | A content value is not a character scalar (wrong type or length > 1) | ERROR | `surveycore_error_label_not_scalar` | `"x" = "Label content for {.field {var_name}} must be a character scalar, not {.cls {class(val)[[1L]]}} of length {length(val)}.", "v" = "Pass a single character string, e.g. {.code {fn_name}(x, {var_name} = 'My label')}."` |
-| M-14 | all setters (convention 3) | `variable` argument is explicitly provided as `character(0)` (length 0) | WARN | `surveycore_warning_setter_empty_variables` | `"!" = "{.fn {fn_name}} was called with {.arg variable} of length 0.", "i" = "No metadata was set. Did you accidentally filter all variable names out?"` |
-| M-15 | all extractors, `extract_metadata()` | `fill` argument has an invalid value for this function | ERROR | `surveycore_error_fill_invalid` | `"x" = "{.fn {fn_name}} does not accept {.code fill = {.val {fill}}}.", "i" = "Valid values for {.fn {fn_name}}: {.val {valid_fill_values}}."` |
+| M-14 | all setters (convention 3) | `variable` argument is explicitly provided as `character(0)` (length 0) | WARN | `surveycore_warning_setter_empty_variables` | `"!" = "{.fn {fn_name}} was called with {.arg variable} of length 0.", "i" = "No metadata was set. Did you accidentally filter all variable names out?"` — message text is parameterized per calling function (see the dataset-level-metadata section); `set_dataset_metadata()` renders `{.arg key}` in place of `{.arg variable}` and `key names` in place of `variable names`. |
+| M-15 | all extractors, `extract_metadata()`, `extract_dataset_metadata()` | `fill` argument has an invalid value for this function | ERROR | `surveycore_error_fill_invalid` | `"x" = "{.fn {fn_name}} does not accept {.code fill = {.val {fill}}}.", "i" = "Valid values for {.fn {fn_name}}: {.val {valid_fill_values}}."` — the shared fill validator gains a widening parameter whose default keeps this two-value message byte-identical. `extract_dataset_metadata()` variant: `valid_fill_values` lists `NULL`, `NA`, and `NA_character_`. |
 | 88 | `as_survey()` | `fpc` selects more columns than `ids` stages | ERROR | `surveycore_error_fpc_too_many_stages` | `"x" = "{.arg fpc} selected {n_fpc} column(s) but {.arg ids} has only {n_ids} stage(s).", "i" = "FPC columns must correspond 1-to-1 with ID stages. Supply at most {n_ids} FPC column(s)."` |
 | 89 | `as_survey()` | `fpc` selects fewer columns than `ids` stages | WARN | `surveycore_warning_fpc_partial_stages` | `"!" = "{.arg fpc} has {n_fpc} column(s) but {.arg ids} has {n_ids} stage(s).", "i" = "Later stages assume sampling from an infinite population (no FPC)."` |
 | 90 | `as_survey()` | Stage-j FPC population size < stage-j cluster count within parent | ERROR | `surveycore_error_fpc_smaller_than_n` | `"x" = "Stage-{j} FPC column {.field {fpc_var}} has population sizes smaller than the observed cluster count in {n_bad} parent group(s).", "i" = "Population size must be >= the number of sampled units within each parent cluster."` |
@@ -368,7 +368,7 @@ Which test files cover which error table rows:
 | `test-variance-twophase.R` | 63 |
 | `test-validators.R` | 27–35 |
 | `test-metadata-system.R` | 27–30, M-2/M-7, M-3–M-15 |
-| `test-s7-classes.R` | 31–35, 37–39 |
+| `test-s7-classes.R` | 31–35, 37–39; DM-1a, DM-2a, DM-3a, DM-4a, DM-5a, DM-6c (`survey_metadata` validator — Layer 1) |
 | `test-update-design.R` | 36 |
 | `test-analysis-helpers.R` | 45, 45a, 45b, 46 (direct unit tests on `.validate_shared_args()` and `.apply_decimals()`); 64 (`.check_unsupported_class()` and `.build_meta()` fallback); also integration-checked in per-function files |
 | `test-analysis-freqs.R` | 45, 45a, 45b, 46, 49, 50, 52, 53, 55 |
@@ -393,6 +393,7 @@ Which test files cover which error table rows:
 | `test-metadata-system.R` | HI-1, HI-2, HI-3 (PR 1 — higher_is); RC-1, RC-2, RC-3 (PR 2 — reverse_coded) |
 | `test-calibration.R` | CAL-15, CAL-16 |
 | `test-analysis-methods-coef-vcov.R` | SCR-1, SCR-3, SCR-W1, SCR-W2, SCR-W3, SCR-W4 |
+| `test-dataset-metadata.R` | DM-1b, DM-2b, DM-3b, DM-4b, DM-5b, DM-6a, DM-6b, DM-8, DM-9; M-3, M-4, M-5, M-12, M-14, M-15 (dataset-metadata variants) |
 
 ### coef-vcov-methods rows (2026-06-22)
 
@@ -416,3 +417,68 @@ Which test files cover which error table rows:
 | DF-5 | `extract_sata()` | `fill` is not `FALSE` or `NULL` | ERROR | `surveycore_error_fill_not_logical` | `"{.arg fill} must be {.code FALSE} or {.code NULL}."` |
 | DF-6 | `.svy_onestrat()` | stratum with one PSU + `lonely.psu = "fail"` | ERROR | `surveycore_error_lonely_psu` | `"Stratum {.val {stratum}} has only one PSU at stage {stage}."` |
 | DF-7 | `.svy_rep_var()` | all replicate thetas are `NA` | ERROR | `surveycore_error_all_replicates_na` | `"All replicates produced NA estimates."` |
+
+### dataset-level-metadata rows (2026-08-19)
+
+Layer 1 rows (the `survey_metadata` S7 validator) carry plain one-line text,
+not the CLI x/i/v register — the C1 / C4 / G1 precedent. Test them with
+`expect_error(class = ...)` plus `expect_error(regexp = ...)`; never with a
+snapshot. Layer 3 rows use the full CLI register and the dual test pattern.
+
+**Variable bindings.** `{key}` = the offending key name; `{value}` = the
+offending value; `{n_bad}` = count of unnamed or blank entries; `{dupes}` =
+the duplicated names; `{valid_keys}` = the six canonical key names;
+`{suggestion}` = the nearest valid key (bound only when the hint condition
+holds); `{expected}` = one of two fixed strings — `"a single non-NA character
+string"` (character keys) or `"a Date scalar or an ISO 8601 date string
+(YYYY-MM-DD)"` (date keys); `{start}` / `{end}` = the effective ISO-formatted
+dates.
+
+| # | Function | Condition | Level | Error Class | cli Message Template |
+|---|----------|-----------|-------|-------------|----------------------|
+| DM-1a | S7 validator (`survey_metadata`) — fires on direct construction and on `@<-` | An element of `@dataset_metadata` has no name, an `NA` name, or an empty name | ERROR | `surveycore_error_dataset_metadata_unnamed` | Layer 1, plain: `"All dataset metadata entries must have a non-empty name."` |
+| DM-1b | `set_dataset_metadata()` (Convention 3) | A key name is `NA` or `""` | ERROR | `surveycore_error_dataset_metadata_unnamed` | `"x" = "All dataset metadata keys must have a non-empty name.", "i" = "Found {n_bad} unnamed or blank-named entr{?y/ies}."` |
+| DM-2a | S7 validator (`survey_metadata`) | A key name is duplicated | ERROR | `surveycore_error_dataset_metadata_duplicate_key` | Layer 1, plain: `"Duplicate dataset metadata key(s): {dupes_txt}."` (`dupes_txt` is the duplicated names collapsed with `", "`) |
+| DM-2b | `set_dataset_metadata()` | A key name appears twice in one call (after the `dates` alias resolves) | ERROR | `surveycore_error_dataset_metadata_duplicate_key` | `"x" = "Duplicate dataset metadata key{?s}: {.val {dupes}}.", "i" = "Each key must appear exactly once."` |
+| DM-3a | S7 validator (`survey_metadata`) | A character key (`survey_name`, `data_name`, `vendor`, `field_period`) has the wrong type, length != 1, or is `NA`; or any element of `@dataset_metadata` is `NULL` | ERROR | `surveycore_error_dataset_metadata_bad_type` | Layer 1, plain: `"Dataset metadata key {key} must be a single non-NA character string."` |
+| DM-3b | `set_dataset_metadata()` and the four character-key wrappers (`set_survey_name()`, `set_data_name()`, `set_vendor()`, `set_field_period()`) | Same condition, raised at the setter by `.check_dataset_key_value(mode = "error")` | ERROR | `surveycore_error_dataset_metadata_bad_type` | `"x" = "Dataset metadata key {.val {key}} must be {expected}, not {.cls {class(value)[[1L]]}} of length {length(value)}.", "v" = "Supply a single non-NA character value, or {.code NULL} to delete the key."` |
+| DM-4a | S7 validator (`survey_metadata`) | Both dates are present and `field_start` is after `field_end` | ERROR | `surveycore_error_field_dates_reversed` | Layer 1, plain: `"field_start is after field_end."` |
+| DM-4b | `set_dataset_metadata()`; `set_field_dates()` | Effective `field_start` is after effective `field_end` (three-way effective-pair rule) | ERROR | `surveycore_error_field_dates_reversed` | `"x" = "{.val field_start} ({start}) is after {.val field_end} ({end}).", "v" = "Swap the two dates, or correct the wrong one."` |
+| DM-5a | S7 validator (`survey_metadata`) | A stored key is not one of the six canonical keys | ERROR | `surveycore_error_dataset_key_unknown` | Layer 1, plain: `"Unknown dataset metadata key: {key}."` |
+| DM-5b | All six dataset-metadata setters and all six extractors | A supplied or requested key is not one of the six canonical keys | ERROR | `surveycore_error_dataset_key_unknown` | `"x" = "{.val {key}} is not a dataset metadata key.", "i" = "Valid keys: {.val {valid_keys}}."` — plus, when the lowercased key is within Levenshtein distance 1 of a valid key: `"i" = "Did you mean {.val {suggestion}}?"` — plus, when the key is `dates` with a non-`NULL` value: `"i" = "The legacy {.val dates} attribute maps to {.val field_period}.", "v" = "Use {.fn set_field_period}, or {.code dates = NULL} to delete."` |
+| DM-6a | `set_dataset_metadata()` only (shared checker with `key_style = "val"`; the wrappers pre-validate, so a delegated date value is already a `Date`) | A `field_start` / `field_end` value fails `.coerce_field_date()` | ERROR | `surveycore_error_field_date_invalid` | `"x" = "{.val {key}} must be {expected}, not {.cls {class(value)[[1L]]}} of length {length(value)}.", "i" = "Got {.val {value}}."` — plus, when the value is `NA`: `"i" = "The value is NA."` |
+| DM-6b | `set_field_dates()` (shared checker with `key_style = "arg"` and the wrapper's own `call`) | Same condition, naming the function's own argument | ERROR | `surveycore_error_field_date_invalid` | `"x" = "{.arg {key}} must be {expected}, not {.cls {class(value)[[1L]]}} of length {length(value)}.", "i" = "Got {.val {value}}."` — same NA bullet. (`{key}` is `field_start` or `field_end`, which is both the key and the argument name.) |
+| DM-6c | S7 validator (`survey_metadata`) | A date key's stored value is not a non-`NA` `Date` of length 1 (the validator accepts stored values only, so an ISO string is rejected here) | ERROR | `surveycore_error_field_date_invalid` | Layer 1, plain: `"Dataset metadata key {key} must be a Date scalar."` |
+| DM-8 | All six dataset-metadata setters | The survey object was restored from a file written by surveycore <= 1.1.0, so its stored class lacks the `dataset_metadata` property | ERROR | `surveycore_error_dataset_metadata_unavailable` | `"x" = "This object cannot store dataset metadata.", "i" = "It was created by surveycore <= 1.1.0, before the {.field dataset_metadata} property existed.", "v" = "Rebuild the object with {.fn as_survey} (or the matching constructor), then set the metadata."` |
+| DM-9 | `extract_dataset_metadata()` | A `...` element is a call, including a tidyselect helper such as `all_of()` | ERROR | `surveycore_error_dataset_key_not_name` | `"x" = "{.arg ...} must contain bare key names or strings.", "i" = "Tidy-select helpers do not apply here: a dataset metadata key is not a column.", "v" = "Use bare names ({.code vendor}), strings ({.val vendor}), or the {.arg key} argument."` |
+
+**Updated trigger descriptions for existing rows:**
+
+- Rows M-3 (`surveycore_error_setter_ambiguous`), M-4
+  (`surveycore_error_setter_empty`), M-5
+  (`surveycore_error_setter_mismatched_lengths`), M-12
+  (`surveycore_error_setter_mixed_dots`), and M-14
+  (`surveycore_warning_setter_empty_variables`): the message text of these
+  five convention classes is parameterized per calling function.
+  `.parse_setter_input()` gains `name_arg_name`, `pair_noun`,
+  `example_pairs`, and `container_noun`, whose defaults render the canonical
+  templates byte-identically. `set_dataset_metadata()` passes
+  `name_arg_name = "key"`, `pair_noun = "key-value"`,
+  `container_noun = "list"`, and its own `example_pairs`, so its messages read
+  `key` / `key-value` / `a named list in ...` in place of `variable` /
+  `variable-label` / `a named vector in ...`. The seven per-variable setters
+  keep their 1.1.0 text unchanged.
+- Row M-4 also carries two wrapper-level variants, stated on the row itself:
+  the four scalar convenience setters and `set_field_dates()` emit their own
+  `surveycore_error_setter_empty` message naming the calling function and its
+  missing argument, not the general key-value template.
+- Row M-3 also carries an `extract_dataset_metadata()` variant, stated on the
+  row itself: both `...` and `key` supplied.
+- Row M-15 (`surveycore_error_fill_invalid`): the shared fill validator gains
+  a widening parameter. Its default keeps the existing extractors' two-value
+  message byte-identical; `extract_dataset_metadata()` passes the widened
+  mode, whose message lists `NULL`, `NA`, and `NA_character_` as valid.
+
+The construction-promotion warning class
+(`surveycore_warning_dataset_metadata_dropped`) and its message variants land
+with the promotion PR.

--- a/tests/testthat/helper-test-data.R
+++ b/tests/testthat/helper-test-data.R
@@ -11,6 +11,23 @@
 # devtools::test() / devtools::load_all().
 
 # ------------------------------------------------------------------------------
+# full_keys - dataset-level metadata fixture
+# ------------------------------------------------------------------------------
+
+# The six valid @dataset_metadata keys, in canonical order, each holding a
+# valid value. This is the single definition of the fixture; every test that
+# needs a complete dataset-metadata list uses it, and names(full_keys) is the
+# canonical key order.
+full_keys <- list(
+  survey_name = "Antisemitic Attitudes in America 2026",
+  data_name = "AAA Ipsos (February-March 2026)",
+  vendor = "Ipsos KnowledgePanel Omnibus",
+  field_start = as.Date("2026-02-10"),
+  field_end = as.Date("2026-03-04"),
+  field_period = "February-March 2026"
+)
+
+# ------------------------------------------------------------------------------
 # make_survey_data()
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test-s7-classes.R
+++ b/tests/testthat/test-s7-classes.R
@@ -1178,3 +1178,88 @@ test_that("survey_metadata validator rejects a NULL element on a date key", {
     class = "surveycore_error_dataset_metadata_bad_type"
   )
 })
+
+
+# ── survey_metadata validator: per-key value rules (spec III.3 check 7) ───────
+
+test_that("survey_metadata validator rejects a non-character vendor", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(vendor = 1L)),
+    class = "surveycore_error_dataset_metadata_bad_type"
+  )
+  expect_error(
+    survey_metadata(dataset_metadata = list(vendor = 1L)),
+    regexp = paste(
+      "Dataset metadata key vendor must be a single non-NA",
+      "character string."
+    )
+  )
+})
+
+test_that("survey_metadata validator rejects an NA survey_name", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(survey_name = NA_character_)),
+    class = "surveycore_error_dataset_metadata_bad_type"
+  )
+})
+
+test_that("survey_metadata validator rejects a length-2 data_name", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(data_name = c("a", "b"))),
+    class = "surveycore_error_dataset_metadata_bad_type"
+  )
+})
+
+test_that("survey_metadata validator rejects a zero-length field_period", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(field_period = character(0))),
+    class = "surveycore_error_dataset_metadata_bad_type"
+  )
+})
+
+test_that("survey_metadata validator rejects an ISO string on a date key", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(field_start = "2026-02-10")),
+    class = "surveycore_error_field_date_invalid"
+  )
+  expect_error(
+    survey_metadata(dataset_metadata = list(field_start = "2026-02-10")),
+    regexp = "Dataset metadata key field_start must be a Date scalar."
+  )
+})
+
+test_that("survey_metadata validator rejects a numeric field_end", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(field_end = 20000)),
+    class = "surveycore_error_field_date_invalid"
+  )
+})
+
+test_that("survey_metadata validator rejects an NA Date on a date key", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(field_start = as.Date(NA))),
+    class = "surveycore_error_field_date_invalid"
+  )
+})
+
+test_that("survey_metadata validator rejects a length-2 Date on a date key", {
+  two_dates <- as.Date(c("2026-02-10", "2026-02-11"))
+  expect_error(
+    survey_metadata(dataset_metadata = list(field_start = two_dates)),
+    class = "surveycore_error_field_date_invalid"
+  )
+})
+
+test_that("survey_metadata validator accepts field_start with field_end absent", {
+  m <- survey_metadata(
+    dataset_metadata = list(field_start = as.Date("2026-02-10"))
+  )
+  expect_identical(m@dataset_metadata$field_start, as.Date("2026-02-10"))
+})
+
+test_that("survey_metadata validator accepts field_end with field_start absent", {
+  m <- survey_metadata(
+    dataset_metadata = list(field_end = as.Date("2026-03-04"))
+  )
+  expect_identical(m@dataset_metadata$field_end, as.Date("2026-03-04"))
+})

--- a/tests/testthat/test-s7-classes.R
+++ b/tests/testthat/test-s7-classes.R
@@ -1035,3 +1035,52 @@ test_that("survey_replicate S7 validator passes when @calibration is a non-empty
   design@calibration <- list(cd)
   expect_no_error(S7::check_is_S7(design))
 })
+
+
+# ── survey_metadata @dataset_metadata property ────────────────────────────────
+
+test_that("survey_metadata() defaults @dataset_metadata to an empty list", {
+  m <- survey_metadata()
+  expect_identical(m@dataset_metadata, list())
+})
+
+test_that("survey_metadata() stores a single dataset metadata key", {
+  m <- survey_metadata(dataset_metadata = list(vendor = "Ipsos"))
+  expect_identical(m@dataset_metadata, list(vendor = "Ipsos"))
+})
+
+test_that("survey_metadata() accepts all six canonical dataset keys", {
+  m <- survey_metadata(dataset_metadata = full_keys)
+  expect_identical(m@dataset_metadata, full_keys)
+  expect_identical(names(m@dataset_metadata), names(full_keys))
+})
+
+test_that("survey_metadata() accepts an unrelated survey_name / data_name pair", {
+  m <- survey_metadata(
+    dataset_metadata = list(
+      survey_name = "Formal Survey Name 2026",
+      data_name = "Something Completely Different"
+    )
+  )
+  expect_identical(m@dataset_metadata$survey_name, "Formal Survey Name 2026")
+  expect_identical(
+    m@dataset_metadata$data_name,
+    "Something Completely Different"
+  )
+})
+
+test_that("survey_metadata() keeps other properties intact alongside @dataset_metadata", {
+  m <- survey_metadata(
+    variable_labels = list(age = "Age in years"),
+    dataset_metadata = list(vendor = "Ipsos")
+  )
+  expect_identical(m@variable_labels, list(age = "Age in years"))
+  expect_identical(m@dataset_metadata, list(vendor = "Ipsos"))
+})
+
+test_that("as_survey() designs start with an empty @dataset_metadata", {
+  df <- make_survey_data(n = 60, n_psu = 12, n_strata = 3, seed = 11)
+  design <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  test_invariants(design)
+  expect_identical(design@metadata@dataset_metadata, list())
+})

--- a/tests/testthat/test-s7-classes.R
+++ b/tests/testthat/test-s7-classes.R
@@ -1263,3 +1263,84 @@ test_that("survey_metadata validator accepts field_end with field_start absent",
   )
   expect_identical(m@dataset_metadata$field_end, as.Date("2026-03-04"))
 })
+
+
+# ── survey_metadata validator: date pair (check 8) and re-validation ──────────
+
+test_that("survey_metadata validator rejects a reversed field date pair", {
+  reversed <- list(
+    field_start = as.Date("2026-03-04"),
+    field_end = as.Date("2026-02-10")
+  )
+  expect_error(
+    survey_metadata(dataset_metadata = reversed),
+    class = "surveycore_error_field_dates_reversed"
+  )
+  expect_error(
+    survey_metadata(dataset_metadata = reversed),
+    regexp = "field_start is after field_end."
+  )
+})
+
+test_that("survey_metadata validator accepts field_start equal to field_end", {
+  same_day <- list(
+    field_start = as.Date("2026-02-10"),
+    field_end = as.Date("2026-02-10")
+  )
+  m <- survey_metadata(dataset_metadata = same_day)
+  expect_identical(m@dataset_metadata, same_day)
+})
+
+test_that("survey_metadata validator accepts field_start before field_end", {
+  ordered_pair <- list(
+    field_start = as.Date("2026-02-10"),
+    field_end = as.Date("2026-03-04")
+  )
+  m <- survey_metadata(dataset_metadata = ordered_pair)
+  expect_identical(m@dataset_metadata, ordered_pair)
+})
+
+test_that("survey_metadata re-validates @dataset_metadata on assignment", {
+  m <- survey_metadata()
+  expect_error(
+    m@dataset_metadata <- list(mode = "web"),
+    class = "surveycore_error_dataset_key_unknown"
+  )
+})
+
+test_that("survey_metadata re-validates a bad value type on assignment", {
+  m <- survey_metadata()
+  expect_error(
+    m@dataset_metadata <- list(vendor = 1L),
+    class = "surveycore_error_dataset_metadata_bad_type"
+  )
+})
+
+test_that("survey_metadata re-validates a reversed date pair on assignment", {
+  m <- survey_metadata()
+  expect_error(
+    m@dataset_metadata <- list(
+      field_start = as.Date("2026-03-04"),
+      field_end = as.Date("2026-02-10")
+    ),
+    class = "surveycore_error_field_dates_reversed"
+  )
+})
+
+test_that("survey_metadata assignment round-trips a valid dataset metadata list", {
+  m <- survey_metadata()
+  m@dataset_metadata <- full_keys
+  expect_identical(m@dataset_metadata, full_keys)
+})
+
+test_that("a design's @metadata re-validates @dataset_metadata on assignment", {
+  df <- make_survey_data(n = 60, n_psu = 12, n_strata = 3, seed = 12)
+  design <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  test_invariants(design)
+  expect_error(
+    design@metadata@dataset_metadata <- list(vendor = NA_character_),
+    class = "surveycore_error_dataset_metadata_bad_type"
+  )
+  design@metadata@dataset_metadata <- list(vendor = "Ipsos")
+  expect_identical(design@metadata@dataset_metadata, list(vendor = "Ipsos"))
+})

--- a/tests/testthat/test-s7-classes.R
+++ b/tests/testthat/test-s7-classes.R
@@ -1084,3 +1084,97 @@ test_that("as_survey() designs start with an empty @dataset_metadata", {
   test_invariants(design)
   expect_identical(design@metadata@dataset_metadata, list())
 })
+
+
+# ── survey_metadata validator: structural checks (spec III.3 checks 2-6) ──────
+
+test_that("survey_metadata validator accepts an explicitly empty dataset list", {
+  m <- survey_metadata()
+  m@dataset_metadata <- list()
+  expect_identical(m@dataset_metadata, list())
+})
+
+test_that("survey_metadata validator rejects an unnamed dataset metadata entry", {
+  expect_error(
+    survey_metadata(dataset_metadata = list("Ipsos")),
+    class = "surveycore_error_dataset_metadata_unnamed"
+  )
+})
+
+test_that("survey_metadata validator rejects a partially named dataset metadata list", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(vendor = "Ipsos", "Cint")),
+    class = "surveycore_error_dataset_metadata_unnamed"
+  )
+})
+
+test_that("survey_metadata validator rejects an NA dataset metadata key name", {
+  bad <- stats::setNames(list("Ipsos"), NA_character_)
+  expect_error(
+    survey_metadata(dataset_metadata = bad),
+    class = "surveycore_error_dataset_metadata_unnamed"
+  )
+})
+
+test_that("survey_metadata validator rejects an empty dataset metadata key name", {
+  bad <- stats::setNames(list("Ipsos"), "")
+  expect_error(
+    survey_metadata(dataset_metadata = bad),
+    class = "surveycore_error_dataset_metadata_unnamed"
+  )
+  expect_error(
+    survey_metadata(dataset_metadata = bad),
+    regexp = "All dataset metadata entries must have a non-empty name."
+  )
+})
+
+test_that("survey_metadata validator rejects a duplicated dataset metadata key", {
+  bad <- list(vendor = "Ipsos", vendor = "Cint")
+  expect_error(
+    survey_metadata(dataset_metadata = bad),
+    class = "surveycore_error_dataset_metadata_duplicate_key"
+  )
+  expect_error(
+    survey_metadata(dataset_metadata = bad),
+    regexp = "Duplicate dataset metadata key\\(s\\): vendor."
+  )
+})
+
+test_that("survey_metadata validator rejects a key outside the closed vocabulary", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(mode = "web")),
+    class = "surveycore_error_dataset_key_unknown"
+  )
+  expect_error(
+    survey_metadata(dataset_metadata = list(mode = "web")),
+    regexp = "Unknown dataset metadata key: mode."
+  )
+})
+
+test_that("survey_metadata validator rejects the legacy dates key", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(dates = "February-March 2026")),
+    class = "surveycore_error_dataset_key_unknown"
+  )
+})
+
+test_that("survey_metadata validator rejects a key that names a base attribute", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(class = "tbl_df")),
+    class = "surveycore_error_dataset_key_unknown"
+  )
+})
+
+test_that("survey_metadata validator rejects a NULL dataset metadata element", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(vendor = NULL)),
+    class = "surveycore_error_dataset_metadata_bad_type"
+  )
+})
+
+test_that("survey_metadata validator rejects a NULL element on a date key", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(field_start = NULL)),
+    class = "surveycore_error_dataset_metadata_bad_type"
+  )
+})

--- a/tests/testthat/test-s7-classes.R
+++ b/tests/testthat/test-s7-classes.R
@@ -1182,6 +1182,60 @@ test_that("survey_metadata validator rejects a NULL element on a date key", {
 
 # ── survey_metadata validator: per-key value rules (spec III.3 check 7) ───────
 
+# Each of the four character keys is violable three ways — non-character,
+# length 2, and NA. All twelve cases carry the same class, and all twelve are
+# asserted, because this suite is what guards the closed value contract on
+# every later change.
+
+test_that("survey_metadata validator rejects a non-character survey_name", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(survey_name = 1L)),
+    class = "surveycore_error_dataset_metadata_bad_type"
+  )
+  expect_error(
+    survey_metadata(dataset_metadata = list(survey_name = 1L)),
+    regexp = paste(
+      "Dataset metadata key survey_name must be a single non-NA",
+      "character string."
+    )
+  )
+})
+
+test_that("survey_metadata validator rejects a length-2 survey_name", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(survey_name = c("a", "b"))),
+    class = "surveycore_error_dataset_metadata_bad_type"
+  )
+})
+
+test_that("survey_metadata validator rejects an NA survey_name", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(survey_name = NA_character_)),
+    class = "surveycore_error_dataset_metadata_bad_type"
+  )
+})
+
+test_that("survey_metadata validator rejects a non-character data_name", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(data_name = TRUE)),
+    class = "surveycore_error_dataset_metadata_bad_type"
+  )
+})
+
+test_that("survey_metadata validator rejects a length-2 data_name", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(data_name = c("a", "b"))),
+    class = "surveycore_error_dataset_metadata_bad_type"
+  )
+})
+
+test_that("survey_metadata validator rejects an NA data_name", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(data_name = NA_character_)),
+    class = "surveycore_error_dataset_metadata_bad_type"
+  )
+})
+
 test_that("survey_metadata validator rejects a non-character vendor", {
   expect_error(
     survey_metadata(dataset_metadata = list(vendor = 1L)),
@@ -1196,16 +1250,38 @@ test_that("survey_metadata validator rejects a non-character vendor", {
   )
 })
 
-test_that("survey_metadata validator rejects an NA survey_name", {
+test_that("survey_metadata validator rejects a length-2 vendor", {
   expect_error(
-    survey_metadata(dataset_metadata = list(survey_name = NA_character_)),
+    survey_metadata(dataset_metadata = list(vendor = c("Ipsos", "Cint"))),
     class = "surveycore_error_dataset_metadata_bad_type"
   )
 })
 
-test_that("survey_metadata validator rejects a length-2 data_name", {
+test_that("survey_metadata validator rejects an NA vendor", {
   expect_error(
-    survey_metadata(dataset_metadata = list(data_name = c("a", "b"))),
+    survey_metadata(dataset_metadata = list(vendor = NA_character_)),
+    class = "surveycore_error_dataset_metadata_bad_type"
+  )
+})
+
+test_that("survey_metadata validator rejects a non-character field_period", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(field_period = 2026)),
+    class = "surveycore_error_dataset_metadata_bad_type"
+  )
+})
+
+test_that("survey_metadata validator rejects a length-2 field_period", {
+  bad <- list(field_period = c("February 2026", "March 2026"))
+  expect_error(
+    survey_metadata(dataset_metadata = bad),
+    class = "surveycore_error_dataset_metadata_bad_type"
+  )
+})
+
+test_that("survey_metadata validator rejects an NA field_period", {
+  expect_error(
+    survey_metadata(dataset_metadata = list(field_period = NA_character_)),
     class = "surveycore_error_dataset_metadata_bad_type"
   )
 })


### PR DESCRIPTION
## Summary
- `survey_metadata` gains the `dataset_metadata` property (`S7::class_list`, default `list()`), typed for six canonical keys.
- `survey_metadata` gains its first validator: checks 2-8 in spec order (names present, no NA/empty name, no duplicate name, closed key vocabulary, no NULL element, per-key value rules, `field_start <= field_end`).
- `R/utils.R` gains `.check_dataset_key_value()` (the single implementation of the per-key value table) plus the `.dataset_metadata_keys` / `.dataset_date_keys` constants. The validator wraps its delegation in `tryCatch()` and re-raises plain Layer-1 messages.
- `plans/error-messages.md` gains the `dataset-level-metadata` section (DM-1 through DM-6, DM-8, DM-9) plus Coverage Map entries. DM-7 promotion-warning rows ship later (PR 5).

## Spec coverage
See review.md — verdict PASS.
- Spec items covered: spec §III.3 checks 2-8, §III.4's seven edge cases, and every §XI class this PR owns.
- Test scenarios: 18 of 18 PASS (test-spec §5, rows C1-C11, expanded to sub-rows; see audit.md Per-Test Result Table).

## Test results
- devtools::test(): PASS — `[ FAIL 0 | WARN 256 | SKIP 4 | PASS 12699 ]` (baseline FAIL 0 / PASS 12580; rise reflects this PR's tests plus a `polycor` install and commits #155/#156)
- R CMD check --as-cran --no-manual: `Status: 2 NOTEs` — `checking CRAN incoming feasibility` (pre-approved) and a `checking examples` note naming `get_corr` (local machine-speed artifact, not touched by this PR; CI reports OK on all four platforms)
- pkgdown: PASS (clean build; this PR adds no export, so `_pkgdown.yml` is untouched)
- covr: package total 95.91% (baseline 95.90%); `R/core-classes.R` 97.09%, `R/utils.R` 99.32%

## Before/After
| Metric | Before PR (baseline) | After PR | Δ |
|---|---|---|---|
| tests passing | 12580 | 12699 | +119 (expected — see audit.md) |
| tests failing | 0 | 0 | 0 |
| tests skipped | 4 (branch baseline) | 4 | 0 |
| warnings | 256 (pre-existing AAPOR advisories) | 256 | 0 |
| R CMD check errors/warnings | 0 / 0 | 0 / 0 | 0 |
| R CMD check notes | 0 (baseline) | 2 (both non-blocking) | +2, classified in audit.md |
| coverage (package total) | 95.90% | 95.91% | +0.01 |
| `R/core-classes.R` coverage | 97.62% | 97.09% | -0.53 (one plan-mandated uncovered line; see audit.md/review.md) |
| `R/utils.R` coverage | 99.20% | 99.32% | +0.12 |

## Artifacts
- Implementation: `.surveycore-workspace/runs/2026-08-19-dataset-level-metadata/prs/pr-1-dataset-metadata-class/implementation.md`
- Audit: `.surveycore-workspace/runs/2026-08-19-dataset-level-metadata/prs/pr-1-dataset-metadata-class/audit.md`
- Review: `.surveycore-workspace/runs/2026-08-19-dataset-level-metadata/prs/pr-1-dataset-metadata-class/review.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)