### PR TITLE
docs(metadata): document dataset-level metadata in the vignette, NEWS and DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,8 +25,10 @@ Description: A modern, 'S7'-based foundation for survey analysis
     with weighted 'polychoric' and 'polyserial' correlation following
     'Mannan' (2025) <doi:10.2139/ssrn.6580480>. A metadata system
     preserves 'haven'-style variable labels, value labels, and
-    question-preface attributes through all operations. Uses a
-    'tidyselect' interface throughout.
+    question-preface attributes through all operations, alongside
+    dataset-level metadata that records the survey name, the fielding
+    vendor, and the field period. Uses a 'tidyselect' interface
+    throughout.
 License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,8 @@ Imports:
     marginaleffects (>= 0.18.0),
     pbivnorm (>= 0.6.0),
     stats,
-    graphics
+    graphics,
+    utils
 Suggests:
     testthat (>= 3.0.0),
     withr (>= 2.5.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,77 @@
+# surveycore (development version)
+
+## New features
+
+* Survey designs and data frames now carry **dataset-level metadata** —
+  metadata about the dataset as a whole rather than about one variable. The
+  vocabulary is closed at six keys: `survey_name`, `data_name`, `vendor`,
+  `field_start`, `field_end`, and `field_period`. Any other key is rejected.
+  `survey_name` and `data_name` are independent: no function reads one to
+  compute, fill, or check the other. See
+  `vignette("creating-survey-objects")`, section 8. (#163, #164, #166, #168,
+  #170)
+
+* New `dataset_metadata` property on the `survey_metadata` class stores the six
+  keys as a named list, in a fixed canonical key order. It defaults to
+  `list()`, so a design with no dataset metadata behaves exactly as it did in
+  1.1.0. (#163)
+
+* New unified setter and extractor: `set_dataset_metadata()` and
+  `extract_dataset_metadata()`. Both accept a survey design object or a plain
+  data frame. `set_dataset_metadata()` takes named arguments, a single named
+  list, or the programmatic `key`/`value` pair, and deletes a key when its
+  value is `NULL`. `extract_dataset_metadata()` returns a named list or a
+  two-column tibble, and can fill absent keys with `NA` to give the full
+  six-key schema. (#163, #164)
+
+* New convenience wrappers, one pair per key: `set_survey_name()` /
+  `extract_survey_name()`, `set_data_name()` / `extract_data_name()`,
+  `set_vendor()` / `extract_vendor()`, `set_field_dates()` /
+  `extract_field_dates()`, and `set_field_period()` / `extract_field_period()`.
+  Each setter delegates to `set_dataset_metadata()`; each extractor returns one
+  scalar, or the two field dates. (#166)
+
+* `as_survey()`, `as_survey_replicate()`, and `as_survey_nonprob()` now promote
+  the six whole-data-frame attributes into the design's metadata at
+  construction, so metadata set in a `data-raw/` script survives into the
+  design with no extra step. `as_survey_twophase()` exposes the phase-1 keys.
+  The older attribute name `dates` is read as `field_period` when no
+  `field_period` attribute is present. Promotion **copies** and never strips,
+  so the attributes stay on the underlying data frame; rebuilding a design from
+  that frame re-promotes the original values, and an edited or deleted key
+  comes back. (#168)
+
+* `print()` and `summary()` now show the dataset metadata. All four print
+  methods gain a `Dataset:` header line, and the `metadata_info = TRUE` block
+  reports the survey name, the vendor, and the field dates. Output is
+  byte-identical to 1.1.0 whenever no dataset metadata is set. (#170)
+
+## Bug fixes
+
+* `as_survey_nonprob()` now promotes weighting history from the data frame into
+  the design's metadata, matching `as_survey()` and `as_survey_replicate()`.
+  Previously the promotion call was missing from this one constructor, so
+  `survey_weighting_history()` reported no history for a non-probability design
+  even when the data frame carried it. This is a pre-existing inconsistency,
+  independent of the dataset-metadata feature. (#168)
+
+## Notes
+
+* **Reading objects saved under surveycore 1.1.0 or earlier.** A design saved
+  with `saveRDS()` or in an `.rda` file under an older version stores a frozen
+  copy of the old metadata class, which has no `dataset_metadata` property.
+  Every read path handles this: all four `print()` methods, all four
+  `summary()` methods, and all six extractors succeed on such an object and
+  report no dataset metadata. A **write** — any of the six setters — raises
+  `surveycore_error_dataset_metadata_unavailable` instead of a raw S7 property
+  error. The remedy the error names is to rebuild the object with the matching
+  constructor, `as_survey()`, `as_survey_replicate()`,
+  `as_survey_nonprob()`, or `as_survey_twophase()`.
+
+* `extract_metadata()` is deliberately unchanged. It reports per-variable
+  fields only, and a dataset-level key is not a variable, so the six keys never
+  appear in its output. They have their own accessors.
+
 # surveycore 1.1.0
 
 ## New features

--- a/vignettes/creating-survey-objects.Rmd
+++ b/vignettes/creating-survey-objects.Rmd
@@ -699,7 +699,166 @@ population unless the sample can be independently defended as representative.
 
 ---
 
-## 8. Reference: Common Codebook Variables {#sec-reference}
+## 8. Dataset-level metadata {#sec-dataset-metadata}
+
+The constructors carry two kinds of metadata. Variable-level metadata
+describes one column — a variable label, value labels, a question preface.
+Dataset-level metadata describes the whole dataset: what the survey is called,
+who fielded it, and when it was in the field.
+
+There are exactly six dataset-level keys. The vocabulary is closed, so any
+other name is rejected:
+
+| Key | Type | Meaning | Example |
+|---|---|---|---|
+| `survey_name` | `character(1)` | Full formal survey name. No dates. | `"Antisemitic Attitudes in America 2026"` |
+| `data_name` | `character(1)` | Display label for this dataset. | `"AAA Ipsos (February-March 2026)"` |
+| `vendor` | `character(1)` | Fielding vendor. | `"Ipsos KnowledgePanel Omnibus"` |
+| `field_start` | `Date(1)` | First day in the field. | `as.Date("2026-02-10")` |
+| `field_end` | `Date(1)` | Last day in the field. | `as.Date("2026-03-04")` |
+| `field_period` | `character(1)` | Prose field period, for display. | `"February-March 2026"` |
+
+### 8.1 The `data-raw/` workflow
+
+On a data frame, dataset metadata lives in whole-object attributes. Set them
+in the `data-raw/` script that prepares the dataset, then save the frame:
+
+```{r dm-dataraw}
+aaa <- data.frame(
+  psu = rep(1:10, each = 20),
+  stratum = rep(1:5, each = 40),
+  wt = rep(c(0.8, 1.2), 100),
+  approve = rep(c(1, 0), 100)
+)
+
+aaa <- set_dataset_metadata(
+  aaa,
+  survey_name = "Antisemitic Attitudes in America 2026",
+  data_name = "AAA Ipsos (February-March 2026)",
+  vendor = "Ipsos KnowledgePanel Omnibus",
+  field_start = as.Date("2026-02-10"),
+  field_end = as.Date("2026-03-04"),
+  field_period = "February-March 2026"
+)
+
+extract_dataset_metadata(aaa, format = "data_frame")
+```
+
+In a real `data-raw/` script the last line is `usethis::use_data(aaa)`. The
+attributes travel with the saved object.
+
+Every constructor promotes those attributes into the design's metadata, so no
+extra step is needed at construction:
+
+```{r dm-promote}
+svy_aaa <- as_survey(aaa, ids = psu, weights = wt, strata = stratum)
+
+print(svy_aaa, metadata_info = TRUE, n = 3)
+```
+
+You can also set the keys directly on a design. That is the better choice when
+the values were not available when the dataset was built:
+
+```{r dm-on-design}
+svy_aaa <- set_vendor(svy_aaa, "Ipsos KnowledgePanel Omnibus")
+svy_aaa <- set_field_dates(
+  svy_aaa,
+  field_start = as.Date("2026-02-10"),
+  field_end = as.Date("2026-03-04")
+)
+
+extract_field_dates(svy_aaa)
+```
+
+### 8.2 `survey_name` and `data_name` are independent
+
+The two name keys answer two different questions, and nothing in surveycore
+derives one from the other:
+
+```{r dm-two-names}
+extract_survey_name(svy_aaa)
+extract_data_name(svy_aaa)
+```
+
+- `survey_name` is the full formal name of the **survey** — the study, the
+  instrument, the thing you cite. It carries no dates.
+- `data_name` is a short display label for **this dataset** — usually a short
+  name plus the field period. It is what the print header shows.
+
+No function reads one key to compute, fill, or check the other. Set one and the
+other stays unset. Change one and the other keeps its old value, so the two can
+drift apart. The print output shows both, which is how you see the drift.
+
+### 8.3 Attribute persistence: set the metadata last
+
+Whole-object attributes on a data frame are fragile. Several everyday
+operations return a new frame without them:
+
+| Operation | Attributes |
+|---|---|
+| `df[, cols]` — the **column** form of `[` | dropped |
+| `df[rows, ]` — the **row** form of `[` | kept |
+| `merge()` | dropped |
+| `subset()`, either form | dropped |
+| `tibble::as_tibble()` | version dependent — do not rely on it |
+
+The column form of `[` drops the attributes; the row form keeps them. So a
+row filter is safe and a column selection is not:
+
+```{r dm-persistence}
+extract_vendor(aaa[1:5, ])
+extract_vendor(aaa[, c("psu", "wt")])
+```
+
+`tibble::as_tibble()` has dropped these attributes in some tibble versions and
+kept them in others, so neither behavior is safe to rely on.
+
+The practical advice follows from the table. Either:
+
+- set dataset metadata **last** in the `data-raw/` script, directly before
+  `usethis::use_data()`, after every reshape, join, and column selection is
+  done; or
+- set it on the survey design instead. There it lives in the design's
+  metadata, where no data-frame operation can drop it.
+
+A constructor **copies** these attributes into the design; it never strips
+them. The data frame inside a design therefore still carries the values it was
+built with:
+
+```{r dm-resurrection}
+svy_cint <- set_vendor(svy_aaa, "Cint")
+
+# The design reports the new value.
+extract_vendor(svy_cint)
+
+# The data frame inside it still carries the original.
+extract_vendor(survey_data(svy_cint))
+```
+
+Rebuilding a design from the frame that `survey_data()` returns therefore
+re-promotes the original attributes, and an edited or deleted key comes back.
+Avoid that round trip and keep working with the design object.
+
+### 8.4 `extract_metadata()` reports variables only
+
+`extract_metadata()` is deliberately separate from the dataset-level API. It
+reports per-variable fields only, and a dataset-level key is not a variable, so
+the six keys never appear in its output. They have their own accessors —
+`extract_dataset_metadata()` and the five convenience extractors:
+
+```{r dm-carveout}
+svy_aaa <- set_var_label(svy_aaa, approve = "Approves of current policy")
+
+# Variable names only — no dataset-level keys.
+names(extract_metadata(svy_aaa))
+
+# The dataset-level keys live here.
+names(extract_dataset_metadata(svy_aaa))
+```
+
+---
+
+## 9. Reference: Common Codebook Variables {#sec-reference}
 
 A lookup table for common codebook terms and how they map to constructor
 arguments:


### PR DESCRIPTION
## Summary

- Adds a new vignette section covering the `data-raw/` workflow, `survey_name` and `data_name` side by side with the independence rule, attribute persistence (including a live demonstration that column-form `[` drops attributes while row-form keeps them), and the note that `extract_metadata()` excludes dataset-level keys.
- Adds a `# surveycore (development version)` heading to `NEWS.md` (newly created) carrying the twelve-export feature list, the serialization caveat for objects saved under surveycore 1.1.0 and earlier, and a separately-described bullet for the `as_survey_nonprob()` weighting-history fix.
- Adds `utils` to `Imports` in `DESCRIPTION`, since the package calls `utils::adist()` and `utils::combn()`. `checking package dependencies ... OK` and `checking dependencies in R code ... OK`, no new NOTE.

**This is the final PR of the dataset-level-metadata feature.** With it, the feature is complete: the `dataset_metadata` class property and validator, the guarded read path, the write path, twelve exported functions, construction promotion in three constructors, print and summary output across eight methods, and now the documentation.

## Spec coverage

See review.md — verdict PASS.
- Spec items covered: §XII.3 (four vignette requirements), §XII.6 (NEWS content), §XII.7 (`Description` extension), §XII.8 (carve-out sentence) — all discharged
- Test scenarios: n/a — this PR adds no tests by design (documentation only)

## Test results

- `devtools::test()`: `[ FAIL 0 | WARN 256 | SKIP 4 | PASS 19313 ]` — unchanged from develop, since this PR adds no tests
- `R CMD check --as-cran --no-manual`: `Status: 2 NOTEs` — `checking CRAN incoming feasibility` (pre-approved) and `checking examples` naming `get_corr` (local machine-speed artifact only; CI reports OK on all platforms)
- `pkgdown::build_site()`: clean; the rendered article was confirmed to contain the new section with live executed chunk output
- `covr`: 96.09%, unchanged — no new R code
- `checking re-building of vignette outputs ... OK`

## Before/After

| | Before | After |
|---|---|---|
| Vignette | No dataset-level metadata coverage | New §8 "Dataset-level metadata" with 7 live chunks: data-raw workflow, name-key independence, attribute persistence (with live `[` subsetting demo), `extract_metadata()` carve-out |
| NEWS.md | No development-version heading | `# surveycore (development version)` with the 12-export feature list, serialization caveat, and standalone weighting-history bug fix bullet |
| DESCRIPTION | No `utils` in Imports; `Description` did not mention dataset metadata | `utils` declared; `Description` extended; `Version:` untouched at `1.1.0.9000` |

## Artifacts

- Implementation: `.surveycore-workspace/runs/2026-08-19-dataset-level-metadata/prs/pr-7-dataset-metadata-docs/implementation.md`
- Audit: `.surveycore-workspace/runs/2026-08-19-dataset-level-metadata/prs/pr-7-dataset-metadata-docs/audit.md`
- Review: `.surveycore-workspace/runs/2026-08-19-dataset-level-metadata/prs/pr-7-dataset-metadata-docs/review.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)