### PR TITLE
fix(glm): preserve newdata$rowid in get_predict.survey_glm_fit()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ SOPs/
 # Claude Code harness runtime lock (session-local)
 .claude/scheduled_tasks.lock
 
+# Local git worktrees
+.worktrees/
+
 # Vignette build artifacts (local devtools::build_vignettes output)
 doc/
 Meta/

--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,14 @@
   even when the data frame carried it. This is a pre-existing inconsistency,
   independent of the dataset-metadata feature. (#168)
 
+* `get_predict.survey_glm_fit()` now preserves a `rowid` column already
+  present in `newdata` instead of always fabricating a fresh sequential one.
+  marginaleffects 1.0.0 relies on `rowid` to reattach grouping columns onto
+  stacked contrast rows, and the fabricated sequence did not match once a
+  contrast block's row identity reset partway through, so grouped
+  `avg_slopes()`/`avg_predictions()` calls on `survey_glm_fit` objects lost
+  or misattributed the grouping column. (#153)
+
 ## Notes
 
 * **Reading objects saved under surveycore 1.1.0 or earlier.** A design saved

--- a/R/glm-marginaleffects.R
+++ b/R/glm-marginaleffects.R
@@ -73,12 +73,25 @@ get_vcov.survey_glm_fit <- function(model, ...) {
 # Requires model@fit_ to be non-NULL. If fit_ is NULL (e.g. after
 # deserialization), errors with surveycore_error_predict_no_fit — the same
 # error class as predict.survey_glm_fit().
+#
+# marginaleffects merges grouping columns back onto contrast rows by
+# matching `rowid` between this output and its own copy of newdata. When
+# newdata already carries a `rowid` column, that column is the row's real
+# identity (it can reset partway through a stacked hi/lo contrast block) and
+# must be preserved as-is. Only fabricate a sequential rowid when newdata has
+# none, matching the fallback marginaleffects' own default get_predict()
+# uses (see `add_rowid()` in the marginaleffects source).
 
 #' @noRd
 get_predict.survey_glm_fit <- function(model, newdata, ...) {
   pred <- stats::predict(model, new_data = newdata, type = "response")
+  rowid <- if ("rowid" %in% names(newdata)) {
+    newdata$rowid
+  } else {
+    seq_len(nrow(newdata))
+  }
   data.frame(
-    rowid = seq_len(nrow(newdata)),
+    rowid = rowid,
     estimate = as.numeric(pred)
   )
 }

--- a/changelog/fix-marginaleffects-rowid.md
+++ b/changelog/fix-marginaleffects-rowid.md
@@ -1,0 +1,38 @@
+# Changelog: fix/marginaleffects-rowid
+
+**Branch:** `fix/marginaleffects-rowid`
+**Status:** Complete
+**Date:** 2026-08-25
+
+## Summary
+
+Fixes #153: `get_diffs()` and the marginaleffects extension interface
+(`avg_slopes()`, `avg_predictions()`) raised `missing value where TRUE/FALSE
+needed` errors and returned rows with a missing group value under the
+in-development `marginaleffects` 1.0.0.
+
+`get_predict.survey_glm_fit()` always fabricated a fresh
+`rowid = seq_len(nrow(newdata))`, discarding a `rowid` column already present
+on `newdata`. marginaleffects 1.0.0 relies on `rowid` to reattach grouping
+columns onto contrast rows; the real `rowid` resets partway through a
+stacked hi/lo contrast block, so the fabricated sequential one stopped
+matching and the merge silently dropped or misattributed the group.
+
+Reproduced locally by installing `marginaleffects` from GitHub (1.0.0 is not
+yet on CRAN); confirmed the fix against both the CRAN release (0.32.0) and
+the GitHub dev version.
+
+## Files Modified
+
+- `R/glm-marginaleffects.R` — `get_predict.survey_glm_fit()` now returns
+  `newdata$rowid` unchanged when present, falling back to `seq_len()` only
+  when `newdata` has no `rowid` column
+- `tests/testthat/test-glm-marginaleffects.R` — regression test asserting
+  `get_predict()` preserves a supplied `newdata$rowid`
+- `NEWS.md` — bug fix entry
+
+## Changes
+
+- Preserve `newdata$rowid` in `get_predict.survey_glm_fit()` instead of
+  always fabricating a sequential one, fixing grouped `avg_slopes()` /
+  `avg_predictions()` results under `marginaleffects` 1.0.0

--- a/tests/testthat/test-glm-marginaleffects.R
+++ b/tests/testthat/test-glm-marginaleffects.R
@@ -108,6 +108,26 @@ test_that("get_predict() returns data frame with rowid and estimate; nrow matche
 })
 
 # ---------------------------------------------------------------------------
+# Item 6b: get_predict() preserves a supplied newdata$rowid (issue #153)
+# ---------------------------------------------------------------------------
+#
+# marginaleffects merges grouping columns back onto contrast rows by
+# matching `rowid` between get_predict()'s output and its own copy of
+# newdata. When newdata carries a `rowid` column (e.g. a stacked hi/lo
+# contrast block whose row identity resets partway through), get_predict()
+# must return that same rowid rather than a fresh seq_len() — otherwise the
+# merge silently drops or misattributes grouping columns.
+
+test_that("get_predict() returns newdata$rowid unchanged when supplied", {
+  skip_if_not_installed("marginaleffects")
+  fit             <- .me_taylor_gaussian()
+  newdata         <- fit@fit_$model[1:10, , drop = FALSE]
+  newdata$rowid   <- c(6:10, 1:5)
+  result          <- marginaleffects::get_predict(fit, newdata = newdata)
+  expect_identical(result$rowid, newdata$rowid)
+})
+
+# ---------------------------------------------------------------------------
 # Item 7: avg_slopes() — Gaussian — AME matches OLS coefficient within 1e-6
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Fixes #153: preserves `newdata$rowid` in `get_predict.survey_glm_fit()` so grouped `avg_slopes()`/`avg_predictions()` calls keep working under `marginaleffects` 1.0.0.

## Details

`get_predict.survey_glm_fit()` always returned `rowid = seq_len(nrow(newdata))`, discarding a `rowid` column already present on `newdata`. `marginaleffects` 1.0.0 relies on `rowid` to reattach grouping columns onto contrast rows; the real `rowid` resets partway through a stacked hi/lo contrast block, so the fabricated sequential one no longer matched and the merge silently dropped or misattributed the group. This produced the `missing value where TRUE/FALSE needed` errors and row-count mismatches reported in #153.

The fix: return `newdata$rowid` unchanged when present, falling back to `seq_len()` only when `newdata` carries none — the same contract `marginaleffects`' own default `get_predict()` uses.

Reproduced locally by installing `marginaleffects` from GitHub (1.0.0 is not yet on CRAN). Verified the originally-failing tests now pass against both the GitHub dev build and the CRAN release (0.32.0).

## Checklist

- [x] Tests written and passing (`devtools::test()` / full suite via `devtools::check()`)
- [x] R CMD check: 0 errors, 0 warnings (`devtools::check()`)
- [ ] Roxygen docs updated and `devtools::document()` run — n/a, no roxygen changes
- [ ] `plans/error-messages.md` updated — n/a, no new errors/warnings
- [ ] `VENDORED.md` updated — n/a, no vendored code
- [x] PR title is a valid Conventional Commit (`fix(glm): description`)
- [x] PR targets `develop`, not `main`
