### PR TITLE
test: narrow test_invariants() to one call per constructor per file

### DIFF
--- a/.claude/rules/testing-surveycore.md
+++ b/.claude/rules/testing-surveycore.md
@@ -8,12 +8,34 @@ file covers only what is specific to surveycore.
 
 | Decision | Choice |
 |----------|--------|
-| Invariant checks | `test_invariants(design)` required as **first** assertion in every constructor test block |
+| Invariant checks | `test_invariants(design)` once per constructor per test FILE — not per block |
 | Layer 1 errors (S7 validators) | `class=` only — no snapshot |
 | Layer 3 errors (constructors) | Dual: `expect_error(class=)` + `expect_snapshot(error=TRUE)` |
 | Variance numerical tolerance | Point: 1e-10, SE/variance: 1e-8, CI bounds: 1e-6 |
 | Synthetic data | `make_survey_data(seed = N)` in `helper-test-data.R` |
 | Real data | `nhanes_2017`, `acs_pums_wy` for numerical validation only |
+
+## Two speeds of local test run
+
+11 files carry a file-level `skip_on_cran()`, including the two polychoric
+files that hold 42% of all test time. Skipping them halves the run.
+
+`devtools::test()` cannot reach the fast speed. It calls
+`withr::local_envvar(devtools:::r_env_vars())`, and that list sets
+`NOT_CRAN = "true"` unconditionally, so the shell variable never reaches the
+tests and the 11 files always run. Use `testthat::test_local()` for the fast
+run — it reads the real environment.
+
+| Run | Command | Expectations | Time | Use for |
+|---|---|---|---|---|
+| Fast | `NOT_CRAN=false Rscript -e "testthat::test_local()"` | 8,841 | 384 s | The edit-run loop. Skips the 11 slow files. |
+| Full | `Rscript -e "devtools::test()"` | 9,847 | 879 s | Before any push or PR. Runs everything. |
+
+Always measure coverage with `NOT_CRAN=true`. `covr` does not set the
+variable, so without it the 11 files skip and coverage reads about 93.7%
+instead of 96.0938% (issue #159).
+
+Measured 2026-08-26 on the narrowed suite.
 
 ## File mapping
 
@@ -35,11 +57,23 @@ same one-to-one convention — `R/analysis-means.R` →
 | `R/utils.R` | `tests/testthat/test-utils.R` |
 | `R/update-design.R` | `tests/testthat/test-update-design.R` |
 
-## `test_invariants()` — required in every constructor test
+## `test_invariants()` — once per constructor per file
 
-Every `test_that()` block that creates a survey object via `as_survey()`,
-`as_survey_rep()`, or `as_survey_twophase()` calls `test_invariants(design)`
-as its **first** assertion.
+Each test FILE calls `test_invariants(design)` once for each constructor it
+exercises — `as_survey()`, `as_survey_rep()`, `as_survey_twophase()`,
+`as_survey_nonprob()` — in the first block that builds with it. Later blocks
+in the same file do not repeat it.
+
+Measured rationale (issue #169): the per-block rule produced 645 calls and
+about 10,300 expectations — 53% of the suite — and stubbing it out moved
+package coverage by 0.0000 points across all 46 files in `R/`. The S7
+validators in `R/core-classes.R` enforce the same invariants on construction
+and on every property assignment, and no code in `R/` bypasses them.
+
+The helper still earns one call per constructor per file: it is the only
+guard against a constructor returning a malformed object through a route the
+validators do not see. `tests/testthat/test-invariants.R` keeps proving the
+helper still fires.
 
 `test_invariants()` is defined in `tests/testthat/helper-test-data.R` — read
 it there for the current source. It asserts all five formal Phase 0

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 *.sh text eol=lf
+
+# testthat snapshots are written LF and must stay LF, or every test run
+# shows all of _snaps/ as modified with no content change. (issue #161)
+tests/testthat/_snaps/*.md text eol=lf

--- a/plans/implementation-plan-test-suite-simplification.md
+++ b/plans/implementation-plan-test-suite-simplification.md
@@ -662,6 +662,127 @@ Run:
 
 ---
 
+---
+
+## Phase 3 - Close the loop on the issues
+
+### Task 7: Report back on #169 and #161
+
+Do this **after** Tasks 2, 3 and 6 are committed, so the comment describes
+work that exists rather than work that is planned.
+
+#169 does **not** get closed by this plan. It asks for four investigation
+steps; this plan answers step 1 and deliberately leaves step 2 unmeasured.
+Left alone, the issue keeps its stale figures - "6 assertions", "about 18% of
+the expectation count" - and keeps asking for an experiment that has already
+run. The cost of that is someone spending a 20-minute coverage pass to
+re-derive a known answer.
+
+**Files:**
+- No files. This task posts comments and closes one issue.
+
+**Interfaces:**
+- Consumes: the measured after-numbers from Task 2 Step 6 and Task 6 Step 1.
+
+- [ ] **Step 1: Collect the real after-numbers**
+
+Do not copy the predictions from this plan. Read the actual values:
+
+    NOT_CRAN=true Rscript -e "r <- as.data.frame(devtools::test()); cat('passed:', sum(r\$passed), 'failed:', sum(r\$failed), 'skipped:', sum(r\$skipped), 'time:', round(sum(r\$real),1), 's\n')"
+    NOT_CRAN=true Rscript -e "cat(covr::percent_coverage(covr::package_coverage()), '\n')"
+
+- [ ] **Step 2: Comment on #169**
+
+Substitute the bracketed values with what Step 1 actually printed.
+
+```markdown
+## Step 1 is done - here is what it measured
+
+**The figures in the issue body are stale.** `test_invariants()` now holds
+**27** assertions, not 6, spanning `helper-test-data.R:569-735`. It runs
+**645** times, not 588 - some call sites sit inside helpers that run
+repeatedly.
+
+So its real contribution is about **10,300 expectations, 53% of the suite** -
+roughly three times the ~18% the issue estimates.
+
+**It buys no coverage.** Replacing it with a no-op and re-running `covr`:
+
+| Run | Coverage |
+|---|---|
+| Baseline | 96.0938% |
+| `test_invariants()` stubbed | 96.0938% |
+| Difference | **0.0000 points** |
+
+Identical to four decimal places, and not one of the 46 files in `R/` lost a
+line. The S7 validators in `R/core-classes.R` already enforce the same
+invariants on construction and on every property assignment, and nothing in
+`R/` bypasses them via `attr()` or `unclass()`.
+
+Caveat worth keeping: line coverage measures whether code **runs**, not
+whether results are **correct**. This proves the assertions reach no new
+code. It does not prove they could never catch a regression. That is why the
+rule was narrowed rather than deleted.
+
+## What changed
+
+- `test_invariants()` is now called once per constructor per test file, not
+  per block. Expectations fell from 19,314 to [ACTUAL PASSED].
+- `.claude/rules/testing-surveycore.md` records the narrowed rule and the
+  two-speed local test workflow.
+- Coverage held at [ACTUAL COVERAGE]%.
+- Runtime is [ACTUAL TIME]s, essentially unchanged - see below.
+
+## The headline assumption in this issue was wrong
+
+The issue reasons that trimming expectations would buy legibility but not
+speed. That is correct, and understated: **bloat and wall-time live in
+different files entirely.**
+
+| File | Time | Share | Expectations |
+|---|---|---|---|
+| `test-analysis-corr-latent.R` | 293.5 s | 36.4% | 126 |
+| `test-analysis-corr-latent-variance.R` | 47.4 s | 5.9% | 86 |
+| `test-dataset-metadata.R` | 70.6 s | 8.8% | 4,254 |
+
+Two polychoric files take **42% of all test time** for **1.1%** of the
+expectations. Chasing the expectation count for speed would have been the
+wrong lever entirely.
+
+That led to **#177**: `get_corr(method = "polychoric")` is about 164x slower
+than `polycor::polychor()`, because `.corr_bivnorm_cdf()` is scalar-only and
+gets called four times per cell inside a nested loop. That is a defect in
+`R/`, and fixing it is worth roughly ten times every test edit here.
+
+## Still open on this issue
+
+1. **Step 2 - the both-modes rule. Not measured.** It is the other 2x
+   multiplier. It needs its own stub-and-measure experiment, exactly like
+   the one above. Trimming it on suspicion would repeat the mistake this
+   issue was raised to avoid.
+2. **Step 3 - the dual pattern. Deliberately left alone.**
+   `expect_error(class = )` and `expect_snapshot(error = TRUE)` test
+   different things - the condition class and the rendered message - and
+   snapshots have caught message regressions in this repo before. The 522
+   snapshot calls stay.
+3. **Separate concern:** `test-dataset-metadata.R` holds 4,254 expectations,
+   22% of the suite, in one 4,277-line file. Worth its own issue.
+
+Keeping this open for step 2.
+```
+
+- [ ] **Step 3: Close #161 once the fix is on develop**
+
+The `.gitattributes` fix is verified but sits on a feature branch. Close
+#161 only after the PR merges, so the tracker never claims a fix that is not
+on `develop`.
+
+    gh issue close 161 --comment "Fixed on develop. A full test run now leaves 0 snapshot files modified, down from 38."
+
+- [ ] **Step 4: No commit**
+
+This task changes no files. Nothing to commit.
+
 ## Final verification
 
 - [ ] **Full suite passes**

--- a/plans/implementation-plan-test-suite-simplification.md
+++ b/plans/implementation-plan-test-suite-simplification.md
@@ -1,0 +1,764 @@
+# Test Suite Simplification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut the test suite's expectation count by about half with no loss of line coverage, close issue #161, and find out where the wall-time actually goes before trying to cut it.
+
+**Closes:** #161 (Task 1). Acts on step 1 of #169.
+
+**Architecture:** Bloat and slowness live in different files, so this plan treats them as two separate problems. Phase 1 removes repeated assertions that buy no coverage. Phase 2 attacks the small number of numerically expensive tests that dominate wall-time. Phase 0 removes a line-ending problem that makes every "is the tree clean?" check unreliable.
+
+**Tech Stack:** R, testthat 3rd edition, covr, devtools, S7.
+
+## Measured baseline
+
+Every number below was measured on `test/investigate-test-count-inflation`
+at `f01b73f`, with `NOT_CRAN=true`. Re-measure before trusting them again.
+
+| Measure | Value |
+|---|---|
+| Package line coverage | 96.0938% |
+| Passing expectations | 19,314 |
+| `test_that()` blocks | 3,478 |
+| Sum of test time | 806.3 s |
+| `devtools::test()` wall-time | 14.25 min |
+| `test_invariants()` runtime calls | 645 |
+| `test_invariants()` expectations | about 10,300 (53% of the suite) |
+
+### Finding 1 - the bloat buys no coverage
+
+`test_invariants()` (`tests/testthat/helper-test-data.R:569-735`) holds 27
+assertions and runs 645 times. Replacing it with a no-op changed package
+coverage by **0.0000 points**, and not one of the 46 files in `R/` lost a
+single line. The S7 validators in `R/core-classes.R` already enforce the
+same invariants on construction and on every property assignment, and no
+code in `R/` bypasses them through `attr()` or `unclass()`.
+
+Note the limit of this evidence: line coverage measures whether code
+**runs**, not whether results are **correct**. The experiment proves these
+assertions reach no new code. It does not prove they could never catch a
+regression. That is why this plan narrows the rule instead of deleting it.
+
+### Finding 2 - the bloat is not the slowness
+
+Time and expectation count are inversely related here:
+
+| File | Time | Share | Expectations | Expectations/sec |
+|---|---|---|---|---|
+| `test-analysis-corr-latent.R` | 293.5 s | 36.4% | 126 | 0.4 |
+| `test-analysis-corr-latent-variance.R` | 47.4 s | 5.9% | 86 | 1.8 |
+| `test-dataset-metadata.R` | 70.6 s | 8.8% | 4,254 | 60.3 |
+| `test-constructors.R` | 47.5 s | 5.9% | 2,549 | 53.7 |
+
+Two polychoric files take **42.3%** of all test time while holding **1.1%**
+of the expectations. The file with the most expectations is 140 times more
+time-efficient than the slowest file.
+
+**Consequence:** Phase 1 delivers legibility, not speed. Phase 2 delivers
+speed. Do not expect either to deliver the other, and do not report Phase 1
+as a performance improvement.
+
+## Global Constraints
+
+- Package line coverage must not fall below **95%**, and should not fall
+  from 96.0938% at all. Measure with `NOT_CRAN=true` (issue #159).
+- Never loosen a numerical tolerance to make a smaller fixture pass. Point
+  estimates 1e-10, SE/variance 1e-8, CI bounds 1e-6, `polycor` parity 1e-6.
+  If a shrunk fixture misses tolerance, keep the original fixture.
+- Feature branches cut from `develop` and merge back to `develop`.
+- Conventional Commits: `test:`, `chore:`, `docs:`, `refactor:`.
+- Run `air::format_package()` before opening a PR.
+- Do not delete `tests/testthat/test-invariants.R`. Those 6 meta-tests are
+  what keep `test_invariants()` itself honest.
+
+## File Structure
+
+| File | Responsibility | Phase |
+|---|---|---|
+| `.gitattributes` | Stop CRLF rewrites of snapshot files | 0 |
+| `tests/testthat/test-*.R` | Drop surplus `test_invariants()` calls | 1 |
+| `.claude/rules/testing-surveycore.md` | Record the narrowed rule | 1 |
+| `tests/testthat/test-analysis-corr-latent.R` | Share polychoric fixtures | 2 |
+| `tests/testthat/test-analysis-corr-latent-variance.R` | Share polychoric fixtures | 2 |
+| `.claude/rules/testing-surveycore.md` | Two-speed local workflow | 2 |
+
+---
+
+## Phase 0 - Housekeeping
+
+### Task 1: Stop snapshot files churning on every test run
+
+**Closes issue #161.**
+
+Running the suite rewrites all 38 `tests/testthat/_snaps/*.md` files with
+CRLF endings and **zero** content change. This is why a checkout sits dirty
+after any test run, and it makes "the tree is clean" meaningless as a gate.
+Issue #161 records the wider cost: any `git add -A` after a test run commits
+the churn, and the pipeline's scoped snapshot guard reads it as a violation
+until someone checks `numstat` and sees `0 0`.
+
+**Correction to issue #161 - the stated blocker does not exist.** The issue
+says to do this only when no feature branch is open, because a renormalize
+commit would rewrite ~38 files and collide with feature PRs. Measured on
+this branch: `git add --renormalize tests/testthat/_snaps/` stages
+**0 files**. The index blobs are already LF - `git ls-files --eol` reports
+`i/lf` for every snapshot. There is no 38-file commit, this task never
+touches `_snaps/`, and it can land at any time. Update #161 to say so.
+
+Two further details confirmed here:
+
+- `_snaps/` is flat - 38 `.md` files, no subdirectories, no other file
+  types - so the issue's `_snaps/*.md` glob is sufficient.
+- Root cause context: `core.autocrlf = true` in the local git config, with
+  `.gitattributes` carrying only `*.sh text eol=lf` from #157. The explicit
+  rule makes the behaviour deterministic rather than dependent on that
+  setting.
+
+**Files:**
+- Modify: `.gitattributes`
+
+**Interfaces:**
+- Produces: a repository where `git status` after a test run is empty, so
+  later tasks can use a clean tree as a real signal.
+
+- [ ] **Step 1: Confirm the churn is line endings only**
+
+Run:
+
+    Rscript -e "devtools::test()" > /dev/null 2>&1
+    git diff --stat tests/testthat/_snaps/ | tail -1
+    git diff --ignore-cr-at-eol --numstat tests/testthat/_snaps/ | wc -l
+
+Expected: the first command reports about 38 changed files; the second
+reports `0`. Zero means no content changed.
+
+- [ ] **Step 2: Inspect the current .gitattributes**
+
+Run:
+
+    cat .gitattributes
+
+- [ ] **Step 3: Add snapshot normalization**
+
+Append to `.gitattributes`:
+
+    # testthat snapshots are written LF and must stay LF, or every test run
+    # shows all of _snaps/ as modified with no content change. (issue #161)
+    tests/testthat/_snaps/*.md text eol=lf
+
+- [ ] **Step 4: Renormalize and confirm it stages nothing**
+
+Run:
+
+    git checkout -- tests/testthat/_snaps/
+    git add --renormalize tests/testthat/_snaps/
+    git diff --cached --numstat | wc -l
+
+Expected: `0`. The index is already LF, so renormalize is a no-op. This is
+the step that proves issue #161's "wait for a quiet moment" constraint does
+not apply. A non-zero count here means the premise changed - stop and
+re-read #161 before committing.
+
+- [ ] **Step 5: Prove the fix**
+
+Run:
+
+    Rscript -e "devtools::test()" > /dev/null 2>&1
+    git status --porcelain tests/testthat/_snaps/ | wc -l
+
+Expected: `0`. Before the fix this was 38.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+    git add .gitattributes
+    git commit -m "chore: keep testthat snapshots LF so test runs stop dirtying the tree (#161)"
+
+- [ ] **Step 7: Update issue #161**
+
+Post a comment recording that `git add --renormalize` stages 0 files
+because the index is already LF, so the "do this only when no feature
+branch is open" constraint does not apply. Then close it with the PR.
+
+---
+
+## Phase 1 - Remove assertions that buy no coverage
+
+### Task 2: Narrow test_invariants() to one call per constructor per file
+
+560 blocks call `test_invariants()`. The narrowed rule keeps the **first**
+block in each file for each constructor it exercises, and drops the call
+from the rest. Expect roughly 80-120 surviving calls, down from 645.
+
+Three blocks must keep their call regardless, because deleting it would
+leave them with no expectation at all:
+
+- `test-s7-classes.R` - "survey_nonprob validator accepts single positive weight among zeros"
+- `test-s7-classes.R` - "survey_nonprob validator accepts mix of zeros and NAs with one positive"
+- `test-update-design.R` - "update_design() validate=TRUE result passes test_invariants()"
+
+**Files:**
+- Modify: `tests/testthat/test-*.R` (about 20 files carry calls)
+- Do not modify: `tests/testthat/helper-test-data.R`, `tests/testthat/test-invariants.R`
+
+**Interfaces:**
+- Consumes: a clean tree from Task 1.
+- Produces: `test_invariants()` unchanged in signature and behaviour, simply
+  called from fewer places. `tests/testthat/test-invariants.R` keeps working
+  untouched.
+
+- [ ] **Step 1: Record the before numbers**
+
+Run:
+
+    NOT_CRAN=true Rscript -e "r <- as.data.frame(devtools::test()); cat('passed:', sum(r\$passed), 'failed:', sum(r\$failed), 'time:', round(sum(r\$real),1), 's\n')"
+
+Expected: `passed: 19314 failed: 0 time: 806.3 s` (small drift is fine).
+Write the numbers down; Step 6 compares against them.
+
+- [ ] **Step 2: Write the rewrite script**
+
+Create `data-raw/narrow-invariants.R`. It parses each test file, decides
+which blocks keep the call, and rewrites the rest. It edits by line number
+from the parse data, so it never disturbs surrounding code.
+
+```r
+# One-shot maintenance script for the test_invariants() narrowing.
+# Keeps the first block per (file, constructor); strips the call elsewhere.
+dir <- "tests/testthat"
+files <- list.files(dir, pattern = "^test-.*[.]R$", full.names = TRUE)
+
+KEEP_ALWAYS <- c(
+  "survey_nonprob validator accepts single positive weight among zeros",
+  "survey_nonprob validator accepts mix of zeros and NAs with one positive",
+  "update_design() validate=TRUE result passes test_invariants()"
+)
+CONSTRUCTORS <- c(
+  "as_survey", "as_survey_rep", "as_survey_twophase", "as_survey_nonprob"
+)
+
+fn_names <- function(e) {
+  out <- character(0)
+  rec <- function(x) {
+    if (is.call(x)) {
+      f <- x[[1L]]
+      if (is.name(f)) out <<- c(out, as.character(f))
+      for (i in seq_along(x)) {
+        if (!is.null(x[[i]])) try(rec(x[[i]]), silent = TRUE)
+      }
+    }
+  }
+  try(rec(e), silent = TRUE)
+  out
+}
+
+total_removed <- 0L
+for (f in files) {
+  if (basename(f) == "test-invariants.R") next
+  lines <- readLines(f)
+  ex <- tryCatch(parse(f, keep.source = TRUE), error = function(e) NULL)
+  if (is.null(ex)) next
+
+  seen <- character(0)
+  drop <- integer(0)
+  for (i in seq_along(ex)) {
+    e <- ex[[i]]
+    if (!is.call(e) || !identical(as.character(e[[1L]])[1L], "test_that")) {
+      next
+    }
+    nm <- tryCatch(as.character(e[[2L]])[1L], error = function(x) "")
+    fns <- fn_names(e)
+    if (!("test_invariants" %in% fns)) next
+    if (nm %in% KEEP_ALWAYS) next
+
+    ctor <- intersect(CONSTRUCTORS, fns)
+    key <- if (length(ctor) == 0L) "none" else ctor[1L]
+    if (!(key %in% seen)) {
+      # First block for this constructor in this file: keep the call.
+      seen <- c(seen, key)
+      next
+    }
+    # Later block: strip the call.
+    sr <- attr(ex, "srcref")[[i]]
+    rng <- sr[1L]:sr[3L]
+    hit <- rng[grepl("^[[:space:]]*test_invariants[(]", lines[rng])]
+    drop <- c(drop, hit)
+  }
+  if (length(drop)) {
+    writeLines(lines[-drop], f)
+    total_removed <- total_removed + length(drop)
+    cat(sprintf("%-42s removed %d\n", basename(f), length(drop)))
+  }
+}
+cat("TOTAL REMOVED:", total_removed, "\n")
+```
+
+- [ ] **Step 3: Run it**
+
+Run:
+
+    Rscript data-raw/narrow-invariants.R
+
+Expected: a per-file tally and a total in the 450-560 range.
+
+- [ ] **Step 4: Check no block was emptied**
+
+Run:
+
+    NOT_CRAN=true Rscript -e "r <- as.data.frame(devtools::test()); cat('failed:', sum(r\$failed), 'skipped:', sum(r\$skipped), '\n')"
+
+Expected: `failed: 0`. `skipped` must stay at 4. A rise in `skipped` means a
+block lost its last expectation - restore that one call by hand.
+
+- [ ] **Step 5: Confirm coverage did not move**
+
+Run:
+
+    NOT_CRAN=true Rscript -e "cat(covr::percent_coverage(covr::package_coverage()), '\n')"
+
+Expected: `96.0938`. **This is the gate.** Any drop means a call was
+reaching code nothing else does; restore calls until coverage returns.
+
+- [ ] **Step 6: Record the after numbers**
+
+Run:
+
+    NOT_CRAN=true Rscript -e "r <- as.data.frame(devtools::test()); cat('passed:', sum(r\$passed), 'time:', round(sum(r\$real),1), 's\n')"
+
+Expected: roughly 9,000-11,000 passing expectations, down from 19,314. Time
+should be near 806 s - unchanged. That is the correct result, not a failure.
+
+- [ ] **Step 7: Delete the one-shot script and commit**
+
+Run:
+
+    rm data-raw/narrow-invariants.R
+    air format .
+    git add -A
+    git commit -m "test: narrow test_invariants() to one call per constructor per file"
+
+### Task 3: Update the rule that mandated the old behaviour
+
+The rule in `.claude/rules/testing-surveycore.md` requires the call in every
+constructing block. Leaving it unchanged guarantees the calls grow back.
+
+**Files:**
+- Modify: `.claude/rules/testing-surveycore.md`
+
+**Interfaces:**
+- Consumes: the narrowed suite from Task 2.
+
+- [ ] **Step 1: Find the current wording**
+
+Run:
+
+    grep -n "test_invariants" .claude/rules/testing-surveycore.md
+
+- [ ] **Step 2: Replace the Quick Reference row**
+
+Old:
+
+    | Invariant checks | `test_invariants(design)` required as **first** assertion in every constructor test block |
+
+New:
+
+    | Invariant checks | `test_invariants(design)` once per constructor per test FILE - not per block |
+
+- [ ] **Step 3: Replace the section body**
+
+Replace the `test_invariants() - required in every constructor test`
+section with:
+
+```markdown
+## `test_invariants()` - once per constructor per file
+
+Each test FILE calls `test_invariants(design)` once for each constructor it
+exercises - `as_survey()`, `as_survey_rep()`, `as_survey_twophase()`,
+`as_survey_nonprob()` - in the first block that builds with it. Later blocks
+in the same file do not repeat it.
+
+Measured rationale (issue #169): the per-block rule produced 645 calls and
+about 10,300 expectations - 53% of the suite - and stubbing it out moved
+package coverage by 0.0000 points across all 46 files in `R/`. The S7
+validators in `R/core-classes.R` enforce the same invariants on construction
+and on every property assignment, and no code in `R/` bypasses them.
+
+The helper still earns one call per constructor per file: it is the only
+guard against a constructor returning a malformed object through a route the
+validators do not see. `tests/testthat/test-invariants.R` keeps proving the
+helper still fires.
+```
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+    git add .claude/rules/testing-surveycore.md
+    git commit -m "docs: narrow the test_invariants() rule to one call per constructor per file"
+
+---
+
+## Phase 2 - Cut wall-time where it actually goes
+
+### Task 4: Find out whether the polychoric implementation is the bottleneck
+
+**This task replaces an earlier "share polychoric fixtures" task, which was
+checked and found void.** All 25 `make_latent_taylor()` calls in
+`test-analysis-corr-latent.R` use a **different seed** - 11, 40, 41, 42, 43,
+60 through 160 - so no two blocks share a fixture. The distinct seeds look
+deliberate: each block tests a different data realization, so a pass is not
+an artefact of one draw. Sharing would reduce test independence and save
+nothing, because the expensive step re-runs per block regardless.
+
+The expensive step is `get_corr(method = "polychoric")` - the
+maximum-likelihood fit - not fixture construction. That raises a sharper
+question: **33 seconds for one polychoric fit at `n = 300` is very slow.**
+`polycor::polychor()` on a 6x7 table that size normally returns in well
+under a second. If surveycore's `.corr_polychoric_mle()` is the reason, the
+fix belongs in `R/`, not in the tests - and it would speed up every user
+call to `get_corr(method = "polychoric")`, not just the suite.
+
+Settle that before touching any test.
+
+**Files:**
+- Read only: `R/analysis-corr.R`, `R/analysis-corr-helpers.R`
+- Create if the hypothesis holds: a new issue describing the slow path
+
+**Interfaces:**
+- Produces: a decision. Either Phase 2 stays a test-shrinking exercise
+  (Task 5), or it becomes an implementation-performance issue that dwarfs it.
+
+- [ ] **Step 1: Benchmark surveycore against polycor on identical data**
+
+Run with nothing else competing for CPU:
+
+```r
+library(surveycore)
+set.seed(87L)
+n <- 300L
+df <- data.frame(
+  id = 1:n,
+  wt = 1,
+  o1 = factor(sample(1:6, n, replace = TRUE), levels = 1:6, ordered = TRUE),
+  o2 = factor(sample(1:7, n, replace = TRUE), levels = 1:7, ordered = TRUE)
+)
+d <- as_survey(df, weights = wt)
+
+t_sc <- system.time(
+  r <- get_corr(d, x = c(o1, o2), method = "polychoric")
+)[["elapsed"]]
+t_pc <- system.time(
+  oracle <- polycor::polychor(df$o1, df$o2)
+)[["elapsed"]]
+
+cat("surveycore:", round(t_sc, 2), "s\n")
+cat("polycor:   ", round(t_pc, 2), "s\n")
+cat("ratio:     ", round(t_sc / max(t_pc, 1e-3), 1), "x\n")
+cat("estimates: ", r$r[[1L]], "vs", oracle, "\n")
+```
+
+- [ ] **Step 2: Decide from the ratio**
+
+- **Ratio under about 3x:** polychoric fitting is simply expensive at this
+  table size. Keep Phase 2 as written - go to Task 5 and shrink the fixture.
+- **Ratio above about 10x:** the implementation is the bottleneck. Stop
+  here. Open an issue against `R/analysis-corr.R` with these numbers, and
+  treat Task 5 as a small interim measure rather than the fix.
+
+#### RESULT - measured 2026-08-26, on a quiet CPU
+
+**The implementation is the bottleneck, by two orders of magnitude.**
+
+| Fixture | surveycore | `polycor` | Ratio |
+|---|---|---|---|
+| 6x7 table, n = 300 (the 33 s block) | 36.09 s | 0.22 s | **164x** |
+| 3x3 table, n = 200 (control) | 4.39 s | 0.03 s | **146x** |
+
+The estimates agree to 6.4e-12, so this is purely a speed defect, not a
+correctness one. The ratio holds at both table sizes, so it is a constant
+factor in the implementation - not a scaling effect of wide tables.
+
+Profile of the 6x7 fit, by self-time:
+
+| Entry | self % | total % |
+|---|---|---|
+| `pbivnorm::pbivnorm` | 16.8 | 84.3 |
+| `replace` | 13.7 | 13.7 |
+| `unique` | 11.4 | 14.4 |
+| `simplify2array` | 8.7 | 28.4 |
+| `.corr_bivnorm_cdf` | 7.8 | 94.0 |
+| `.corr_polychoric_loglik` | 4.6 | 93.5 |
+
+Only about 17% of the time is the actual numerical work. The rest is R-level
+plumbing around it.
+
+**Root cause.** `.corr_bivnorm_cdf()` (`R/analysis-corr-latent.R:340`) is
+scalar-only - its `if (is.na(a) || is.na(b) || ...)` guards require length-1
+input. `.corr_polychoric_loglik()` (`R/analysis-corr-latent.R:395-418`) calls
+it four times per cell inside a nested `for` loop over `k_x` by `k_y` cells.
+
+For a 6x7 table that is 42 cells x 4 calls = **168 separate scalar calls into
+`pbivnorm`'s Fortran routine per log-likelihood evaluation**, and the
+optimiser evaluates the likelihood many times per fit. `pbivnorm` is
+vectorised - it is built to take whole vectors in one call.
+
+**The fix, for the separate PR.** The four calls per cell only ever read from
+the `(k_x + 1)` by `(k_y + 1)` grid of threshold pairs - 56 distinct values
+for a 6x7 table, not 168. Evaluate that whole grid in **one** vectorised
+`pbivnorm` call per `rho`, then form each cell probability by differencing
+four entries of the resulting matrix. That removes both the repeated Fortran
+entry cost and the redundant recomputation, since each threshold pair is
+currently recomputed by up to four neighbouring cells.
+
+The same loop appears a second time at `R/analysis-corr-latent.R:709-712`.
+Fix both, or extract one shared helper.
+
+**Filed as issue #177.** That issue carries the benchmark, the profile, the
+root cause, and the suggested vectorisation, along with the tolerances any
+fix must hold.
+
+**Consequence for this plan:** Task 5 is now a small interim measure, not the
+fix. Do not spend effort shrinking test fixtures to work around a defect that
+belongs in `R/`. If #177 lands first, re-measure before doing Task 5 at all -
+it may become unnecessary.
+
+- [ ] **Step 3: If the implementation is slow, profile the hot path**
+
+```r
+Rprof(tmp <- tempfile(), interval = 0.01)
+invisible(get_corr(d, x = c(o1, o2), method = "polychoric"))
+Rprof(NULL)
+print(head(summaryRprof(tmp)$by.self, 15))
+```
+
+Record the top self-time entries in the new issue. Likely suspects are a
+per-cell loop, repeated `pmvnorm`-style bivariate normal integration, or a
+threshold search that re-derives values it already has.
+
+- [ ] **Step 4: Do not change `R/` under this plan**
+
+This plan's write surface is tests and rules. If Step 2 says the
+implementation is at fault, that is a separate PR with its own numerical
+tolerances to protect. Record it and move on to Task 5.
+
+### Task 5: Shrink the two slowest polychoric cases
+
+Two blocks cost 66 s between them. Polychoric fitting scales with table size
+and row count, so a smaller table is much cheaper. Shrink only where the
+property under test survives at the same tolerance.
+
+**Files:**
+- Modify: `tests/testthat/test-analysis-corr-latent.R`
+
+**Interfaces:**
+- Consumes: the shared fixtures from Task 4.
+
+- [ ] **Step 1: Read the two blocks**
+
+Run:
+
+    grep -n "6x7 ordinal pair runs without error" -A 25 tests/testthat/test-analysis-corr-latent.R
+    grep -n "matches polycor on 4x5 equal wt" -A 25 tests/testthat/test-analysis-corr-latent.R
+
+- [ ] **Step 2: Shrink the 6x7 block only**
+
+Only one of the two is safe to touch. This was checked:
+
+| Block | Time | Verdict |
+|---|---|---|
+| 6x7 ordinal pair (line 623) | 33.1 s | **Shrinkable.** Asserts only `expect_no_error()` and `is.finite()`. Nothing pins the table size. |
+| 4x5 `polycor` parity (line 179) | 32.9 s | **Leave alone.** Its comment pins the fixture to a spec fixture - `rho = -0.3, n = 800, k_x = 4, k_y = 5, seed = 2` - matching PR 1's primitives test at 1e-6. Shrinking breaks a documented link to the spec. |
+
+Halving Phase 2's headline saving is the correct outcome here. Do not
+"recover" it by shrinking the parity fixture.
+
+- [ ] **Step 3: Shrink the 6x7 case**
+
+The block at `tests/testthat/test-analysis-corr-latent.R:623` builds its own
+frame inline. Reduce the level counts:
+
+```r
+# before
+o1 = factor(sample(1:6, n, replace = TRUE), levels = 1:6, ordered = TRUE),
+o2 = factor(sample(1:7, n, replace = TRUE), levels = 1:7, ordered = TRUE)
+
+# after - 5x6 exercises the same wide-table path for fewer threshold
+# parameters. This block asserts "runs without error", not a table size.
+o1 = factor(sample(1:5, n, replace = TRUE), levels = 1:5, ordered = TRUE),
+o2 = factor(sample(1:6, n, replace = TRUE), levels = 1:6, ordered = TRUE)
+```
+
+If that is not enough, reduce `n <- 300L` as well. Nothing in the block
+depends on the row count either.
+
+- [ ] **Step 4: Re-run and compare**
+
+Run:
+
+    NOT_CRAN=true Rscript -e "r <- as.data.frame(devtools::test(filter = 'analysis-corr-latent')); cat('failed:', sum(r\$failed), 'TOTAL:', round(sum(r\$real),1), 's\n')"
+
+Expected: `failed: 0` and a total below Task 4's. If the shrunk case fails,
+restore the original size - the size mattered after all.
+
+- [ ] **Step 5: Confirm full-suite coverage is untouched**
+
+Run:
+
+    NOT_CRAN=true Rscript -e "cat(covr::percent_coverage(covr::package_coverage()), '\n')"
+
+Expected: `96.0938`.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+    air format .
+    git add tests/testthat/test-analysis-corr-latent.R
+    git commit -m "test(analysis): shrink the widest polychoric fixtures to cut fit time"
+
+### Task 6: Write down the two-speed local workflow
+
+11 test files carry a file-level `skip_on_cran()`, including both polychoric
+files. So `NOT_CRAN=true` runs everything (806 s) and a plain run skips
+those files (about 400 s). That is already a 2x lever, available today at no
+risk - it just is not written down anywhere.
+
+**Files:**
+- Modify: `.claude/rules/testing-surveycore.md`
+
+- [ ] **Step 1: Confirm the two speeds**
+
+Run:
+
+    Rscript -e "r <- as.data.frame(devtools::test()); cat('plain - passed:', sum(r\$passed), 'skipped:', sum(r\$skipped), 'time:', round(sum(r\$real),1), 's\n')"
+    NOT_CRAN=true Rscript -e "r <- as.data.frame(devtools::test()); cat('NOT_CRAN - passed:', sum(r\$passed), 'skipped:', sum(r\$skipped), 'time:', round(sum(r\$real),1), 's\n')"
+
+Expected: the plain run is roughly half the time with far more skips.
+
+- [ ] **Step 2: Add the section**
+
+```markdown
+## Two speeds of local test run
+
+11 files carry a file-level `skip_on_cran()`, including the two polychoric
+files that hold 42% of all test time.
+
+| Run | Command | Use for |
+|---|---|---|
+| Fast | `devtools::test()` | The edit-run loop. Skips the 11 slow files. |
+| Full | `NOT_CRAN=true devtools::test()` | Before any push or PR. Runs everything. |
+
+Always measure coverage with `NOT_CRAN=true`. Without it, the 11 files skip
+and coverage reads about 93.7% instead of about 96.1% (issue #159).
+```
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+    git add .claude/rules/testing-surveycore.md
+    git commit -m "docs: record the fast and full local test workflows"
+
+---
+
+## Final verification
+
+- [ ] **Full suite passes**
+
+Run:
+
+    NOT_CRAN=true Rscript -e "r <- as.data.frame(devtools::test()); cat('failed:', sum(r\$failed), 'skipped:', sum(r\$skipped), 'passed:', sum(r\$passed), 'time:', round(sum(r\$real),1), 's\n')"
+
+Expected: `failed: 0`, `skipped: 4`.
+
+- [ ] **Coverage held**
+
+Run:
+
+    NOT_CRAN=true Rscript -e "cat(covr::percent_coverage(covr::package_coverage()), '\n')"
+
+Expected: `96.0938`, and never below the 95% floor.
+
+- [ ] **Tree is clean after a test run** (proves Task 1)
+
+Run:
+
+    git status --porcelain | wc -l
+
+Expected: `0`.
+
+- [ ] **R CMD check clean**
+
+Run:
+
+    Rscript -e "devtools::check()"
+
+Expected: 0 errors, 0 warnings, at most 2 pre-approved notes.
+
+## Expected outcome
+
+| Measure | Before | Target | Confidence |
+|---|---|---|---|
+| Passing expectations | 19,314 | about 9,000-11,000 | High - measured |
+| Coverage | 96.0938% | 96.0938% - unchanged | High - measured |
+| Dirty files after a run | 38 | 0 | High - measured |
+| Fast-loop time | not documented | about 400 s | High - measured |
+| Full-suite time | 806 s | about 770 s from Task 5 alone | Low - see below |
+
+The expectation drop comes entirely from Phase 1 and buys legibility, not
+speed. Report the two separately.
+
+**Phase 2's saving is now much smaller than first drafted, and honest about
+it.** The original plan assumed shared fixtures (void - every seed differs)
+and assumed both 33-second blocks could shrink (only one can - the other is
+pinned to a spec fixture). What remains under this plan's write surface is
+one block worth about 33 s, so roughly 806 s becomes roughly 770 s.
+
+**Task 4 has now run, and the answer is issue #177.** The polychoric fit is
+164x slower than `polycor` because of scalar `pbivnorm` calls in a nested
+loop. The two latent files hold 341 s of the 806 s suite. Fixing #177 is
+worth roughly ten times every test edit in this plan combined, and it speeds
+up user calls to `get_corr(method = "polychoric")` as well.
+
+So the speed ranking is:
+
+1. **#177** - up to about 341 s, in a separate PR against `R/`.
+2. **Task 6** - about 400 s off the edit-run loop, no code change, available
+   today.
+3. **Task 5** - about 33 s, and possibly unnecessary once #177 lands.
+
+## Deliberately not in this plan
+
+Issue #169 lists four investigation steps. This plan acts on step 1 and
+leaves two others alone, on purpose:
+
+- **The both-modes rule (issue step 2) - not measured yet.** Test-spec
+  conventions run most behavioural rows in both survey-object and data-frame
+  mode, a 2x multiplier. Whether the two modes share a code path after
+  argument resolution has not been tested. It needs its own stub-and-measure
+  experiment, exactly like the one run for `test_invariants()`. Do not trim
+  it on suspicion.
+- **The dual pattern (issue step 3) - leave it.** `expect_error(class = )`
+  and `expect_snapshot(error = TRUE)` test different things: the condition
+  class and the rendered message. Message regressions have been caught by
+  snapshots in this repo before. The 522 snapshot calls stay.
+
+A third item is out of scope but worth its own issue: `test-dataset-metadata.R`
+holds 4,254 expectations - 22% of the suite - in one 4,277-line file. That is
+a legibility problem this plan does not address.
+
+## Open questions for the maintainer
+
+1. **Is one call per constructor per file the right level?** The measured
+   floor is zero - coverage is identical either way. One per constructor per
+   file is a judgement call that keeps a cheap guard against a malformed
+   constructor result. Zero is defensible on the evidence; this plan chooses
+   the conservative option.
+2. **Is the `polycor` parity suite worth 42% of test time?** It is a genuine
+   oracle test against an independent implementation, which is valuable. The
+   alternative is moving it to a nightly or on-demand lane rather than
+   shrinking it.
+3. **Phase 2 targets one file.** If `test-analysis-corr-latent.R` must keep
+   its current cost, the realistic full-suite floor is about 700 s, and the
+   fast-loop workflow in Task 6 becomes the main lever.

--- a/tests/testthat/test-analysis-corr.R
+++ b/tests/testthat/test-analysis-corr.R
@@ -1630,7 +1630,6 @@ test_that("get_corr() polyserial works for survey_nonprob with repweights", {
     repweights = tidyselect::all_of(repwt_cols),
     type = "bootstrap"
   )
-  test_invariants(d)
   result <- get_corr(d, x = c(ord1, y2), method = "polyserial")
   test_result_invariants(result, "survey_corr")
   expect_equal(nrow(result), 1L)
@@ -1650,7 +1649,6 @@ test_that("get_corr() polychoric raises PC-7 for survey_nonprob without repweigh
   df$ord2 <- cut(df$y2, breaks = 5, labels = FALSE, include.lowest = TRUE)
   df$ord2 <- factor(df$ord2, ordered = TRUE)
   d <- as_survey_nonprob(df, weights = wt)
-  test_invariants(d)
   expect_error(
     get_corr(d, x = c(ord1, ord2), method = "polychoric"),
     class = "surveycore_error_polychoric_design_unsupported"
@@ -1666,7 +1664,6 @@ test_that("get_corr() polyserial raises PC-7 for survey_nonprob without repweigh
   df$ord1 <- cut(df$y1, breaks = 5, labels = FALSE, include.lowest = TRUE)
   df$ord1 <- factor(df$ord1, ordered = TRUE)
   d <- as_survey_nonprob(df, weights = wt)
-  test_invariants(d)
   expect_error(
     get_corr(d, x = c(ord1, y2), method = "polyserial"),
     class = "surveycore_error_polychoric_design_unsupported"
@@ -1752,7 +1749,6 @@ test_that("get_corr() PC-4 fires through nonprob latent path when ordinal has on
     repweights = tidyselect::all_of(repwt_cols),
     type = "bootstrap"
   )
-  test_invariants(d)
   expect_error(
     get_corr(d, x = c(ord_single, ord2), method = "polychoric"),
     class = "surveycore_error_polychoric_single_level_ordinal"
@@ -1773,7 +1769,6 @@ test_that("get_corr() nonprob with repweights + method = 'pearson' is unchanged 
     repweights = tidyselect::all_of(repwt_cols),
     type = "bootstrap"
   )
-  test_invariants(d)
   result <- get_corr(d, x = c(y1, y2), method = "pearson")
   test_result_invariants(result, "survey_corr")
   expect_true(is.finite(result$r[[1L]]))
@@ -1810,7 +1805,6 @@ test_that("get_corr() all-NA ordinal returns NA (early-exit) through nonprob lat
     repweights = tidyselect::all_of(repwt_cols),
     type = "bootstrap"
   )
-  test_invariants(d)
   # All-NA ordinal: pairwise-complete domain is empty, early return with NA.
   result <- get_corr(d, x = c(ord_na, ord2), method = "polychoric")
   test_result_invariants(result, "survey_corr")

--- a/tests/testthat/test-analysis-covariance.R
+++ b/tests/testthat/test-analysis-covariance.R
@@ -50,7 +50,6 @@ test_that("get_covariance() Taylor SE matches SE(svyvar()) off-diag — NHANES [
     weights = wtmec2yr,
     nest = TRUE
   )
-  test_invariants(sc)
   sv <- survey::svydesign(
     ids = ~sdmvpsu,
     strata = ~sdmvstra,
@@ -73,7 +72,6 @@ test_that("get_covariance() Taylor SE matches SE(svyvar()) off-diag — NHANES [
 test_that("get_covariance() Wald CI = covariance ± qnorm(0.975) * SE", {
   df <- make_survey_data(n = 200L, n_psu = 20L, design = "taylor", seed = 1L)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- get_covariance(sc, c(y1, y2), variance = c("se", "ci"))
   z <- stats::qnorm(0.975)
@@ -96,7 +94,6 @@ test_that("get_covariance() Wald CI = covariance ± qnorm(0.975) * SE", {
 test_that("get_covariance() diagonal-parity gate — Taylor", {
   df <- make_survey_data(n = 200L, n_psu = 20L, design = "taylor", seed = 2L)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   # `c(y1, y1)` resolves to a single column under tidy-select, which would
   # trip the n>=2 guard. Use a duplicate column so we can exercise the
@@ -182,7 +179,6 @@ test_that("get_covariance() diagonal-parity gate — twophase", {
 
   ph1_sc <- as_survey(pbc_ph1, ids = row_id, weights = wt)
   d <- as_survey_twophase(ph1_sc, subset = in_ph2, method = "approx")
-  test_invariants(d)
 
   cov_diag <- suppressWarnings(get_covariance(
     d,
@@ -244,7 +240,6 @@ test_that("get_covariance() diagonal-parity gate — nonprob", {
 test_that("get_covariance() symmetry under redundant=TRUE — covariance and SE", {
   df <- make_survey_data(n = 200L, n_psu = 20L, design = "taylor", seed = 4L)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- get_covariance(
     sc,
@@ -320,7 +315,6 @@ test_that("get_covariance() nonprob matches svyvar() off-diag [oracle]", {
     w = runif(500L, 0.5, 2)
   )
   d <- as_survey_nonprob(df, weights = w)
-  test_invariants(d)
 
   d_sv <- survey::svydesign(ids = ~1, weights = ~w, data = df)
   sv <- survey::svyvar(~ a + b, d_sv, na.rm = TRUE)
@@ -347,7 +341,6 @@ test_that("get_covariance() twophase matches svyvar() off-diag [oracle]", {
 
   ph1_sc <- as_survey(pbc_ph1, ids = row_id, weights = wt)
   d_sc <- as_survey_twophase(ph1_sc, subset = in_ph2, method = "approx")
-  test_invariants(d_sc)
 
   d_sv <- survey::twophase(
     id = list(~1, ~1),
@@ -374,7 +367,6 @@ test_that("get_covariance() returns exact 0 when one var is constant", {
   df <- make_survey_data(n = 100L, design = "taylor", seed = 30L)
   df$const <- 7
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- suppressWarnings(get_covariance(
     sc,
@@ -395,7 +387,6 @@ test_that("get_covariance() returns 0 when both vars are constant", {
   df$c1 <- 1
   df$c2 <- 5
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- suppressWarnings(get_covariance(sc, c(c1, c2), variance = "se"))
   expect_identical(res$covariance[[1L]], 0)
@@ -409,7 +400,6 @@ test_that("get_covariance() returns 0 when both vars are constant", {
 test_that("get_covariance() name_style='broom' renames covariance/se/ci_low/ci_high", {
   df <- make_survey_data(n = 200L, n_psu = 20L, design = "taylor", seed = 40L)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- get_covariance(
     sc,
@@ -434,7 +424,6 @@ test_that("get_covariance() name_style='broom' renames covariance/se/ci_low/ci_h
 test_that("get_covariance() n_weighted = TRUE appends n_weighted column", {
   df <- make_survey_data(n = 200L, n_psu = 20L, design = "taylor", seed = 50L)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- get_covariance(sc, c(y1, y2), variance = NULL, n_weighted = TRUE)
   expect_true("n_weighted" %in% names(res))
@@ -455,7 +444,6 @@ test_that("get_covariance() attaches label attribute to every output column", {
     with_labels = TRUE
   )
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- get_covariance(
     sc,
@@ -493,7 +481,6 @@ test_that("get_covariance() conf_level interpolates into CI labels", {
 test_that("get_covariance() .meta has expected top-level keys", {
   df <- make_survey_data(n = 200L, design = "taylor", seed = 70L)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- get_covariance(sc, c(y1, y2))
   m <- meta(res)
@@ -1015,7 +1002,6 @@ test_that("get_covariance() replicate near-constant pair returns se = 0 (no NaN)
     repweights = all_of(rep_cols),
     type = "BRR"
   )
-  test_invariants(sc)
   res <- suppressWarnings(
     get_covariance(sc, c(const1, const2), variance = c("se", "ci"))
   )
@@ -1056,7 +1042,6 @@ test_that("get_covariance() group= matches svyby(svyvar) off-diag [oracle]", {
   df <- make_survey_data(n = 400L, n_psu = 40L, design = "taylor", seed = 300L)
   df$g <- factor(sample(c("A", "B"), nrow(df), replace = TRUE))
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
   sv <- survey::svydesign(
     ids = ~psu,
     strata = ~strata,

--- a/tests/testthat/test-analysis-helpers.R
+++ b/tests/testthat/test-analysis-helpers.R
@@ -697,7 +697,6 @@ test_that(".degf() returns design-based finite df for survey_twophase", {
   twophase <- suppressWarnings(
     as_survey_twophase(phase1, subset = subset, method = "approx")
   )
-  test_invariants(twophase)
 
   expect_equal(.degf(twophase), .degf(phase1))
   expect_true(is.finite(.degf(phase1)))
@@ -708,7 +707,6 @@ test_that(".degf() returns design-based finite df for SRS-style design", {
   # SRS with 50 rows → degf = 50 - 1 = 49
   df <- make_survey_data(n = 50L, n_psu = 6L, n_strata = 1L, seed = 13L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
 
   expect_equal(.degf(d), nrow(df) - 1L)
 })
@@ -746,7 +744,6 @@ test_that(".degf() returns Inf for survey_nonprob with repweights", {
     weights = wt,
     repweights = starts_with("repwt_")
   )
-  test_invariants(d)
 
   expect_equal(.degf(d), Inf)
 })

--- a/tests/testthat/test-analysis-methods-coef-vcov.R
+++ b/tests/testthat/test-analysis-methods-coef-vcov.R
@@ -744,7 +744,6 @@ test_that("coef.survey_result() returns group-major names for grouped quantiles"
 test_that("confint.survey_result() uses t-distribution for Taylor designs (finite df)", {
   df <- make_survey_data(design = "taylor", seed = 63)
   d <- as_survey(df, ids = psu, weights = wt, strata = strata)
-  test_invariants(d)
   result <- get_means(d, y1, variance = "se")
   df_stored <- attr(result, ".survey_result")$df
   expect_true(all(is.finite(df_stored)))
@@ -766,7 +765,6 @@ test_that("confint.survey_result() matches normal approximation for replicate de
     repweights = tidyselect::starts_with("repwt_"),
     type = "BRR"
   )
-  test_invariants(d)
   result <- get_means(d, y1, variance = "se")
   expect_true(is.infinite(attr(result, ".survey_result")$df[1]))
   ci <- confint(result, level = 0.95)
@@ -799,7 +797,6 @@ test_that("vcov/SE/confint throw surveycore_error_result_method_unsupported for 
       nest = TRUE
     )
   )
-  test_invariants(d_gss)
   result <- suppressWarnings(get_pairwise(d_gss, age, by = sex))
   expect_error(
     vcov(result),
@@ -874,7 +871,6 @@ test_that("confint.survey_result() uses finite design df for Taylor designs", {
     y1 = c(10, 12, 9, 11, 8, 7, 6, 9)
   )
   d <- as_survey(small_df, ids = psu, weights = wt, strata = strata)
-  test_invariants(d)
   result <- suppressWarnings(get_means(d, y1, variance = "se"))
   df_stored <- attr(result, ".survey_result")$df
   # 4 PSUs in 2 strata => df = sum(n_h - 1) = (2-1) + (2-1) = 2
@@ -895,7 +891,6 @@ test_that("confint.survey_result() matches normal approximation for replicate (Â
     repweights = tidyselect::starts_with("repwt_"),
     type = "BRR"
   )
-  test_invariants(d)
   result <- get_means(d, y1, variance = "se")
   expect_true(is.infinite(attr(result, ".survey_result")$df))
   ci <- confint(result, level = 0.95)
@@ -1072,7 +1067,6 @@ test_that("vcov() diagonal matches SE^2 for replicate design", {
     repweights = tidyselect::starts_with("repwt_"),
     type = "BRR"
   )
-  test_invariants(d)
   result <- get_means(d, y1, variance = "se")
   v <- vcov(result)
   se_val <- SE(result)
@@ -1132,7 +1126,6 @@ test_that("coef() for get_diffs() two-group names are correct", {
 test_that("coef() works before broom rename and throws SCR-1 after rename", {
   df <- make_survey_data(seed = 19L)
   d <- as_survey(df, ids = psu, weights = wt, strata = strata)
-  test_invariants(d)
   result <- suppressWarnings(get_means(d, y1, variance = "se"))
   # Works before broom rename
   expect_no_error(coef(result))

--- a/tests/testthat/test-analysis-variance-twophase-nonprob.R
+++ b/tests/testthat/test-analysis-variance-twophase-nonprob.R
@@ -72,7 +72,6 @@ test_that("get_variance() twophase full matches survey::svyvar on pbc [oracle]",
     subset = in_ph2,
     method = "full"
   )
-  test_invariants(d_sc)
 
   d_sv <- survey::twophase(
     id = list(~1, ~1),
@@ -108,7 +107,6 @@ test_that("get_variance() twophase n reflects Phase 2 sample size", {
 
   ph1_sc <- as_survey(pbc_ph1, ids = row_id, weights = wt)
   d_sc <- as_survey_twophase(ph1_sc, subset = in_ph2, method = "approx")
-  test_invariants(d_sc)
 
   sc_est <- get_variance(d_sc, chol, variance = "se")
 
@@ -169,7 +167,6 @@ test_that("get_variance() nonprob excludes zero-weight rows from n and mean", {
   df_inj <- df_pos
   df_inj$w[zero_idx] <- 0
   d <- S7::set_props(d, data = df_inj)
-  test_invariants(d)
 
   # Oracle: pre-filter zero-weight rows, then run svyvar on svydesign(ids=~1)
   df_keep <- df_inj[df_inj$w > 0, , drop = FALSE]
@@ -208,7 +205,6 @@ test_that("get_variance() twophase returns survey_variance tibble", {
 
   ph1_sc <- as_survey(pbc_ph1, ids = row_id, weights = wt)
   d <- as_survey_twophase(ph1_sc, subset = in_ph2, method = "approx")
-  test_invariants(d)
 
   sc <- get_variance(d, chol)
   expect_s3_class(sc, "survey_variance")
@@ -222,7 +218,6 @@ test_that("get_variance() nonprob returns survey_variance tibble", {
   set.seed(301L)
   df <- data.frame(y = rnorm(100L), w = runif(100L, 0.5, 2))
   d <- as_survey_nonprob(df, weights = w)
-  test_invariants(d)
 
   sc <- get_variance(d, y)
   expect_s3_class(sc, "survey_variance")

--- a/tests/testthat/test-analysis-variance.R
+++ b/tests/testthat/test-analysis-variance.R
@@ -49,7 +49,6 @@ test_that("get_variance() Taylor SE matches SE(svyvar()) — NHANES [oracle]", {
     weights = wtmec2yr,
     nest = TRUE
   )
-  test_invariants(sc)
   sv <- survey::svydesign(
     ids = ~sdmvpsu,
     strata = ~sdmvstra,
@@ -79,7 +78,6 @@ test_that("get_variance() Taylor CI = coef +/- qnorm(0.975) * SE — NHANES [ora
     weights = wtmec2yr,
     nest = TRUE
   )
-  test_invariants(sc)
 
   sc_est <- get_variance(sc, ridageyr, variance = c("se", "ci"))
   z <- stats::qnorm(0.975)
@@ -151,7 +149,6 @@ test_that("get_variance() multi-variable pairwise matches per-variable svyvar() 
     weights = wtmec2yr,
     nest = TRUE
   )
-  test_invariants(sc)
   sv <- survey::svydesign(
     ids = ~sdmvpsu,
     strata = ~sdmvstra,
@@ -183,7 +180,6 @@ test_that("get_variance() listwise matches svyvar() diagonal on shared complete 
     weights = wtmec2yr,
     nest = TRUE
   )
-  test_invariants(sc)
   sv <- survey::svydesign(
     ids = ~sdmvpsu,
     strata = ~sdmvstra,
@@ -224,7 +220,6 @@ test_that("get_variance() group= matches svyby(svyvar) [oracle]", {
     weights = wtmec2yr,
     nest = TRUE
   )
-  test_invariants(sc)
   sv <- survey::svydesign(
     ids = ~sdmvpsu,
     strata = ~sdmvstra,
@@ -271,7 +266,6 @@ test_that("get_variance() group_by(design) matches group= [oracle]", {
     weights = wtmec2yr,
     nest = TRUE
   )
-  test_invariants(sc)
 
   sc_grouped <- surveytidy::group_by(sc, riagendr)
   est_a <- suppressWarnings(
@@ -295,7 +289,6 @@ test_that("get_variance() constant variable returns exact 0 for point + SE + CI 
   df <- make_survey_data(n = 50L, design = "taylor", seed = 101L)
   df$const <- 7
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- suppressWarnings(
     get_variance(sc, const, variance = c("se", "ci", "var", "moe", "deff"))
@@ -314,7 +307,6 @@ test_that("get_variance() constant variable with variance='cv' fires cv_undefine
   df <- make_survey_data(n = 50L, design = "taylor", seed = 102L)
   df$const <- 3
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   expect_warning(
     res <- get_variance(sc, const, variance = "cv"),
@@ -330,7 +322,6 @@ test_that("get_variance() constant variable with variance='cv' fires cv_undefine
 test_that("get_variance() name_style='broom' renames variance/se/ci_low/ci_high", {
   df <- make_survey_data(n = 200L, n_psu = 20L, design = "taylor", seed = 103L)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- get_variance(
     sc,
@@ -360,7 +351,6 @@ test_that("get_variance() name_style='broom' renames variance/se/ci_low/ci_high"
 test_that("get_variance() n_weighted = TRUE appends n_weighted column", {
   df <- make_survey_data(n = 200L, n_psu = 20L, design = "taylor", seed = 104L)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- get_variance(sc, y1, variance = NULL, n_weighted = TRUE)
   expect_true("n_weighted" %in% names(res))
@@ -376,7 +366,6 @@ test_that("get_variance() n_weighted = TRUE appends n_weighted column", {
 test_that("get_variance() attaches label attribute to every output column", {
   df <- make_survey_data(n = 200L, n_psu = 20L, design = "taylor", seed = 105L)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- get_variance(
     sc,
@@ -402,7 +391,6 @@ test_that("get_variance() attaches label attribute to every output column", {
 test_that("get_variance() conf_level interpolates into CI labels", {
   df <- make_survey_data(n = 200L, n_psu = 20L, design = "taylor", seed = 106L)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- get_variance(sc, y1, variance = "ci", conf_level = 0.90)
   expect_identical(attr(res$ci_low, "label"), "90% CI low")
@@ -416,7 +404,6 @@ test_that("get_variance() conf_level interpolates into CI labels", {
 test_that("get_variance() .meta has FAMILY_META_KEYS + design_class + conf_level + name_style + min_cell_n + na_handling", {
   df <- make_survey_data(n = 200L, n_psu = 20L, design = "taylor", seed = 107L)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- get_variance(sc, y1)
   m <- meta(res)
@@ -446,7 +433,6 @@ test_that("get_variance() .meta has FAMILY_META_KEYS + design_class + conf_level
 test_that("get_variance() .meta$group populated when grouping is active", {
   df <- make_survey_data(n = 200L, n_psu = 20L, design = "taylor", seed = 108L)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- suppressWarnings(get_variance(sc, y1, group = group))
   m <- meta(res)
@@ -466,7 +452,6 @@ test_that("get_variance() label_vars = TRUE/FALSE controls name column display",
     with_labels = TRUE
   )
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   # Set a variable label so label_vars has a visible effect
   sc2 <- set_var_label(sc, y1 = "Outcome Y1")
@@ -480,7 +465,6 @@ test_that("get_variance() label_vars = TRUE/FALSE controls name column display",
 test_that("get_variance() label_vars = TRUE falls back to raw name when label is unset", {
   df <- make_survey_data(n = 200L, n_psu = 20L, design = "taylor", seed = 110L)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   # No label set on y1; label_vars=TRUE should fall back
   res <- get_variance(sc, y1, label_vars = TRUE)
@@ -494,7 +478,6 @@ test_that("get_variance() label_vars = TRUE falls back to raw name when label is
 test_that("get_variance() decimals = 3 rounds every numeric output column exactly", {
   df <- make_survey_data(n = 200L, n_psu = 20L, design = "taylor", seed = 111L)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res_full <- get_variance(
     sc,
@@ -528,7 +511,6 @@ test_that("get_variance() decimals = 3 rounds every numeric output column exactl
 test_that("get_variance() deff = (se / se_srs)^2 where se_srs is SRS-of-score SE", {
   df <- make_survey_data(n = 200L, n_psu = 20L, design = "taylor", seed = 112L)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- get_variance(sc, y1, variance = c("se", "deff"))
 
@@ -553,7 +535,6 @@ test_that("get_variance() deff = (se / se_srs)^2 where se_srs is SRS-of-score SE
 test_that("get_variance() print method returns invisibly and does not error", {
   df <- make_survey_data(n = 200L, n_psu = 20L, design = "taylor", seed = 113L)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res_single <- get_variance(sc, y1)
   res_multi <- suppressWarnings(get_variance(sc, c(y1, y2)))
@@ -572,7 +553,6 @@ test_that("broom::tidy(survey_variance) returns a tibble", {
   skip_if_not_installed("broom")
   df <- make_survey_data(n = 200L, n_psu = 20L, design = "taylor", seed = 114L)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- get_variance(sc, y1)
   td <- broom::tidy(res)
@@ -583,7 +563,6 @@ test_that("broom::glance(survey_variance) returns a 1-row tibble", {
   skip_if_not_installed("broom")
   df <- make_survey_data(n = 200L, n_psu = 20L, design = "taylor", seed = 115L)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- get_variance(sc, y1)
   gl <- broom::glance(res)
@@ -731,7 +710,6 @@ test_that("get_variance() rejects unknown na_handling via match.arg()", {
 test_that("get_variance() fires small_cell when any row has n < min_cell_n", {
   df <- make_survey_data(n = 20L, n_psu = 10L, design = "taylor", seed = 301L)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   expect_warning(
     get_variance(sc, y1),
@@ -743,7 +721,6 @@ test_that("get_variance() fires single_level when grouping var has one observed 
   df <- make_survey_data(n = 100L, design = "taylor", seed = 302L)
   df$const_grp <- 1L
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   expect_warning(
     get_variance(sc, y1, group = const_grp),
@@ -755,7 +732,6 @@ test_that("get_variance() fires cv_undefined when variance='cv' on constant vari
   df <- make_survey_data(n = 100L, design = "taylor", seed = 303L)
   df$const <- 5
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   expect_warning(
     get_variance(sc, const, variance = "cv"),
@@ -767,7 +743,6 @@ test_that("get_variance() fires variance_all_na when focal var is all-NA in acti
   df <- make_survey_data(n = 100L, design = "taylor", seed = 304L)
   df$allna <- NA_real_
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   expect_warning(
     get_variance(sc, allna),
@@ -783,7 +758,6 @@ test_that("get_variance() fires variance_all_na under listwise with empty inters
   df$a[1:50] <- NA
   df$b[51:100] <- NA
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   expect_warning(
     get_variance(sc, c(a, b), na_handling = "listwise"),
@@ -796,7 +770,6 @@ test_that("get_variance() fires variance_insufficient_n when n == 1", {
   df$one <- NA_real_
   df$one[[1L]] <- 42
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   expect_warning(
     get_variance(sc, one),
@@ -812,7 +785,6 @@ test_that("get_variance() all-NA focal with na.rm=TRUE returns NaN point + uncer
   df <- make_survey_data(n = 100L, design = "taylor", seed = 401L)
   df$allna <- NA_real_
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- suppressWarnings(
     get_variance(sc, allna, variance = c("se", "ci", "var", "moe", "deff"))
@@ -829,7 +801,6 @@ test_that("get_variance() single non-NA observation returns NaN point + n=1", {
   df$one <- NA_real_
   df$one[[1L]] <- 3.14
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- suppressWarnings(get_variance(sc, one))
   expect_true(is.nan(res$variance[[1L]]))
@@ -841,7 +812,6 @@ test_that("get_variance() na.rm=FALSE with NAs returns NaN estimate", {
   df$y_na <- df$y1
   df$y_na[1:5] <- NA
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- suppressWarnings(get_variance(sc, y_na, na.rm = FALSE))
   # n reflects all in-domain rows regardless of NA (spec §Edge cases)
@@ -853,7 +823,6 @@ test_that("get_variance() single-level grouping produces one row per focal varia
   df <- make_survey_data(n = 100L, design = "taylor", seed = 404L)
   df$g1 <- 1L
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- suppressWarnings(get_variance(sc, y1, group = g1))
   expect_identical(nrow(res), 1L)
@@ -866,7 +835,6 @@ test_that("get_variance() listwise shares n across variables with differing NA p
   df$a[1:20] <- NA
   df$b[21:40] <- NA
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- suppressWarnings(
     get_variance(sc, c(a, b), na_handling = "listwise")
@@ -881,7 +849,6 @@ test_that("get_variance() pairwise per-variable n differs across rows", {
   df$a[1:20] <- NA
   df$b[21:40] <- NA
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- suppressWarnings(
     get_variance(sc, c(a, b), na_handling = "pairwise")
@@ -908,7 +875,6 @@ test_that("get_variance() replicate near-zero variance returns se = 0 via max(0,
     repweights = all_of(rep_cols),
     type = "BRR"
   )
-  test_invariants(sc)
 
   res <- suppressWarnings(
     get_variance(sc, const, variance = c("se", "ci"))
@@ -924,7 +890,6 @@ test_that("get_variance() CI bounds are NOT clamped at zero (may be negative)", 
   df <- make_survey_data(n = 200L, n_psu = 20L, design = "taylor", seed = 408L)
   df$near <- 1 + rnorm(nrow(df)) * 1e-6 # near-constant, tiny variance
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
-  test_invariants(sc)
 
   res <- get_variance(sc, near, variance = c("se", "ci"))
   # Check that we DO NOT clamp: if ci_low < 0 arithmetically, it stays negative

--- a/tests/testthat/test-calibration.R
+++ b/tests/testthat/test-calibration.R
@@ -940,7 +940,6 @@ test_that("as_survey() with calibration = list() succeeds; @calibration is list(
 test_that("as_survey() with calibration = NULL succeeds; @calibration is NULL", {
   df <- data.frame(y = 1:10, wt = rep(1, 10))
   d <- suppressWarnings(as_survey(df, weights = wt, calibration = NULL))
-  test_invariants(d)
   expect_null(d@calibration)
 })
 
@@ -1049,7 +1048,6 @@ test_that("as_survey_replicate() with calibration = NULL succeeds", {
     type = "BRR",
     calibration = NULL
   )
-  test_invariants(d)
   expect_null(d@calibration)
 })
 
@@ -1068,7 +1066,6 @@ test_that("as_survey_replicate() SE unchanged with/without @calibration (provena
     repweights = tidyselect::all_of(repwt_cols),
     type = "BRR"
   )
-  test_invariants(d_without)
   cd <- as_caldata(df$wt, rep(1.05, nrow(df)), matrix(1, nrow(df), 1))
   d_with <- as_survey_replicate(
     df,
@@ -1090,7 +1087,6 @@ test_that("as_survey() stores calibration argument at @calibration", {
   mm <- model.matrix(~strata, df)
   cd <- as_caldata(base_w, g_w, mm)
   d <- as_survey(df, weights = wt, calibration = list(cd))
-  test_invariants(d)
   expect_identical(d@calibration, list(cd))
 })
 
@@ -1099,7 +1095,6 @@ test_that("as_survey() stores list of two caldata elements at @calibration", {
   cd1 <- as_caldata(df$wt, rep(1.05, nrow(df)), matrix(1, nrow(df), 1))
   cd2 <- as_caldata(df$wt, rep(1.02, nrow(df)), matrix(1, nrow(df), 1))
   d <- as_survey(df, weights = wt, calibration = list(cd1, cd2))
-  test_invariants(d)
   expect_identical(d@calibration, list(cd1, cd2))
 })
 
@@ -1109,7 +1104,6 @@ test_that("as_survey() @calibration matches whether set via arg or post-construc
   d_via_arg <- as_survey(df, weights = wt, calibration = list(cd))
   d_post <- as_survey(df, weights = wt)
   d_post@calibration <- list(cd)
-  test_invariants(d_via_arg)
   expect_identical(d_via_arg@calibration, d_post@calibration)
 })
 
@@ -1127,6 +1121,5 @@ test_that("as_survey_replicate() stores calibration argument at @calibration", {
     type = "BRR",
     calibration = list(cd)
   )
-  test_invariants(d)
   expect_identical(d@calibration, list(cd))
 })

--- a/tests/testthat/test-constructors.R
+++ b/tests/testthat/test-constructors.R
@@ -29,7 +29,6 @@ test_that("as_survey() creates survey_taylor with NULL ids/strata (no ids or str
 test_that("as_survey() creates survey_taylor for weighted SRS (weights only)", {
   df <- make_survey_data(n = 100, seed = 1L)
   d <- suppressWarnings(as_survey(df, weights = wt))
-  test_invariants(d)
   expect_true(S7::S7_inherits(d, survey_taylor))
   expect_identical(d@variables$weights, "wt")
   expect_identical(d@variables$ids, NULL)
@@ -39,7 +38,6 @@ test_that("as_survey() creates survey_taylor for weighted SRS (weights only)", {
 test_that("as_survey() creates survey_taylor for stratified design", {
   df <- make_survey_data(n = 200, seed = 2L)
   d <- as_survey(df, weights = wt, strata = strata)
-  test_invariants(d)
   expect_true(S7::S7_inherits(d, survey_taylor))
   expect_identical(d@variables$weights, "wt")
   expect_identical(d@variables$strata, "strata")
@@ -49,7 +47,6 @@ test_that("as_survey() creates survey_taylor for stratified design", {
 test_that("as_survey() creates survey_taylor for single-stage cluster design", {
   df <- make_survey_data(n = 200, seed = 3L)
   d <- suppressWarnings(as_survey(df, ids = psu, weights = wt, strata = strata))
-  test_invariants(d)
   expect_true(S7::S7_inherits(d, survey_taylor))
   expect_identical(d@variables$ids, "psu")
   expect_identical(d@variables$weights, "wt")
@@ -68,7 +65,6 @@ test_that("as_survey() creates survey_taylor for NHANES design (nest = TRUE)", {
     strata = sdmvstra,
     nest = TRUE
   )
-  test_invariants(d)
   expect_true(S7::S7_inherits(d, survey_taylor))
   expect_identical(d@variables$ids, "sdmvpsu")
   expect_identical(d@variables$weights, "wtmec2yr")
@@ -86,7 +82,6 @@ test_that("as_survey() stores call in @call", {
 test_that("as_survey() extracts haven metadata when present", {
   df <- make_survey_data(n = 100, with_labels = TRUE, seed = 5L)
   d <- suppressWarnings(as_survey(df, weights = wt))
-  test_invariants(d)
   expect_identical(
     d@metadata@variable_labels[["y1"]],
     "Outcome variable 1 (continuous)"
@@ -97,7 +92,6 @@ test_that("as_survey() extracts haven metadata when present", {
 test_that("as_survey() returns an empty metadata object when no haven attrs", {
   df <- make_survey_data(n = 50, seed = 6L)
   d <- suppressWarnings(as_survey(df, weights = wt))
-  test_invariants(d)
   expect_identical(length(d@metadata@variable_labels), 0L)
 })
 
@@ -107,7 +101,6 @@ test_that("as_survey() returns an empty metadata object when no haven attrs", {
 test_that("as_survey() converts probs to weights (1/probs) stored as ..surveycore_wt..", {
   df <- data.frame(y = 1:5, prob = rep(0.2, 5))
   d <- suppressWarnings(as_survey(df, probs = prob))
-  test_invariants(d)
   expect_identical(d@variables$weights, surveycore:::.SURVEYCORE_WT_COL)
   expect_true(d@variables$probs_provided)
   expect_equal(d@data[[surveycore:::.SURVEYCORE_WT_COL]], rep(5, 5))
@@ -126,7 +119,6 @@ test_that("as_survey() uses weights when both probs and weights are consistent",
     },
     class = "surveycore_inform_probs_weights_consistent"
   )
-  test_invariants(d)
   expect_identical(d@variables$weights, "wt")
   expect_true(d@variables$probs_provided)
 })
@@ -134,7 +126,6 @@ test_that("as_survey() uses weights when both probs and weights are consistent",
 test_that("as_survey() stores fpc column name in @variables", {
   df <- make_survey_data(n = 100, seed = 7L)
   d <- suppressWarnings(as_survey(df, weights = wt, fpc = fpc))
-  test_invariants(d)
   expect_identical(d@variables$fpc, "fpc")
 })
 
@@ -251,7 +242,6 @@ test_that("as_survey() warns with SRS message when strata given but no ids and n
 test_that("as_survey() creates equal weights (..surveycore_wt..) for SRS [row 7]", {
   df <- data.frame(y = 1:10)
   d <- suppressWarnings(as_survey(df))
-  test_invariants(d)
   expect_identical(d@data[[surveycore:::.SURVEYCORE_WT_COL]], rep(1L, 10L))
 })
 
@@ -376,7 +366,6 @@ test_that("as_survey() errors when nest = TRUE and strata is NULL [row 15]", {
 test_that("as_survey() handles weights with NA values mixed in (valid)", {
   df <- data.frame(x = 1:5, wt = c(1.0, NA_real_, 2.0, 1.5, NA_real_))
   d <- suppressWarnings(as_survey(df, weights = wt))
-  test_invariants(d)
   expect_identical(d@variables$weights, "wt")
 })
 
@@ -384,7 +373,6 @@ test_that("as_survey() with tibble input (inherits data.frame)", {
   skip_if_not_installed("tibble")
   tb <- tibble::tibble(y = 1:10, wt = runif(10, 0.5, 2))
   d <- suppressWarnings(as_survey(tb, weights = wt))
-  test_invariants(d)
   expect_true(S7::S7_inherits(d, survey_taylor))
 })
 
@@ -442,14 +430,12 @@ test_that("as_survey() does NOT warn for PSU in multiple strata when nest = TRUE
 test_that("as_survey() accepts bare name for weights", {
   df <- data.frame(y = 1:5, weight_col = rep(1, 5))
   d <- suppressWarnings(as_survey(df, weights = weight_col))
-  test_invariants(d)
   expect_identical(d@variables$weights, "weight_col")
 })
 
 test_that("as_survey() accepts bare name for strata", {
   df <- data.frame(y = 1:10, wt = rep(1, 10), region = rep(c("N", "S"), 5))
   d <- as_survey(df, weights = wt, strata = region)
-  test_invariants(d)
   expect_identical(d@variables$strata, "region")
 })
 
@@ -460,14 +446,12 @@ test_that("as_survey() accepts c() for multi-stage cluster ids", {
     wt = rep(1, 20)
   )
   d <- as_survey(df, ids = c(psu, ssu), weights = wt)
-  test_invariants(d)
   expect_identical(d@variables$ids, c("psu", "ssu"))
 })
 
 test_that("as_survey() accepts single bare name for ids", {
   df <- make_survey_data(n = 100, seed = 10L)
   d <- suppressWarnings(as_survey(df, ids = psu, weights = wt, strata = strata))
-  test_invariants(d)
   expect_identical(d@variables$ids, "psu")
 })
 
@@ -514,7 +498,6 @@ test_that("as_survey_replicate() creates survey_replicate for JK1 design (bare n
     repweights = starts_with("repwt_"),
     type = "JK1"
   )
-  test_invariants(d)
   expect_true(S7::S7_inherits(d, survey_replicate))
   expect_identical(d@variables$type, "JK1")
 })
@@ -533,7 +516,6 @@ test_that("as_survey_replicate() creates survey_replicate for bootstrap design",
     repweights = starts_with("repwt_"),
     type = "bootstrap"
   )
-  test_invariants(d)
   expect_true(S7::S7_inherits(d, survey_replicate))
   expect_identical(d@variables$type, "bootstrap")
 })
@@ -564,7 +546,6 @@ test_that("as_survey_replicate() extracts haven metadata when present", {
     repweights = starts_with("repwt_"),
     type = "JK1"
   )
-  test_invariants(d)
   expect_identical(
     d@metadata@variable_labels[["y1"]],
     "Outcome variable 1 (continuous)"
@@ -579,7 +560,6 @@ test_that("as_survey_replicate() returns empty metadata when no haven attrs", {
     repweights = starts_with("repwt_"),
     type = "JK1"
   )
-  test_invariants(d)
   expect_identical(length(d@metadata@variable_labels), 0L)
 })
 
@@ -599,7 +579,6 @@ test_that("as_survey_replicate() accepts explicit rscales of correct length", {
     type = "JK1",
     rscales = rep(1, n_rep)
   )
-  test_invariants(d)
   expect_identical(length(d@variables$rscales), n_rep)
 })
 
@@ -612,7 +591,6 @@ test_that("as_survey_replicate() accepts explicit scale argument", {
     type = "JK1",
     scale = 0.5
   )
-  test_invariants(d)
   expect_equal(d@variables$scale, 0.5)
 })
 
@@ -708,7 +686,6 @@ test_that("as_survey_replicate() stores fpc column name when fpc provided", {
     type = "BRR",
     fpc = fpc
   )
-  test_invariants(d)
   expect_identical(d@variables$fpc, "fpc")
 })
 
@@ -898,7 +875,6 @@ test_that("as_survey_replicate() with tibble input (inherits data.frame)", {
     repweights = starts_with("repwt_"),
     type = "JK1"
   )
-  test_invariants(d)
   expect_true(S7::S7_inherits(d, survey_replicate))
 })
 
@@ -946,7 +922,6 @@ test_that("as_survey_replicate() accepts starts_with() for repweights", {
     repweights = starts_with("repwt_"),
     type = "BRR"
   )
-  test_invariants(d)
   expect_true(all(startsWith(d@variables$repweights, "repwt_")))
 })
 
@@ -964,7 +939,6 @@ test_that("as_survey_replicate() accepts c() for explicit repweight columns", {
     repweights = c(r1, r2, r3),
     type = "JK1"
   )
-  test_invariants(d)
   expect_identical(d@variables$repweights, c("r1", "r2", "r3"))
 })
 
@@ -981,7 +955,6 @@ test_that("as_survey_replicate() accepts bare name for weights", {
     repweights = starts_with("r"),
     type = "JK1"
   )
-  test_invariants(d)
   expect_identical(d@variables$weights, "sampling_weight")
 })
 
@@ -996,7 +969,6 @@ test_that("as_survey_twophase() creates survey_twophase for minimal two-phase de
   df <- make_survey_data(n = 200, design = "twophase", seed = 1L)
   phase1 <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
   d2 <- as_survey_twophase(phase1, subset = subset)
-  test_invariants(d2)
   expect_true(S7::S7_inherits(d2, survey_twophase))
   expect_identical(d2@variables$subset, "subset")
   expect_identical(d2@variables$method, "full")
@@ -1006,7 +978,6 @@ test_that("as_survey_twophase() creates survey_twophase with method = 'approx'",
   df <- make_survey_data(n = 200, design = "twophase", seed = 2L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
   d2 <- as_survey_twophase(phase1, subset = subset, method = "approx")
-  test_invariants(d2)
   expect_identical(d2@variables$method, "approx")
 })
 
@@ -1015,7 +986,6 @@ test_that("as_survey_twophase() creates survey_twophase with method = 'simple' (
   df <- make_survey_data(n = 200, design = "twophase", seed = 3L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
   d2 <- as_survey_twophase(phase1, subset = subset, method = "simple")
-  test_invariants(d2)
   expect_identical(d2@variables$method, "simple")
 })
 
@@ -1023,7 +993,6 @@ test_that("as_survey_twophase() stores Phase 2 stratification in @variables$phas
   df <- make_survey_data(n = 200, design = "twophase", seed = 4L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
   d2 <- as_survey_twophase(phase1, strata2 = strata, subset = subset)
-  test_invariants(d2)
   expect_identical(d2@variables$phase2$strata, "strata")
   expect_null(d2@variables$phase2$ids)
   expect_null(d2@variables$phase2$probs)
@@ -1041,7 +1010,6 @@ test_that("as_survey_twophase() stores Phase 2 probs in @variables$phase2", {
     subset = subset,
     method = "full"
   )
-  test_invariants(d2)
   expect_identical(d2@variables$phase2$probs, "subsamprate")
 })
 
@@ -1049,7 +1017,6 @@ test_that("as_survey_twophase() stores Phase 2 cluster ids in @variables$phase2"
   df <- make_survey_data(n = 200, design = "twophase", seed = 6L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
   d2 <- as_survey_twophase(phase1, ids2 = psu, subset = subset)
-  test_invariants(d2)
   expect_identical(d2@variables$phase2$ids, "psu")
 })
 
@@ -1057,7 +1024,6 @@ test_that("as_survey_twophase() stores Phase 2 fpc in @variables$phase2", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 7L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
   d2 <- as_survey_twophase(phase1, fpc2 = fpc, subset = subset)
-  test_invariants(d2)
   expect_identical(d2@variables$phase2$fpc, "fpc")
 })
 
@@ -1065,7 +1031,6 @@ test_that("as_survey_twophase() stores Phase 1 @variables in @variables$phase1",
   df <- make_survey_data(n = 200, design = "twophase", seed = 8L)
   phase1 <- as_survey(df, ids = psu, weights = wt, strata = strata, nest = TRUE)
   d2 <- as_survey_twophase(phase1, subset = subset)
-  test_invariants(d2)
   # Phase 1 variables preserved in nested structure
   expect_identical(d2@variables$phase1$weights, "wt")
   expect_identical(d2@variables$phase1$strata, "strata")
@@ -1082,7 +1047,6 @@ test_that("as_survey_twophase() inherits metadata from phase1", {
   )
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
   d2 <- as_survey_twophase(phase1, subset = subset)
-  test_invariants(d2)
   # Metadata inherited from phase1
   expect_identical(
     d2@metadata@variable_labels[["y1"]],
@@ -1111,7 +1075,6 @@ test_that("as_survey_twophase() sets all Phase 2 variables to NULL when not prov
   df <- make_survey_data(n = 200, design = "twophase", seed = 12L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
   d2 <- as_survey_twophase(phase1, subset = subset)
-  test_invariants(d2)
   expect_null(d2@variables$phase2$ids)
   expect_null(d2@variables$phase2$strata)
   expect_null(d2@variables$phase2$probs)
@@ -1166,7 +1129,6 @@ test_that("as_survey_twophase() warns when a phase-2 design column is all NA in 
     d2 <- as_survey_twophase(phase1, strata2 = ph2_str, subset = ph2),
     class = "surveycore_warning_phase2_all_na"
   )
-  test_invariants(d2)
   expect_true(S7::S7_inherits(d2, survey_twophase))
   expect_identical(d2@variables$phase2$strata, "ph2_str")
 })
@@ -1195,7 +1157,6 @@ test_that("as_survey_twophase() accepts survey_taylor phase-1 (weights only, no 
   df <- make_survey_data(n = 200, design = "twophase", seed = 42L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt))
   tp <- as_survey_twophase(phase1, subset = subset)
-  test_invariants(tp)
   expect_true(S7::S7_inherits(tp, survey_twophase))
 })
 
@@ -1332,7 +1293,6 @@ test_that("as_survey_twophase() with multi-stage Phase 2 ids (c())", {
   df$ssu2 <- rep(1:4, length.out = nrow(df))
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
   d2 <- as_survey_twophase(phase1, ids2 = c(psu2, ssu2), subset = subset)
-  test_invariants(d2)
   expect_identical(d2@variables$phase2$ids, c("psu2", "ssu2"))
 })
 
@@ -1355,7 +1315,6 @@ test_that("as_survey_twophase() subset with only 1 TRUE row is valid (not degene
   phase1 <- as_survey(df, weights = wt, strata = strata)
   # 1 TRUE and 19 FALSE — not degenerate
   d2 <- as_survey_twophase(phase1, subset = in_phase2)
-  test_invariants(d2)
   expect_true(S7::S7_inherits(d2, survey_twophase))
 })
 
@@ -1388,7 +1347,6 @@ test_that("as_survey_twophase() accepts bare name for subset", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 30L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
   d2 <- as_survey_twophase(phase1, subset = subset)
-  test_invariants(d2)
   expect_identical(d2@variables$subset, "subset")
 })
 
@@ -1396,7 +1354,6 @@ test_that("as_survey_twophase() accepts bare name for strata2", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 31L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
   d2 <- as_survey_twophase(phase1, strata2 = strata, subset = subset)
-  test_invariants(d2)
   expect_identical(d2@variables$phase2$strata, "strata")
 })
 
@@ -1404,7 +1361,6 @@ test_that("as_survey_twophase() accepts bare name for ids2", {
   df <- make_survey_data(n = 200, design = "twophase", seed = 32L)
   phase1 <- suppressWarnings(as_survey(df, weights = wt, strata = strata))
   d2 <- as_survey_twophase(phase1, ids2 = psu, subset = subset)
-  test_invariants(d2)
   expect_identical(d2@variables$phase2$ids, "psu")
 })
 
@@ -1586,14 +1542,12 @@ test_that("as_survey_nonprob() stores calibration provenance object", {
   df <- data.frame(y = rnorm(50), w = runif(50, 1, 3))
   cal <- list(targets = list(age = c(0.3, 0.4, 0.3)), method = "raking")
   d <- as_survey_nonprob(df, weights = w, calibration = cal)
-  test_invariants(d)
   expect_identical(d@calibration, cal)
 })
 
 test_that("as_survey_nonprob() calibration is NULL when not supplied", {
   df <- data.frame(y = 1:20, w = rep(1, 20))
   d <- as_survey_nonprob(df, weights = w)
-  test_invariants(d)
   expect_null(d@calibration)
 })
 
@@ -1601,14 +1555,12 @@ test_that("as_survey_nonprob() extracts haven variable labels", {
   df <- data.frame(y = 1:50, w = rep(1, 50))
   attr(df$y, "label") <- "Outcome variable"
   d <- as_survey_nonprob(df, weights = w)
-  test_invariants(d)
   expect_equal(d@metadata@variable_labels[["y"]], "Outcome variable")
 })
 
 test_that("as_survey_nonprob() is a subclass of survey_base", {
   df <- data.frame(y = 1:30, w = rep(1.5, 30))
   d <- as_survey_nonprob(df, weights = w)
-  test_invariants(d)
   expect_true(S7::S7_inherits(d, survey_base))
 })
 
@@ -2011,7 +1963,6 @@ test_that("as_survey_nonprob() with repweights stores 5 keys in @variables", {
     repweights = starts_with("rw"),
     type = "bootstrap"
   )
-  test_invariants(d)
   expect_identical(d@variables$repweights, c("rw1", "rw2", "rw3"))
   expect_identical(d@variables$type, "bootstrap")
   expect_equal(d@variables$scale, 1 / 3)
@@ -2026,7 +1977,6 @@ test_that("as_survey_nonprob() stores reference_sample in @reference_sample", {
   d_ref <- as_survey(df_ref, ids = psu, weights = wt, strata = strata)
 
   d <- as_survey_nonprob(df_np, weights = w, reference_sample = d_ref)
-  test_invariants(d)
   expect_true(S7::S7_inherits(d@reference_sample, survey_taylor))
 })
 
@@ -2047,7 +1997,6 @@ test_that("as_survey_nonprob() accepts valid calibration provenance + repweights
     type = "bootstrap",
     calibration = cal
   )
-  test_invariants(d)
   expect_identical(d@calibration, cal)
   expect_identical(d@variables$repweights, c("rw1", "rw2"))
 })
@@ -2069,7 +2018,6 @@ test_that("as_survey_nonprob() computes default scale = 1/R and rscales = rep(1,
     repweights = starts_with("rw"),
     type = "bootstrap"
   )
-  test_invariants(d)
   expect_equal(d@variables$scale, 1 / 4)
   expect_identical(d@variables$rscales, rep(1, 4))
 })
@@ -2077,7 +2025,6 @@ test_that("as_survey_nonprob() computes default scale = 1/R and rscales = rep(1,
 test_that("as_survey_nonprob() with no repweights has all 5 keys as NULL", {
   df <- data.frame(y = 1:20, w = rep(1, 20))
   d <- as_survey_nonprob(df, weights = w)
-  test_invariants(d)
   expect_null(d@variables$repweights)
   expect_null(d@variables$type)
   expect_null(d@variables$scale)
@@ -2088,7 +2035,6 @@ test_that("as_survey_nonprob() with no repweights has all 5 keys as NULL", {
 test_that("as_survey_nonprob(df, weights = w) still works (backward compat)", {
   df <- data.frame(y = 1:20, w = rep(1.5, 20))
   d <- as_survey_nonprob(df, weights = w)
-  test_invariants(d)
   expect_true(S7::S7_inherits(d, survey_nonprob))
   expect_identical(d@variables$weights, "w")
 })
@@ -2407,7 +2353,6 @@ test_that("calibration = list() with type = 'JK1' accepted", {
 test_that("two-row data constructs valid JK1 object (minimum sample size)", {
   df <- data.frame(x = 1:2, wt = c(1, 1), r1 = c(1, 1), r2 = c(1, 1))
   d <- as_survey_nonprob(df, weights = wt, repweights = c(r1, r2), type = "JK1")
-  test_invariants(d)
   expect_true(S7::S7_inherits(d, survey_nonprob))
 })
 
@@ -2438,7 +2383,6 @@ test_that("'jackknife' alias not stored: design@variables$type == 'JK1'", {
     repweights = c(r1, r2, r3),
     type = "jackknife"
   )
-  test_invariants(d)
   expect_identical(d@variables$type, "JK1")
 })
 
@@ -2459,7 +2403,6 @@ test_that("JK1 scale exact value for R = 10: 9/10 exactly", {
     repweights = tidyselect::starts_with("r"),
     type = "JK1"
   )
-  test_invariants(d)
   expect_equal(d@variables$scale, 9 / 10)
 })
 
@@ -2475,21 +2418,18 @@ test_that("JK2 default scale = 1 exactly", {
     type = "JK2",
     rscales = c(0.5, 0.5, 0.5, 0.5)
   )
-  test_invariants(d)
   expect_equal(d@variables$scale, 1)
 })
 
 test_that("repweights = NULL ignores type = 'jackknife': type NULL in variables", {
   df <- data.frame(x = 1:5, wt = rep(1, 5))
   d <- as_survey_nonprob(df, weights = wt, type = "jackknife")
-  test_invariants(d)
   expect_null(d@variables$type)
 })
 
 test_that("repweights = NULL ignores type = 'BRR': all rep vars NULL in variables", {
   df <- data.frame(x = 1:5, wt = rep(1, 5))
   d <- as_survey_nonprob(df, weights = wt, type = "BRR")
-  test_invariants(d)
   expect_null(d@variables$type)
   expect_null(d@variables$repweights)
   expect_null(d@variables$scale)
@@ -2508,7 +2448,6 @@ test_that("jackknife alias with explicit non-uniform rscales normalizes to JK1",
     type = "jackknife",
     rscales = c(0.9, 0.8, 0.85, 0.95)
   )
-  test_invariants(d)
   expect_identical(d@variables$type, "JK1")
   expect_equal(d@variables$rscales, c(0.9, 0.8, 0.85, 0.95))
 })
@@ -2601,7 +2540,6 @@ test_that("as_survey() promotes weighting_history attribute from data", {
   history <- list(list(step = 1L, operation = "raking"))
   attr(df, "weighting_history") <- history
   d <- as_survey(df, ids = psu, weights = wt, strata = strata)
-  test_invariants(d)
   expect_identical(d@metadata@weighting_history, history)
 })
 
@@ -2620,7 +2558,6 @@ test_that("as_survey_replicate() promotes weighting_history attribute from data"
     repweights = starts_with("repwt_"),
     type = "JK1"
   )
-  test_invariants(d)
   expect_identical(d@metadata@weighting_history, history)
 })
 
@@ -2629,14 +2566,12 @@ test_that("as_survey() promotes weighting_history for weights-only design", {
   history <- list(list(step = 1L, operation = "nonresponse_weighting_class"))
   attr(df, "weighting_history") <- history
   d <- suppressWarnings(as_survey(df, weights = wt))
-  test_invariants(d)
   expect_identical(d@metadata@weighting_history, history)
 })
 
 test_that("as_survey() leaves weighting_history as list() for plain data.frame", {
   df <- make_survey_data(n = 100L, seed = 103L)
   d <- as_survey(df, ids = psu, weights = wt, strata = strata)
-  test_invariants(d)
   expect_identical(d@metadata@weighting_history, list())
 })
 
@@ -2653,14 +2588,12 @@ test_that("as_survey() accepts multi-column fpc and stores as character vector",
     strata = strata,
     fpc = c(fpc, fpc2)
   )
-  test_invariants(sc)
   expect_identical(sc@variables$fpc, c("fpc", "fpc2"))
 })
 
 test_that("as_survey() stores single-column fpc as character(1) [backward compat]", {
   df <- make_survey_data(n = 200, n_psu = 20, seed = 1)
   sc <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc)
-  test_invariants(sc)
   expect_identical(sc@variables$fpc, "fpc")
 })
 
@@ -3122,7 +3055,6 @@ test_that("JK1 type stored and scale defaults to (R-1)/R", {
   d <- as_survey_nonprob(
     df, weights = wt, repweights = c(r1, r2, r3, r4), type = "JK1"
   )
-  test_invariants(d)
   expect_identical(d@variables$type, "JK1")
   expect_equal(d@variables$scale, 3 / 4)
   expect_equal(d@variables$rscales, rep(1, 4))
@@ -3136,7 +3068,6 @@ test_that("jackknife alias normalizes to JK1", {
   d <- as_survey_nonprob(
     df, weights = wt, repweights = c(r1, r2, r3), type = "jackknife"
   )
-  test_invariants(d)
   expect_identical(d@variables$type, "JK1")
   expect_equal(d@variables$scale, 2 / 3)
 })
@@ -3150,7 +3081,6 @@ test_that("JK2 with explicit rscales: scale defaults to 1", {
     df, weights = wt, repweights = c(r1, r2),
     type = "JK2", rscales = c(0.5, 0.5)
   )
-  test_invariants(d)
   expect_identical(d@variables$type, "JK2")
   expect_equal(d@variables$scale, 1)
   expect_equal(d@variables$rscales, c(0.5, 0.5))
@@ -3165,7 +3095,6 @@ test_that("JKn with explicit rscales: type stored and scale defaults to 1", {
     df, weights = wt, repweights = c(r1, r2, r3),
     type = "JKn", rscales = c(0.5, 0.5, 0.5)
   )
-  test_invariants(d)
   expect_identical(d@variables$type, "JKn")
   expect_equal(d@variables$scale, 1)
 })
@@ -3179,7 +3108,6 @@ test_that("Bootstrap unchanged: scale = 1/R, rscales = rep(1, R)", {
   d <- as_survey_nonprob(
     df, weights = wt, repweights = c(r1, r2, r3, r4, r5), type = "bootstrap"
   )
-  test_invariants(d)
   expect_equal(d@variables$scale, 1 / 5)
   expect_equal(d@variables$rscales, rep(1, 5))
 })
@@ -3193,7 +3121,6 @@ test_that("Explicit scale overrides default for JK1", {
     df, weights = wt, repweights = c(r1, r2, r3, r4),
     type = "JK1", scale = 0.5
   )
-  test_invariants(d)
   expect_equal(d@variables$scale, 0.5)
 })
 
@@ -3206,7 +3133,6 @@ test_that("scale = 0 is accepted for JK1", {
     df, weights = wt, repweights = c(r1, r2, r3, r4),
     type = "JK1", scale = 0
   )
-  test_invariants(d)
   expect_equal(d@variables$scale, 0)
 })
 
@@ -3239,7 +3165,6 @@ test_that("scale = 0 is accepted for JK1", {
 
 test_that("as_survey() promotes all six canonical attributes in canonical order", {
   d <- .promo_design(full_keys)
-  test_invariants(d)
 
   expect_identical(extract_dataset_metadata(d), full_keys)
   expect_identical(names(extract_dataset_metadata(d)), names(full_keys))
@@ -3247,7 +3172,6 @@ test_that("as_survey() promotes all six canonical attributes in canonical order"
 
 test_that("as_survey() promotes only the attributes that are present", {
   d <- .promo_design(full_keys[c("vendor", "field_period")])
-  test_invariants(d)
 
   expect_identical(
     extract_dataset_metadata(d),
@@ -3262,7 +3186,6 @@ test_that("as_survey() never derives data_name from the survey_name attribute", 
   # that WAS set has to survive promotion, otherwise NA_character_ would only
   # prove that nothing at all was promoted.
   d <- .promo_design(full_keys["survey_name"])
-  test_invariants(d)
 
   expect_identical(extract_data_name(d), NA_character_)
   expect_identical(extract_survey_name(d), full_keys$survey_name)
@@ -3273,7 +3196,6 @@ test_that("as_survey() never derives survey_name from the data_name attribute", 
   # The mirror of the block above. Independence runs in both directions, so
   # the reverse derivation needs its own assertion.
   d <- .promo_design(full_keys["data_name"])
-  test_invariants(d)
 
   expect_identical(extract_survey_name(d), NA_character_)
   expect_identical(extract_data_name(d), full_keys$data_name)
@@ -3284,7 +3206,6 @@ test_that("as_survey() skips an absent attribute silently", {
   # `survey_name` is absent, `vendor` is set. The absent key must produce no
   # warning at all — silence is reserved for absence (a zero-length value warns).
   expect_no_warning(d <- .promo_design(full_keys["vendor"]))
-  test_invariants(d)
 
   expect_identical(extract_dataset_metadata(d), full_keys["vendor"])
 })
@@ -3294,14 +3215,12 @@ test_that("as_survey() leaves @dataset_metadata empty when no attribute is set",
   # metadata object unchanged AND stays silent. Nothing was dropped, so a
   # warning here would report a loss that never happened.
   expect_no_warning(d <- .promo_design(list()))
-  test_invariants(d)
 
   expect_identical(extract_dataset_metadata(d), list())
 })
 
 test_that("as_survey() coerces a strict-ISO character date attribute to Date", {
   d <- .promo_design(list(field_start = "2026-02-10"))
-  test_invariants(d)
 
   got <- extract_dataset_metadata(d)
   expect_identical(got$field_start, as.Date("2026-02-10"))
@@ -3310,7 +3229,6 @@ test_that("as_survey() coerces a strict-ISO character date attribute to Date", {
 
 test_that("as_survey() promotes the legacy dates attribute as field_period", {
   d <- .promo_design(list(vendor = "Ipsos", dates = "February-March 2026"))
-  test_invariants(d)
 
   expect_identical(
     extract_dataset_metadata(d),
@@ -3329,7 +3247,6 @@ test_that("as_survey() prefers a present field_period over the legacy dates attr
       dates = "some other period"
     ))
   )
-  test_invariants(d)
 
   expect_identical(
     extract_dataset_metadata(d)$field_period,
@@ -3343,7 +3260,6 @@ test_that("as_survey() ignores an attribute outside the seven recognized names",
   expect_no_warning(
     d <- .promo_design(list(vendor = "Ipsos", weight_scheme = "raked"))
   )
-  test_invariants(d)
 
   expect_identical(extract_dataset_metadata(d), list(vendor = "Ipsos"))
   expect_false("weight_scheme" %in% names(extract_dataset_metadata(d)))
@@ -3360,7 +3276,6 @@ test_that("as_survey() warns and drops a wrong-typed canonical attribute", {
     d <- .promo_design(keys),
     class = "surveycore_warning_dataset_metadata_dropped"
   )
-  test_invariants(d)
   expect_identical(extract_dataset_metadata(d), list())
   expect_snapshot(d2 <- .promo_design(keys))
 })
@@ -3372,7 +3287,6 @@ test_that("as_survey() warns and drops a canonical attribute of length > 1", {
     d <- .promo_design(keys),
     class = "surveycore_warning_dataset_metadata_dropped"
   )
-  test_invariants(d)
   expect_identical(extract_dataset_metadata(d), list())
   expect_snapshot(d2 <- .promo_design(keys))
 })
@@ -3384,7 +3298,6 @@ test_that("as_survey() warns and drops an NA canonical attribute", {
     d <- .promo_design(keys),
     class = "surveycore_warning_dataset_metadata_dropped"
   )
-  test_invariants(d)
   expect_identical(extract_dataset_metadata(d), list())
   expect_snapshot(d2 <- .promo_design(keys))
 })
@@ -3398,7 +3311,6 @@ test_that("as_survey() warns and drops an unparseable date attribute", {
     d <- .promo_design(keys),
     class = "surveycore_warning_dataset_metadata_dropped"
   )
-  test_invariants(d)
   expect_identical(extract_dataset_metadata(d), list())
   expect_snapshot(d2 <- .promo_design(keys))
 })
@@ -3413,7 +3325,6 @@ test_that("as_survey() warns and drops a date attribute that is not date-shaped"
     d <- .promo_design(keys),
     class = "surveycore_warning_dataset_metadata_dropped"
   )
-  test_invariants(d)
   expect_true(S7::S7_inherits(d, survey_taylor))
   expect_identical(extract_dataset_metadata(d), list())
 
@@ -3434,7 +3345,6 @@ test_that("as_survey() warns and drops an ISO-shaped date that does not exist", 
     d <- .promo_design(keys),
     class = "surveycore_warning_dataset_metadata_dropped"
   )
-  test_invariants(d)
   expect_true(S7::S7_inherits(d, survey_taylor))
   expect_identical(extract_dataset_metadata(d), list())
 
@@ -3453,7 +3363,6 @@ test_that("as_survey() keeps the valid attributes when another one is dropped", 
     d <- .promo_design(keys),
     class = "surveycore_warning_dataset_metadata_dropped"
   )
-  test_invariants(d)
   expect_identical(extract_dataset_metadata(d), list(vendor = "Ipsos"))
 })
 
@@ -3461,7 +3370,6 @@ test_that("as_survey() warns once per dropped attribute", {
   keys <- list(survey_name = 1L, vendor = 2L)
 
   warnings <- testthat::capture_warnings(d <- .promo_design(keys))
-  test_invariants(d)
   expect_length(warnings, 2L)
   expect_identical(extract_dataset_metadata(d), list())
 })
@@ -3477,7 +3385,6 @@ test_that("as_survey() warns and drops a zero-length canonical attribute", {
     d <- .promo_design(keys),
     class = "surveycore_warning_dataset_metadata_dropped"
   )
-  test_invariants(d)
   expect_identical(extract_dataset_metadata(d), list())
   expect_snapshot(d2 <- .promo_design(keys))
 })
@@ -3493,7 +3400,6 @@ test_that("as_survey() warns once and drops both dates when the pair is reversed
   )
 
   warnings <- testthat::capture_warnings(d <- .promo_design(keys))
-  test_invariants(d)
   expect_length(warnings, 1L)
   expect_identical(extract_dataset_metadata(d), list())
   expect_snapshot(d2 <- .promo_design(keys))
@@ -3507,7 +3413,6 @@ test_that("as_survey() judges the reversed pair on the coerced ISO strings", {
     d <- .promo_design(keys),
     class = "surveycore_warning_dataset_metadata_dropped"
   )
-  test_invariants(d)
   expect_identical(extract_dataset_metadata(d), list())
 })
 
@@ -3519,7 +3424,6 @@ test_that("as_survey() promotes an equal date pair without warning", {
   )
 
   expect_no_warning(d <- .promo_design(keys))
-  test_invariants(d)
   expect_identical(extract_dataset_metadata(d), keys)
 })
 
@@ -3535,7 +3439,6 @@ test_that("as_survey() warns with the legacy variant for a wrong-typed dates att
     d <- .promo_design(keys),
     class = "surveycore_warning_dataset_metadata_dropped"
   )
-  test_invariants(d)
   expect_identical(extract_dataset_metadata(d), list())
   expect_snapshot(d2 <- .promo_design(keys))
 })
@@ -3549,7 +3452,6 @@ test_that("as_survey() warns with the legacy variant for a zero-length dates att
     d <- .promo_design(keys),
     class = "surveycore_warning_dataset_metadata_dropped"
   )
-  test_invariants(d)
   expect_identical(extract_dataset_metadata(d), list())
   expect_snapshot(d2 <- .promo_design(keys))
 })
@@ -3561,7 +3463,6 @@ test_that("as_survey() warns with the legacy variant for a dates attribute of le
     d <- .promo_design(keys),
     class = "surveycore_warning_dataset_metadata_dropped"
   )
-  test_invariants(d)
   expect_identical(extract_dataset_metadata(d), list())
   expect_snapshot(d2 <- .promo_design(keys))
 })
@@ -3591,7 +3492,6 @@ test_that("haven column labels and dataset attributes both promote", {
       nest = TRUE
     )
   )
-  test_invariants(d)
 
   # Per-variable metadata: variable labels and value labels.
   expect_identical(
@@ -3637,7 +3537,6 @@ test_that("promotion leaves the original attributes on @data", {
   # Promotion COPIES; it never strips. Every one of the six attributes holds a
   # genuine value going in, so a stripping implementation would fail here.
   d <- .promo_design(full_keys)
-  test_invariants(d)
 
   for (key in names(full_keys)) {
     expect_identical(
@@ -3660,7 +3559,6 @@ test_that("promotion leaves the caller's data frame unchanged", {
     fpc = fpc,
     nest = TRUE
   )
-  test_invariants(d)
 
   expect_identical(attributes(df), before)
 })
@@ -3674,7 +3572,6 @@ test_that("promotion keeps a dropped attribute on @data even though the key is u
     d <- .promo_design(keys),
     class = "surveycore_warning_dataset_metadata_dropped"
   )
-  test_invariants(d)
 
   expect_identical(extract_dataset_metadata(d), list())
   expect_identical(attr(d@data, "vendor", exact = TRUE), c("Ipsos", "Cint"))
@@ -3684,7 +3581,6 @@ test_that("rebuilding from @data resurrects an edited key", {
   # Documented consequence of section V.4: the design's metadata changed, the
   # data frame's attribute did not, so a rebuild re-promotes the ORIGINAL.
   d <- .promo_design(full_keys)
-  test_invariants(d)
 
   d2 <- set_vendor(d, "Cint")
   expect_identical(extract_vendor(d2), "Cint")
@@ -3697,14 +3593,12 @@ test_that("rebuilding from @data resurrects an edited key", {
     fpc = fpc,
     nest = TRUE
   )
-  test_invariants(rebuilt)
   expect_identical(extract_vendor(rebuilt), full_keys$vendor)
   expect_false(identical(extract_vendor(rebuilt), "Cint"))
 })
 
 test_that("rebuilding from @data resurrects a deleted key", {
   d <- .promo_design(full_keys)
-  test_invariants(d)
 
   d2 <- set_vendor(d, NULL)
   expect_identical(extract_vendor(d2), NA_character_)
@@ -3717,7 +3611,6 @@ test_that("rebuilding from @data resurrects a deleted key", {
     fpc = fpc,
     nest = TRUE
   )
-  test_invariants(rebuilt)
   expect_identical(extract_vendor(rebuilt), full_keys$vendor)
 })
 
@@ -3726,7 +3619,6 @@ test_that("column subsetting @data drops the attributes, so a rebuild promotes n
   # a new frame without them, so nothing is left to promote. This is why the
   # roxygen advises setting dataset metadata last.
   d <- .promo_design(full_keys)
-  test_invariants(d)
   expect_identical(extract_vendor(d), full_keys$vendor)
 
   stripped <- d@data[, names(d@data), drop = FALSE]
@@ -3740,13 +3632,11 @@ test_that("column subsetting @data drops the attributes, so a rebuild promotes n
     fpc = fpc,
     nest = TRUE
   )
-  test_invariants(rebuilt)
   expect_identical(extract_dataset_metadata(rebuilt), list())
 })
 
 test_that("merge() drops the attributes, so a rebuild promotes nothing", {
   d <- .promo_design(full_keys)
-  test_invariants(d)
 
   lookup <- data.frame(strata = unique(d@data$strata))
   lookup$region <- seq_len(nrow(lookup))
@@ -3761,7 +3651,6 @@ test_that("merge() drops the attributes, so a rebuild promotes nothing", {
     fpc = fpc,
     nest = TRUE
   )
-  test_invariants(rebuilt)
   expect_identical(extract_dataset_metadata(rebuilt), list())
 })
 
@@ -3772,7 +3661,6 @@ test_that("as_survey() warns once for an invalid field_period and never falls ba
   keys <- list(field_period = 99, dates = "February-March 2026")
 
   warnings <- testthat::capture_warnings(d <- .promo_design(keys))
-  test_invariants(d)
   expect_length(warnings, 1L)
   expect_identical(extract_dataset_metadata(d), list())
   expect_snapshot(d2 <- .promo_design(keys))
@@ -3798,7 +3686,6 @@ test_that("as_survey_replicate() promotes the dataset attributes", {
     repweights = starts_with("repwt_"),
     type = "JK1"
   )
-  test_invariants(d)
 
   expect_identical(extract_dataset_metadata(d), full_keys)
 })
@@ -3821,7 +3708,6 @@ test_that("as_survey_replicate() warns and drops an invalid dataset attribute", 
     ),
     class = "surveycore_warning_dataset_metadata_dropped"
   )
-  test_invariants(d)
 
   expect_identical(extract_dataset_metadata(d), list())
 })
@@ -3833,7 +3719,6 @@ test_that("as_survey_nonprob() promotes the dataset attributes", {
   }
 
   d <- as_survey_nonprob(df, weights = wt)
-  test_invariants(d)
 
   expect_identical(extract_dataset_metadata(d), full_keys)
 })
@@ -3846,7 +3731,6 @@ test_that("as_survey_nonprob() warns and drops an invalid dataset attribute", {
     d <- as_survey_nonprob(df, weights = wt),
     class = "surveycore_warning_dataset_metadata_dropped"
   )
-  test_invariants(d)
 
   expect_identical(extract_dataset_metadata(d), list())
 })
@@ -3861,7 +3745,6 @@ test_that("as_survey_nonprob() promotes the weighting_history attribute", {
   attr(df, "weighting_history") <- history
 
   d <- as_survey_nonprob(df, weights = wt)
-  test_invariants(d)
 
   expect_identical(d@metadata@weighting_history, history)
 })
@@ -3870,7 +3753,6 @@ test_that("as_survey_nonprob() leaves weighting_history as list() with no attrib
   df <- make_survey_data(n = 100L, n_psu = 10L, seed = 207L)
 
   d <- as_survey_nonprob(df, weights = wt)
-  test_invariants(d)
 
   expect_identical(d@metadata@weighting_history, list())
 })

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -129,7 +129,6 @@ test_that("as_svydesign() converts survey_taylor without error", {
 test_that("as_svydesign() converts SRS-style survey_taylor without error", {
   skip_if_not_installed("survey")
   d <- make_srs()
-  test_invariants(d)
   sv <- as_svydesign(d)
   expect_true(!is.null(sv))
 })
@@ -140,7 +139,6 @@ test_that("as_svydesign() converts SRS-style survey_taylor without error", {
 test_that("as_svydesign() converts survey_replicate without error", {
   skip_if_not_installed("survey")
   d <- make_rep()
-  test_invariants(d)
   sv <- as_svydesign(d)
   expect_true(!is.null(sv))
 })
@@ -151,7 +149,6 @@ test_that("as_svydesign() converts survey_replicate without error", {
 test_that("as_svydesign() converts survey_twophase without error", {
   skip_if_not_installed("survey")
   d <- make_twophase()
-  test_invariants(d)
   sv <- suppressWarnings(as_svydesign(d))
   expect_true(!is.null(sv))
 })
@@ -296,7 +293,6 @@ test_that("as_tbl_svy() converts survey_taylor to tbl_svy", {
   skip_if_not_installed("survey")
   skip_if_not_installed("srvyr")
   d <- make_taylor()
-  test_invariants(d)
   ts <- as_tbl_svy(d)
   expect_true(inherits(ts, "tbl_svy"))
 })
@@ -462,7 +458,6 @@ test_that("from_svydesign() preserves all data rows", {
     nest = TRUE
   )
   d <- from_svydesign(sv)
-  test_invariants(d)
   expect_identical(nrow(d@data), nrow(df))
 })
 
@@ -605,7 +600,6 @@ test_that("from_tbl_svy() converts tbl_svy to survey_taylor", {
   skip_if_not_installed("survey")
   skip_if_not_installed("srvyr")
   d <- make_taylor()
-  test_invariants(d)
   ts <- as_tbl_svy(d)
   d2 <- from_tbl_svy(ts)
   expect_true(S7::S7_inherits(d2, survey_taylor))

--- a/tests/testthat/test-dataset-metadata.R
+++ b/tests/testthat/test-dataset-metadata.R
@@ -63,7 +63,6 @@ test_that("extract_dataset_metadata() returns all present keys on a frame", {
 test_that("extract_dataset_metadata() returns visibly on a design", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
   d@metadata@dataset_metadata <- full_keys
 
   # The sibling SETTERS return invisibly; this extractor must not. withVisible()
@@ -86,7 +85,6 @@ test_that("extract_dataset_metadata() returns visibly on a frame", {
 test_that("extract_dataset_metadata() returns list() when nothing is set", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
 
   expect_identical(extract_dataset_metadata(d), list())
 })
@@ -100,7 +98,6 @@ test_that("extract_dataset_metadata() returns list() for a bare frame", {
 test_that("extract_dataset_metadata() orders present keys canonically", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
   d@metadata@dataset_metadata <- list(
     field_period = "February-March 2026",
     vendor = "Ipsos",
@@ -131,7 +128,6 @@ test_that("extract_dataset_metadata() orders frame keys canonically", {
 test_that("extract_dataset_metadata() accepts bare key names in ...", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
   d@metadata@dataset_metadata <- full_keys
 
   expect_identical(
@@ -152,7 +148,6 @@ test_that("extract_dataset_metadata() accepts bare names on a frame", {
 test_that("extract_dataset_metadata() accepts quoted key names in ...", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
   d@metadata@dataset_metadata <- full_keys
 
   expect_identical(
@@ -173,7 +168,6 @@ test_that("extract_dataset_metadata() accepts quoted names on a frame", {
 test_that("extract_dataset_metadata() supports !!! splicing of names", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
   d@metadata@dataset_metadata <- full_keys
   wanted <- c("vendor", "field_period")
 
@@ -196,7 +190,6 @@ test_that("extract_dataset_metadata() supports !!! splicing on a frame", {
 test_that("extract_dataset_metadata() preserves request order, not canonical", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
   d@metadata@dataset_metadata <- full_keys
 
   expect_identical(
@@ -217,7 +210,6 @@ test_that("extract_dataset_metadata() preserves request order on a frame", {
 test_that("extract_dataset_metadata() dedups a repeated request, first pos", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
   d@metadata@dataset_metadata <- full_keys
 
   expect_identical(
@@ -238,7 +230,6 @@ test_that("extract_dataset_metadata() dedups a repeated request on a frame", {
 test_that("extract_dataset_metadata() reads keys from the `key` argument", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
   d@metadata@dataset_metadata <- full_keys
 
   expect_identical(
@@ -259,7 +250,6 @@ test_that("extract_dataset_metadata() reads the `key` argument on a frame", {
 test_that("extract_dataset_metadata() omits an unset requested key by default", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
   d@metadata@dataset_metadata <- list(vendor = "Ipsos")
 
   expect_identical(
@@ -280,7 +270,6 @@ test_that("extract_dataset_metadata() omits an unset key on a frame", {
 test_that("extract_dataset_metadata() never warns about an unset valid key", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
 
   expect_no_warning(extract_dataset_metadata(d, vendor))
 })
@@ -294,7 +283,6 @@ test_that("extract_dataset_metadata() never warns about an unset key on a frame"
 test_that("extract_dataset_metadata() returns list() for a zero-length key", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
   d@metadata@dataset_metadata <- full_keys
 
   expect_identical(
@@ -308,7 +296,6 @@ test_that("extract_dataset_metadata() returns list() for a zero-length key", {
 test_that("extract_var_label() still rejects fill = NA (sibling regression)", {
   df <- make_survey_data(n = 20L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
 
   expect_error(
     extract_var_label(d, fill = NA),
@@ -320,7 +307,6 @@ test_that("extract_var_label() still rejects fill = NA (sibling regression)", {
 test_that("extract_dataset_metadata() type-matches fill = NA on a design", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
   d@metadata@dataset_metadata <- list(vendor = "Ipsos")
 
   expect_identical(
@@ -349,7 +335,6 @@ test_that("extract_dataset_metadata() type-matches fill = NA on a frame", {
 test_that("extract_dataset_metadata() accepts fill = NA_character_", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
 
   expect_identical(
     extract_dataset_metadata(d, survey_name, fill = NA_character_),
@@ -369,7 +354,6 @@ test_that("extract_dataset_metadata() accepts fill = NA_character_ on a frame", 
 test_that("an empty request with fill = NA returns the full six-key schema", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
   d@metadata@dataset_metadata <- list(vendor = "Ipsos")
 
   expect_identical(
@@ -397,7 +381,6 @@ test_that("an empty request with fill = NA returns the schema on a frame", {
 test_that("an empty request with no metadata and fill = NA fills all six", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
 
   result <- extract_dataset_metadata(d, fill = NA)
 
@@ -410,7 +393,6 @@ test_that("an empty request with no metadata and fill = NA fills all six", {
 test_that("extract_dataset_metadata() renders a two-column tibble", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
   d@metadata@dataset_metadata <- full_keys
 
   result <- extract_dataset_metadata(d, format = "data_frame")
@@ -441,7 +423,6 @@ test_that("data_frame format renders a Date through format()", {
 test_that("data_frame format renders a design Date through format()", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
   d@metadata@dataset_metadata <- list(
     field_start = as.Date("2026-02-10"),
     field_end = as.Date("2026-03-04")
@@ -461,7 +442,6 @@ test_that("data_frame format renders a design Date through format()", {
 test_that("data_frame format returns a 0-row tibble for an empty result", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
 
   result <- extract_dataset_metadata(d, format = "data_frame")
 
@@ -483,7 +463,6 @@ test_that("data_frame format returns a 0-row tibble for a bare frame", {
 test_that("data_frame format fills an absent date key with NA_character_", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
 
   result <- extract_dataset_metadata(
     d,
@@ -748,7 +727,6 @@ test_that("extract_dataset_metadata() rejects a non-survey, non-frame x", {
 test_that("extract_dataset_metadata() rejects a survey_collection", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
   coll <- survey_collection(list(a = d, b = d))
 
   expect_error(
@@ -760,7 +738,6 @@ test_that("extract_dataset_metadata() rejects a survey_collection", {
 test_that("extract_dataset_metadata() rejects both ... and key together", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
 
   expect_error(
     extract_dataset_metadata(d, vendor, key = "vendor"),
@@ -784,7 +761,6 @@ test_that("extract_dataset_metadata() rejects ... and key on a frame", {
 test_that("extract_dataset_metadata() rejects a tidyselect helper in ...", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
 
   expect_error(
     extract_dataset_metadata(d, all_of("vendor")),
@@ -805,7 +781,6 @@ test_that("extract_dataset_metadata() rejects any call in ... on a frame", {
 test_that("extract_dataset_metadata() rejects an unknown requested key", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
 
   expect_error(
     extract_dataset_metadata(d, mode),
@@ -835,7 +810,6 @@ test_that("extract_dataset_metadata() rejects the legacy `dates` as a key", {
 test_that("extract_dataset_metadata() rejects an invalid format", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
 
   expect_error(
     extract_dataset_metadata(d, format = "named_vector"),
@@ -859,7 +833,6 @@ test_that("extract_dataset_metadata() rejects an invalid format on a frame", {
 test_that("extract_dataset_metadata() rejects an invalid fill", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
 
   expect_error(
     extract_dataset_metadata(d, fill = "none"),
@@ -882,7 +855,6 @@ test_that("extract_dataset_metadata() rejects an invalid fill on a frame", {
 test_that("extract_dataset_metadata() returns list() on a stale design", {
   for (cls in c("taylor", "replicate", "twophase", "nonprob")) {
     d <- make_stale_metadata_design(cls)
-    test_invariants(d)
 
     expect_identical(extract_dataset_metadata(d), list())
   }
@@ -890,7 +862,6 @@ test_that("extract_dataset_metadata() returns list() on a stale design", {
 
 test_that("a stale design fills the full schema when fill = NA", {
   d <- make_stale_metadata_design("taylor")
-  test_invariants(d)
 
   expect_identical(
     names(extract_dataset_metadata(d, fill = NA)),
@@ -910,7 +881,6 @@ test_that("a stale design fills the full schema when fill = NA", {
 test_that("set_var_label() keeps the default setter_ambiguous wording", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
 
   expect_error(
     set_var_label(d, y1 = "A", variable = "y2"),
@@ -922,7 +892,6 @@ test_that("set_var_label() keeps the default setter_ambiguous wording", {
 test_that("set_var_label() keeps the default setter_empty wording", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
 
   expect_error(set_var_label(d), class = "surveycore_error_setter_empty")
   expect_snapshot(error = TRUE, set_var_label(d))
@@ -931,7 +900,6 @@ test_that("set_var_label() keeps the default setter_empty wording", {
 test_that("set_var_label() keeps the default empty_variables wording", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
 
   expect_warning(
     set_var_label(d, variable = character(0)),
@@ -943,7 +911,6 @@ test_that("set_var_label() keeps the default empty_variables wording", {
 test_that("set_var_label() keeps the default mismatched_lengths wording", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
 
   expect_error(
     set_var_label(d, variable = c("y1", "y2"), label = "A"),
@@ -958,7 +925,6 @@ test_that("set_var_label() keeps the default mismatched_lengths wording", {
 test_that("set_var_label() keeps the default mixed_dots wording", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
 
   expect_error(
     set_var_label(d, "y1", "y2", "y3"),
@@ -982,7 +948,6 @@ test_that("set_dataset_metadata() rejects a non-survey, non-frame x", {
 
 test_that("set_dataset_metadata() rejects a survey_collection", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
   coll <- survey_collection(list(a = d, b = d))
 
   expect_error(
@@ -993,7 +958,6 @@ test_that("set_dataset_metadata() rejects a survey_collection", {
 
 test_that("set_dataset_metadata() rejects both ... and key on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, vendor = "Ipsos", key = "vendor"),
@@ -1016,7 +980,6 @@ test_that("set_dataset_metadata() rejects both ... and key on a frame", {
 
 test_that("set_dataset_metadata() rejects a call with no key at all", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d),
@@ -1036,7 +999,6 @@ test_that("set_dataset_metadata() rejects an empty call on a frame", {
 
 test_that("set_dataset_metadata() warns and no-ops for a length-0 key", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   expect_warning(
     result <- set_dataset_metadata(d, key = character(0)),
@@ -1059,7 +1021,6 @@ test_that("a length-0 key on a frame warns and leaves attributes alone", {
 
 test_that("set_dataset_metadata() rejects mismatched key and value lengths", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(
@@ -1094,7 +1055,6 @@ test_that("mismatched key and value lengths are rejected on a frame", {
 
 test_that("set_dataset_metadata() rejects unnamed ... elements", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, "vendor", "data_name"),
@@ -1119,7 +1079,6 @@ test_that("unnamed ... elements are rejected on a frame", {
 
 test_that("Convention 1 writes one key on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, vendor = "Ipsos KnowledgePanel Omnibus")
 
@@ -1146,7 +1105,6 @@ test_that("Convention 1 writes one key on a frame", {
 
 test_that("Convention 1 writes several keys at once on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, vendor = "Ipsos", data_name = "AAA (Feb 2026)")
 
@@ -1169,7 +1127,6 @@ test_that("Convention 1 writes several keys at once on a frame", {
 
 test_that("Convention 2 accepts one named list in ... on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, list(vendor = "Ipsos", survey_name = "AAA 2026"))
 
@@ -1195,7 +1152,6 @@ test_that("Convention 2 accepts one named list in ... on a frame", {
 
 test_that("Convention 2 accepts a spliced list on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, !!!list(vendor = "Ipsos"))
 
@@ -1204,7 +1160,6 @@ test_that("Convention 2 accepts a spliced list on a design", {
 
 test_that("Convention 3 writes key and value pairs on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_dataset_metadata(
     d,
@@ -1235,7 +1190,6 @@ test_that("Convention 3 writes key and value pairs on a frame", {
 
 test_that("Convention 3 coerces an atomic value with as.list()", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_dataset_metadata(
     d,
@@ -1259,7 +1213,6 @@ test_that("Convention 3 coerces an atomic value on a frame", {
 
 test_that("Convention 3 ignores names on value; key wins", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_dataset_metadata(
     d,
@@ -1272,7 +1225,6 @@ test_that("Convention 3 ignores names on value; key wins", {
 
 test_that("set_dataset_metadata() returns the design invisibly", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   # The sibling extractors return visibly; the setters must not.
   seen <- withVisible(set_dataset_metadata(d, vendor = "Ipsos"))
@@ -1298,7 +1250,6 @@ test_that("set_dataset_metadata() returns the frame invisibly", {
 
 test_that("set_dataset_metadata() rejects a blank key name on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, key = c("")),
@@ -1318,7 +1269,6 @@ test_that("set_dataset_metadata() rejects a blank key name on a frame", {
 
 test_that("set_dataset_metadata() rejects an NA key name", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, key = NA_character_),
@@ -1328,7 +1278,6 @@ test_that("set_dataset_metadata() rejects an NA key name", {
 
 test_that("set_dataset_metadata() counts every blank key name", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_snapshot(
     error = TRUE,
@@ -1338,7 +1287,6 @@ test_that("set_dataset_metadata() counts every blank key name", {
 
 test_that("set_dataset_metadata() rejects a duplicated named ... key", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, vendor = "Ipsos", vendor = "Cint"),
@@ -1361,7 +1309,6 @@ test_that("a duplicated named ... key is rejected on a frame", {
 
 test_that("set_dataset_metadata() rejects a duplicated Convention 3 key", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(
@@ -1392,7 +1339,6 @@ test_that("a duplicated Convention 3 key is rejected on a frame", {
 
 test_that("a duplicated key in a Convention 2 list is rejected", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, list(vendor = "Ipsos", vendor = "Cint")),
@@ -1402,7 +1348,6 @@ test_that("a duplicated key in a Convention 2 list is rejected", {
 
 test_that("the dates alias resolves before the duplicate check", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   # `dates` and `field_period` are two spellings of one key, so naming both in
   # one call names that key twice.
@@ -1429,7 +1374,6 @@ test_that("the dates alias resolves before the duplicate check on a frame", {
 
 test_that("set_dataset_metadata() rejects an unknown key on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, mode = "web"),
@@ -1449,7 +1393,6 @@ test_that("set_dataset_metadata() rejects an unknown key on a frame", {
 
 test_that("an unknown key with the wrong case shows the did-you-mean hint", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, Vendor = "Ipsos"),
@@ -1460,7 +1403,6 @@ test_that("an unknown key with the wrong case shows the did-you-mean hint", {
 
 test_that("a misspelled unknown key shows the did-you-mean hint", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, vender = "Ipsos"),
@@ -1477,7 +1419,6 @@ test_that("the did-you-mean hint also fires on a frame", {
 
 test_that("a non-NULL dates value is an unknown key naming field_period", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, dates = "February-March 2026"),
@@ -1512,7 +1453,6 @@ test_that("an unknown key equal to a data column leaves the column alone", {
 
 test_that("a non-character key is coerced and then fails as unknown", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   # A non-character `key` passes through as.character() and then fails the
   # closed-vocabulary check, matching the extractor's convention.
@@ -1537,7 +1477,6 @@ test_that("a non-character key is coerced and fails as unknown on a frame", {
 
 test_that("the extractor renders the completed unknown-key hint on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   expect_error(
     extract_dataset_metadata(d, vender),
@@ -1560,7 +1499,6 @@ test_that("the extractor renders the completed unknown-key hint on a frame", {
 
 test_that("a non-character value for a character key is rejected", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, vendor = 1L),
@@ -1580,7 +1518,6 @@ test_that("a non-character value for a character key is rejected on a frame", {
 
 test_that("a length-2 value for a character key is rejected", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, vendor = c("Ipsos", "Cint")),
@@ -1599,7 +1536,6 @@ test_that("a length-2 value for a character key is rejected on a frame", {
 
 test_that("an NA value for a character key is rejected", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, vendor = NA_character_),
@@ -1609,7 +1545,6 @@ test_that("an NA value for a character key is rejected", {
 
 test_that("a zero-length value is rejected rather than treated as deletion", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   # character(0) is not a deletion. Only NULL deletes.
   expect_error(
@@ -1630,7 +1565,6 @@ test_that("a zero-length value is rejected on a frame", {
 
 test_that("a zero-length value is rejected for character keys on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   # character(0) is not a deletion for any of the three remaining character
   # keys either. Only NULL deletes.
@@ -1670,7 +1604,6 @@ test_that("a zero-length value is rejected for character keys on a frame", {
 
 test_that("a zero-length value is rejected for date keys on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   # The date keys carry their own class, so a zero-length Date is rejected as
   # an invalid field date rather than as a bad type.
@@ -1701,7 +1634,6 @@ test_that("a zero-length value is rejected for date keys on a frame", {
 
 test_that("a bare number for a date key is rejected", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, field_start = 20260210),
@@ -1721,7 +1653,6 @@ test_that("a bare number for a date key is rejected on a frame", {
 
 test_that("an NA value for a date key is rejected with the NA bullet", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, field_start = NA),
@@ -1741,7 +1672,6 @@ test_that("an NA value for a date key is rejected on a frame", {
 
 test_that("a Date value for a date key is stored as given on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, field_start = as.Date("2026-02-10"))
 
@@ -1753,7 +1683,6 @@ test_that("a Date value for a date key is stored as given on a design", {
 
 test_that("an ISO string for a date key is stored as a Date on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, field_start = "2026-02-10")
 
@@ -1776,7 +1705,6 @@ test_that("an ISO string for a date key is stored as a Date on a frame", {
 
 test_that("a non-strict slash date is rejected on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, field_start = "2026/02/10"),
@@ -1795,7 +1723,6 @@ test_that("a non-strict slash date is rejected on a frame", {
 
 test_that("an unpadded date string fails the round trip on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   # as.Date() parses "2026-2-1", but it does not round-trip through format(),
   # so the strict ISO rule rejects it.
@@ -1816,7 +1743,6 @@ test_that("an unpadded date string fails the round trip on a frame", {
 
 test_that("an impossible calendar date is rejected on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, field_start = "2026-02-30"),
@@ -1826,7 +1752,6 @@ test_that("an impossible calendar date is rejected on a design", {
 
 test_that("no base as.Date() condition escapes an invalid date value", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   # The only condition raised is surveycore's own.
   expect_error(
@@ -1842,7 +1767,6 @@ test_that("no base as.Date() condition escapes an invalid date value", {
 
 test_that("a second call merges into the stored keys on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, vendor = "Ipsos")
   d <- set_dataset_metadata(d, survey_name = "AAA 2026")
@@ -1867,7 +1791,6 @@ test_that("a second call merges into the stored keys on a frame", {
 
 test_that("overwriting a key keeps its canonical position on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, vendor = "Cint")
 
@@ -1887,7 +1810,6 @@ test_that("overwriting a key keeps its canonical position on a frame", {
 
 test_that("keys written out of order are stored canonically on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_dataset_metadata(
     d,
@@ -1920,7 +1842,6 @@ test_that("keys written out of order are read canonically on a frame", {
 
 test_that("a NULL value deletes a stored key on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, vendor = NULL)
 
@@ -1942,7 +1863,6 @@ test_that("a NULL value deletes a stored key on a frame", {
 
 test_that("deleting an unset key is a silent no-op on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_no_condition(result <- set_dataset_metadata(d, vendor = NULL))
   expect_identical(extract_dataset_metadata(result), list())
@@ -1957,7 +1877,6 @@ test_that("deleting an unset key is a silent no-op on a frame", {
 
 test_that("one call can set one key and delete another on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, vendor = "Cint", data_name = NULL)
 
@@ -1978,7 +1897,6 @@ test_that("one call can set one key and delete another on a frame", {
 
 test_that("bulk deletion via key and a NULL value works on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, key = c("vendor", "data_name"), value = NULL)
 
@@ -1990,7 +1908,6 @@ test_that("bulk deletion via key and a NULL value works on a design", {
 
 test_that("bulk deletion tolerates an absent key among the names", {
   d <- make_dataset_design("taylor", "survey_name")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, key = c("vendor", "data_name"), value = NULL)
 
@@ -2010,7 +1927,6 @@ test_that("bulk deletion via key and a NULL value works on a frame", {
 
 test_that("bulk deletion mixes a present and an absent key on a design", {
   d <- make_dataset_design("taylor", "partial")
-  test_invariants(d)
 
   # The "partial" state sets `vendor` but not `survey_name`, so this one call
   # covers both halves of the rule: the set key is deleted, and the absent key
@@ -2050,7 +1966,6 @@ test_that("bulk deletion mixes a present and an absent key on a frame", {
 
 test_that("a NULL element inside a value list deletes that key", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   d <- set_dataset_metadata(
     d,
@@ -2079,7 +1994,6 @@ test_that("a NULL element inside a value list deletes that key on a frame", {
 
 test_that("a reversed date pair in one call is rejected on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(
@@ -2114,7 +2028,6 @@ test_that("a reversed date pair in one call is rejected on a frame", {
 
 test_that("a new start after the stored end is rejected on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, field_start = "2026-06-01"),
@@ -2136,7 +2049,6 @@ test_that("a new start after the stored end is rejected on a frame", {
 
 test_that("deleting the end date frees a later start on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   # The deleted date is absent from the effective pair, so no comparison runs.
   d <- set_dataset_metadata(
@@ -2166,7 +2078,6 @@ test_that("deleting the end date frees a later start on a frame", {
 
 test_that("deleting the start date frees an earlier end on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   # The mirror of the delete-end case. The stored start is 2026-02-10, so
   # 2026-01-05 would reverse the pair; the deletion removes the start from the
@@ -2198,7 +2109,6 @@ test_that("deleting the start date frees an earlier end on a frame", {
 
 test_that("deleting both dates always succeeds on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, field_start = NULL, field_end = NULL)
 
@@ -2208,7 +2118,6 @@ test_that("deleting both dates always succeeds on a design", {
 
 test_that("an equal start and end pair is accepted on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_dataset_metadata(
     d,
@@ -2227,7 +2136,6 @@ test_that("an equal start and end pair is accepted on a design", {
 
 test_that("one date alone never triggers the pair check on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, field_end = "2026-02-10")
 
@@ -2239,7 +2147,6 @@ test_that("one date alone never triggers the pair check on a design", {
 
 test_that("a rejected value in a multi-key call writes nothing on a design", {
   d <- make_dataset_design("taylor", "survey_name")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, vendor = "Ipsos", data_name = 1L),
@@ -2275,7 +2182,6 @@ test_that("a rejected unknown key in a multi-key call writes nothing", {
 
 test_that("the write leaves the other metadata properties alone", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
   d <- set_var_label(d, y1 = "Outcome one")
   d <- set_val_labels(d, y3 = c(No = 0L, Yes = 1L))
   before_labels <- d@metadata@variable_labels
@@ -2291,7 +2197,6 @@ test_that("the write leaves the other metadata properties alone", {
 
 test_that("the write leaves @data and @variables alone", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
   before_data <- d@data
   before_vars <- d@variables
 
@@ -2303,7 +2208,6 @@ test_that("the write leaves @data and @variables alone", {
 
 test_that("the write never touches whole-frame attributes on @data", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, vendor = "Ipsos")
 
@@ -2314,7 +2218,6 @@ test_that("the write never touches whole-frame attributes on @data", {
 
 test_that("all six keys round-trip on a taylor design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, !!!full_keys)
 
@@ -2323,7 +2226,6 @@ test_that("all six keys round-trip on a taylor design", {
 
 test_that("all six keys round-trip on a replicate design", {
   d <- make_dataset_design("replicate", "none")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, !!!full_keys)
 
@@ -2332,7 +2234,6 @@ test_that("all six keys round-trip on a replicate design", {
 
 test_that("all six keys round-trip on a twophase design", {
   d <- make_dataset_design("twophase", "none")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, !!!full_keys)
 
@@ -2341,7 +2242,6 @@ test_that("all six keys round-trip on a twophase design", {
 
 test_that("all six keys round-trip on a nonprob design", {
   d <- make_dataset_design("nonprob", "none")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, !!!full_keys)
 
@@ -2350,7 +2250,6 @@ test_that("all six keys round-trip on a nonprob design", {
 
 test_that("all six keys round-trip on a nonprob design with repweights", {
   d <- make_dataset_design("nonprob_rep", "none")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, !!!full_keys)
 
@@ -2359,7 +2258,6 @@ test_that("all six keys round-trip on a nonprob design with repweights", {
 
 test_that("make_dataset_design() applies each state through the setter", {
   d_none <- make_dataset_design("taylor", "none")
-  test_invariants(d_none)
   d_full <- make_dataset_design("taylor", "full")
   d_name <- make_dataset_design("taylor", "survey_name")
   d_data <- make_dataset_design("taylor", "data_name")
@@ -2384,7 +2282,6 @@ test_that("make_dataset_design() applies each state through the setter", {
 
 test_that("make_dataset_design() applies a state on a nonprob_rep design", {
   d <- make_dataset_design("nonprob_rep", "data_name")
-  test_invariants(d)
 
   expect_identical(extract_dataset_metadata(d), full_keys["data_name"])
 })
@@ -2428,7 +2325,6 @@ test_that("dates = NULL is an alias that removes both spellings", {
 
 test_that("dates = NULL on a design deletes field_period", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   d <- set_dataset_metadata(d, dates = NULL)
 
@@ -2533,7 +2429,6 @@ test_that("a tibble keeps its class through the write", {
 
 test_that("a write on a stale design raises the unavailable error", {
   d <- make_stale_metadata_design("taylor")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, vendor = "Ipsos"),
@@ -2545,7 +2440,6 @@ test_that("a write on a stale design raises the unavailable error", {
 test_that("a write on a stale design of any class raises the same error", {
   for (cls in c("taylor", "replicate", "twophase", "nonprob")) {
     d <- make_stale_metadata_design(cls)
-    test_invariants(d)
 
     expect_error(
       set_dataset_metadata(d, vendor = "Ipsos"),
@@ -2556,7 +2450,6 @@ test_that("a write on a stale design of any class raises the same error", {
 
 test_that("the stale guard runs ahead of the convention rules", {
   d <- make_stale_metadata_design("taylor")
-  test_invariants(d)
 
   # An empty call and an ambiguous call both report the stale object, because
   # the property guard runs before any input parsing.
@@ -2572,7 +2465,6 @@ test_that("the stale guard runs ahead of the convention rules", {
 
 test_that("the stale guard runs ahead of the unknown-key rule", {
   d <- make_stale_metadata_design("taylor")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, mode = "web"),
@@ -2590,7 +2482,6 @@ test_that("the stale guard runs after the x class check", {
 
 test_that("a deletion on a stale design raises the unavailable error", {
   d <- make_stale_metadata_design("taylor")
-  test_invariants(d)
 
   expect_error(
     set_dataset_metadata(d, vendor = NULL),
@@ -2605,7 +2496,6 @@ test_that("a deletion on a stale design raises the unavailable error", {
 
 test_that("set_vendor() stores the vendor on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_vendor(d, "Ipsos KnowledgePanel Omnibus")
   expect_identical(extract_dataset_metadata(d), full_keys["vendor"])
@@ -2625,7 +2515,6 @@ test_that("set_vendor() returns the modified object invisibly", {
 
 test_that("set_vendor() with NULL deletes the key on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   d <- set_vendor(d, NULL)
   expect_identical(
@@ -2646,7 +2535,6 @@ test_that("set_vendor() with NULL deletes the key on a frame", {
 
 test_that("set_vendor() writes only the vendor key on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   d <- set_vendor(d, "Cint")
   stored <- extract_dataset_metadata(d)
@@ -2657,7 +2545,6 @@ test_that("set_vendor() writes only the vendor key on a design", {
 
 test_that("set_vendor() with no value raises the wrapper setter_empty", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(set_vendor(d), class = "surveycore_error_setter_empty")
   expect_snapshot(error = TRUE, set_vendor(d))
@@ -2671,7 +2558,6 @@ test_that("set_vendor() with no value raises setter_empty on a frame", {
 
 test_that("set_vendor() rejects a non-character value on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_vendor(d, 1L),
@@ -2691,7 +2577,6 @@ test_that("set_vendor() rejects a non-character value on a frame", {
 
 test_that("a rejected set_vendor() call writes nothing on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   expect_error(set_vendor(d, 1L))
   expect_identical(extract_dataset_metadata(d), full_keys)
@@ -2699,7 +2584,6 @@ test_that("a rejected set_vendor() call writes nothing on a design", {
 
 test_that("extract_vendor() returns the stored vendor on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   expect_identical(extract_vendor(d), full_keys[["vendor"]])
 })
@@ -2711,7 +2595,6 @@ test_that("extract_vendor() returns the stored vendor on a frame", {
 
 test_that("extract_vendor() returns NA_character_ when unset on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_identical(extract_vendor(d), NA_character_)
 })
@@ -2730,7 +2613,6 @@ test_that("the vendor pair round-trips on every design class", {
   designs <- c("taylor", "replicate", "twophase", "nonprob", "nonprob_rep")
   for (design in designs) {
     d <- make_dataset_design(design, "none")
-    test_invariants(d)
 
     d <- set_vendor(d, "Ipsos KnowledgePanel Omnibus")
     expect_identical(extract_vendor(d), full_keys[["vendor"]])
@@ -2744,7 +2626,6 @@ test_that("the vendor pair round-trips on every design class", {
 
 test_that("set_survey_name() stores the survey name on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_survey_name(d, "Antisemitic Attitudes in America 2026")
   expect_identical(extract_dataset_metadata(d), full_keys["survey_name"])
@@ -2759,7 +2640,6 @@ test_that("set_survey_name() stores the survey name on a frame", {
 
 test_that("set_data_name() stores the data name on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_data_name(d, "AAA Ipsos (February-March 2026)")
   expect_identical(extract_dataset_metadata(d), full_keys["data_name"])
@@ -2774,7 +2654,6 @@ test_that("set_data_name() stores the data name on a frame", {
 
 test_that("set_survey_name() never writes data_name on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   # Independence rule: the two keys are separate and never fill each other.
   d <- set_survey_name(d, "Antisemitic Attitudes in America 2026")
@@ -2792,7 +2671,6 @@ test_that("set_survey_name() never writes data_name on a frame", {
 
 test_that("set_data_name() never writes survey_name on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_data_name(d, "AAA Ipsos (February-March 2026)")
   expect_false("survey_name" %in% names(extract_dataset_metadata(d)))
@@ -2809,7 +2687,6 @@ test_that("set_data_name() never writes survey_name on a frame", {
 
 test_that("set_survey_name() leaves an unrelated data_name alone", {
   d <- make_dataset_design("taylor", "data_name")
-  test_invariants(d)
 
   # The two values may drift; no function reconciles them.
   d <- set_survey_name(d, "A Completely Unrelated Survey Title")
@@ -2842,7 +2719,6 @@ test_that("set_survey_name() leaves an unrelated data_name alone on a frame", {
 
 test_that("set_data_name() leaves an unrelated survey_name alone", {
   d <- make_dataset_design("taylor", "survey_name")
-  test_invariants(d)
 
   # Mirror of the set_survey_name() case. The design arrives with a genuine
   # survey_name, so a setter that filled or overwrote it would fail here.
@@ -2881,7 +2757,6 @@ test_that("set_data_name() leaves an unrelated survey_name alone on a frame", {
 
 test_that("set_survey_name() with NULL deletes only survey_name", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   d <- set_survey_name(d, NULL)
   expect_identical(
@@ -2912,7 +2787,6 @@ test_that("set_data_name() returns the modified object invisibly", {
 
 test_that("set_survey_name() with no value raises setter_empty", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(set_survey_name(d), class = "surveycore_error_setter_empty")
   expect_snapshot(error = TRUE, set_survey_name(d))
@@ -2920,7 +2794,6 @@ test_that("set_survey_name() with no value raises setter_empty", {
 
 test_that("set_data_name() with no value raises setter_empty", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(set_data_name(d), class = "surveycore_error_setter_empty")
   expect_snapshot(error = TRUE, set_data_name(d))
@@ -2938,7 +2811,6 @@ test_that("set_data_name() with no value raises setter_empty on a frame", {
 
 test_that("set_survey_name() rejects a non-character value on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_survey_name(d, 1L),
@@ -2949,7 +2821,6 @@ test_that("set_survey_name() rejects a non-character value on a design", {
 
 test_that("set_data_name() rejects a non-character value on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_data_name(d, 1L),
@@ -2976,7 +2847,6 @@ test_that("set_data_name() rejects a non-character value on a frame", {
 
 test_that("extract_survey_name() returns the stored name on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   expect_identical(extract_survey_name(d), full_keys[["survey_name"]])
 })
@@ -2988,7 +2858,6 @@ test_that("extract_survey_name() returns the stored name on a frame", {
 
 test_that("extract_data_name() returns the stored name on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   expect_identical(extract_data_name(d), full_keys[["data_name"]])
 })
@@ -3000,14 +2869,12 @@ test_that("extract_data_name() returns the stored name on a frame", {
 
 test_that("extract_survey_name() returns NA_character_ when unset", {
   d <- make_dataset_design("taylor", "data_name")
-  test_invariants(d)
 
   expect_identical(extract_survey_name(d), NA_character_)
 })
 
 test_that("extract_data_name() returns NA_character_ when unset", {
   d <- make_dataset_design("taylor", "survey_name")
-  test_invariants(d)
 
   expect_identical(extract_data_name(d), NA_character_)
 })
@@ -3016,7 +2883,6 @@ test_that("extract_data_name() never composes a label on a design", {
   # Strictness rule: every other key is set, and data_name is still NA.
   others <- setdiff(names(full_keys), "data_name")
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
   d <- set_dataset_metadata(d, !!!full_keys[others])
 
   expect_identical(extract_dataset_metadata(d), full_keys[others])
@@ -3033,7 +2899,6 @@ test_that("extract_data_name() never composes a label on a frame", {
 
 test_that("extract_survey_name() does not fall back to data_name", {
   d <- make_dataset_design("taylor", "data_name")
-  test_invariants(d)
 
   expect_identical(extract_survey_name(d), NA_character_)
 })
@@ -3042,7 +2907,6 @@ test_that("the name pairs round-trip on every design class", {
   designs <- c("taylor", "replicate", "twophase", "nonprob", "nonprob_rep")
   for (design in designs) {
     d <- make_dataset_design(design, "none")
-    test_invariants(d)
 
     d <- set_survey_name(d, full_keys[["survey_name"]])
     d <- set_data_name(d, full_keys[["data_name"]])
@@ -3058,7 +2922,6 @@ test_that("the name pairs round-trip on every design class", {
 
 test_that("set_field_period() stores the period on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   # The argument is `period`; the STORED key is still `field_period`.
   d <- set_field_period(d, "February-March 2026")
@@ -3086,7 +2949,6 @@ test_that("set_field_period() returns the modified object invisibly", {
 
 test_that("set_field_period() with NULL deletes the key on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   d <- set_field_period(d, NULL)
   expect_identical(
@@ -3106,7 +2968,6 @@ test_that("set_field_period() with NULL clears the legacy name too", {
 
 test_that("set_field_period() never touches the field dates", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   d <- set_field_period(d, "Spring 2026")
   expect_identical(
@@ -3117,7 +2978,6 @@ test_that("set_field_period() never touches the field dates", {
 
 test_that("set_field_period() with no value raises setter_empty", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(set_field_period(d), class = "surveycore_error_setter_empty")
   expect_snapshot(error = TRUE, set_field_period(d))
@@ -3130,7 +2990,6 @@ test_that("set_field_period() with no value raises setter_empty on a frame", {
 
 test_that("set_field_period() rejects a non-character value on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_field_period(d, 1L),
@@ -3150,7 +3009,6 @@ test_that("set_field_period() rejects a non-character value on a frame", {
 
 test_that("extract_field_period() returns the stored period on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   expect_identical(extract_field_period(d), full_keys[["field_period"]])
 })
@@ -3162,7 +3020,6 @@ test_that("extract_field_period() returns the stored period on a frame", {
 
 test_that("extract_field_period() returns NA_character_ when unset", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_identical(extract_field_period(d), NA_character_)
 })
@@ -3176,7 +3033,6 @@ test_that("the period pair round-trips on every design class", {
   designs <- c("taylor", "replicate", "twophase", "nonprob", "nonprob_rep")
   for (design in designs) {
     d <- make_dataset_design(design, "none")
-    test_invariants(d)
 
     d <- set_field_period(d, full_keys[["field_period"]])
     expect_identical(extract_field_period(d), full_keys[["field_period"]])
@@ -3190,7 +3046,6 @@ test_that("the period pair round-trips on every design class", {
 
 test_that("set_field_dates() stores both dates on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_field_dates(
     d,
@@ -3219,7 +3074,6 @@ test_that("set_field_dates() stores both dates on a frame", {
 
 test_that("set_field_dates() coerces ISO strings to Date on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_field_dates(d, "2026-02-10", "2026-03-04")
   expect_identical(
@@ -3245,7 +3099,6 @@ test_that("set_field_dates() returns the modified object invisibly", {
 
 test_that("set_field_dates() sets the start alone on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   d <- set_field_dates(d, field_start = "2026-02-10")
   expect_identical(extract_dataset_metadata(d), full_keys["field_start"])
@@ -3260,7 +3113,6 @@ test_that("set_field_dates() sets the end alone on a frame", {
 
 test_that("an unsupplied set_field_dates() argument leaves the key alone", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   # Only field_start is forwarded, so the stored field_end must survive.
   d <- set_field_dates(d, field_start = "2026-01-05")
@@ -3288,7 +3140,6 @@ test_that("an unsupplied set_field_dates() argument leaves a frame key alone", {
 
 test_that("set_field_dates() leaves the other keys alone on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   d <- set_field_dates(d, "2026-02-11", "2026-03-05")
   others <- setdiff(names(full_keys), c("field_start", "field_end"))
@@ -3297,7 +3148,6 @@ test_that("set_field_dates() leaves the other keys alone on a design", {
 
 test_that("set_field_dates() never touches field_period", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   d <- set_field_dates(d, field_start = NULL, field_end = NULL)
   expect_identical(extract_field_period(d), full_keys[["field_period"]])
@@ -3305,7 +3155,6 @@ test_that("set_field_dates() never touches field_period", {
 
 test_that("an explicit NULL deletes the start on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   d <- set_field_dates(d, field_start = NULL)
   expect_identical(
@@ -3326,7 +3175,6 @@ test_that("an explicit NULL deletes the end on a frame", {
 
 test_that("two explicit NULLs delete both dates on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   d <- set_field_dates(d, field_start = NULL, field_end = NULL)
   expect_identical(
@@ -3356,7 +3204,6 @@ test_that("deleting an unset date raises no condition", {
 
 test_that("set_field_dates() with no arguments raises setter_empty", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(set_field_dates(d), class = "surveycore_error_setter_empty")
   expect_snapshot(error = TRUE, set_field_dates(d))
@@ -3369,7 +3216,6 @@ test_that("set_field_dates() with no arguments raises setter_empty on a frame", 
 
 test_that("set_field_dates() rejects a non-strict ISO start on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_field_dates(d, field_start = "2026/02/10"),
@@ -3381,7 +3227,6 @@ test_that("set_field_dates() rejects a non-strict ISO start on a design", {
 
 test_that("set_field_dates() rejects a non-strict ISO end on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_field_dates(d, field_end = "2026-3-4"),
@@ -3401,7 +3246,6 @@ test_that("set_field_dates() rejects an impossible date on a frame", {
 
 test_that("set_field_dates() rejects a numeric date on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_field_dates(d, field_start = 20260210),
@@ -3412,7 +3256,6 @@ test_that("set_field_dates() rejects a numeric date on a design", {
 
 test_that("set_field_dates() rejects an NA date with its own bullet", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_field_dates(d, field_start = NA),
@@ -3432,7 +3275,6 @@ test_that("set_field_dates() rejects a zero-length date on a frame", {
 
 test_that("set_field_dates() raises no base as.Date() condition", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   # The raised condition is the typed surveycore error and nothing else: a
   # stray base warning from as.Date() would fail expect_no_warning().
@@ -3446,7 +3288,6 @@ test_that("set_field_dates() raises no base as.Date() condition", {
 
 test_that("a rejected set_field_dates() call writes nothing on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   expect_error(set_field_dates(d, field_start = "2026/02/10"))
   expect_identical(extract_dataset_metadata(d), full_keys)
@@ -3461,7 +3302,6 @@ test_that("a rejected set_field_dates() call writes nothing on a frame", {
 
 test_that("extract_field_dates() returns both stored dates on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   expect_identical(
     extract_field_dates(d),
@@ -3486,7 +3326,6 @@ test_that("extract_field_dates() returns both stored dates on a frame", {
 
 test_that("extract_field_dates() names the two entries with field_ prefixes", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   expect_identical(
     names(extract_field_dates(d)),
@@ -3496,7 +3335,6 @@ test_that("extract_field_dates() names the two entries with field_ prefixes", {
 
 test_that("extract_field_dates() fills an unset entry with as.Date(NA)", {
   d <- make_dataset_design("taylor", "partial")
-  test_invariants(d)
 
   # The "partial" state sets field_start only.
   expect_identical(
@@ -3507,7 +3345,6 @@ test_that("extract_field_dates() fills an unset entry with as.Date(NA)", {
 
 test_that("extract_field_dates() returns the all-NA pair when both unset", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_identical(
     extract_field_dates(d),
@@ -3542,7 +3379,6 @@ test_that("the dates pair round-trips on every design class", {
   designs <- c("taylor", "replicate", "twophase", "nonprob", "nonprob_rep")
   for (design in designs) {
     d <- make_dataset_design(design, "none")
-    test_invariants(d)
 
     d <- set_field_dates(d, "2026-02-10", "2026-03-04")
     expect_identical(
@@ -3562,7 +3398,6 @@ test_that("the dates pair round-trips on every design class", {
 
 test_that("a reversed pair in one set_field_dates() call is rejected", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   expect_error(
     set_field_dates(d, "2026-03-04", "2026-02-10"),
@@ -3585,7 +3420,6 @@ test_that("a reversed pair in one call is rejected on a frame", {
 
 test_that("a start after the STORED end is rejected on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   # Rule branch 3: the unmentioned end contributes its stored value.
   expect_error(
@@ -3609,7 +3443,6 @@ test_that("a start after the STORED end is rejected on a frame", {
 
 test_that("an end before the STORED start is rejected on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   expect_error(
     set_field_dates(d, field_end = "2026-01-05"),
@@ -3619,7 +3452,6 @@ test_that("an end before the STORED start is rejected on a design", {
 
 test_that("deleting the end frees a later start on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   # Rule branch 2: an explicit NULL counts as ABSENT, so the pair check has
   # only one effective value and does not run.
@@ -3642,7 +3474,6 @@ test_that("deleting the end frees a later start on a frame", {
 
 test_that("deleting the start frees an earlier end on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   d <- set_field_dates(d, field_start = NULL, field_end = "2026-01-05")
   expect_identical(
@@ -3653,7 +3484,6 @@ test_that("deleting the start frees an earlier end on a design", {
 
 test_that("deleting both dates always succeeds on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   expect_no_condition(
     d <- set_field_dates(d, field_start = NULL, field_end = NULL)
@@ -3666,7 +3496,6 @@ test_that("deleting both dates always succeeds on a design", {
 
 test_that("equal effective dates are accepted on a design", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   # The rule rejects start AFTER end, so a one-day field period is valid.
   d <- set_field_dates(d, "2026-02-10", "2026-02-10")
@@ -3681,7 +3510,6 @@ test_that("equal effective dates are accepted on a design", {
 
 test_that("a rejected reversed pair writes neither date on a design", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   expect_error(set_field_dates(d, "2026-05-01", "2026-04-01"))
   expect_identical(extract_dataset_metadata(d), full_keys)
@@ -3694,7 +3522,6 @@ test_that("a rejected reversed pair writes neither date on a design", {
 
 test_that("the five wrapper setters raise DM-8 on a stale taylor design", {
   d <- make_stale_metadata_design("taylor")
-  test_invariants(d)
 
   expect_error(
     set_vendor(d, "Ipsos"),
@@ -3720,7 +3547,6 @@ test_that("the five wrapper setters raise DM-8 on a stale taylor design", {
 
 test_that("set_vendor() on a stale design names the rebuild remedy", {
   d <- make_stale_metadata_design("taylor")
-  test_invariants(d)
 
   expect_error(
     set_vendor(d, "x"),
@@ -3732,7 +3558,6 @@ test_that("set_vendor() on a stale design names the rebuild remedy", {
 test_that("the wrapper setters raise DM-8 on every stale design class", {
   for (design in c("taylor", "replicate", "twophase", "nonprob")) {
     d <- make_stale_metadata_design(design)
-    test_invariants(d)
 
     expect_error(
       set_vendor(d, "Ipsos"),
@@ -3747,7 +3572,6 @@ test_that("the wrapper setters raise DM-8 on every stale design class", {
 
 test_that("a wrapper deletion on a stale design also raises DM-8", {
   d <- make_stale_metadata_design("taylor")
-  test_invariants(d)
 
   expect_error(
     set_vendor(d, NULL),
@@ -3761,7 +3585,6 @@ test_that("a wrapper deletion on a stale design also raises DM-8", {
 
 test_that("the stale guard runs ahead of a wrapper's missing-value guard", {
   d <- make_stale_metadata_design("taylor")
-  test_invariants(d)
 
   # Guard order: class check, then DM-8, then the wrapper's own argument
   # guard. A stale object with no value reports the object, not the argument.
@@ -3795,7 +3618,6 @@ test_that("the x class check runs ahead of the stale guard in a wrapper", {
 
 test_that("the stale guard runs ahead of a wrapper's value check", {
   d <- make_stale_metadata_design("taylor")
-  test_invariants(d)
 
   # A bad value on a stale object reports the object: the wrapper cannot write
   # anywhere, which is the problem the caller has to fix first.
@@ -3812,7 +3634,6 @@ test_that("the stale guard runs ahead of a wrapper's value check", {
 test_that("the four scalar extractors return NA on a stale design", {
   for (design in c("taylor", "replicate", "twophase", "nonprob")) {
     d <- make_stale_metadata_design(design)
-    test_invariants(d)
 
     expect_identical(extract_survey_name(d), NA_character_)
     expect_identical(extract_data_name(d), NA_character_)
@@ -3824,7 +3645,6 @@ test_that("the four scalar extractors return NA on a stale design", {
 test_that("extract_field_dates() returns the all-NA pair on a stale design", {
   for (design in c("taylor", "replicate", "twophase", "nonprob")) {
     d <- make_stale_metadata_design(design)
-    test_invariants(d)
 
     expect_identical(
       extract_field_dates(d),
@@ -3835,7 +3655,6 @@ test_that("extract_field_dates() returns the all-NA pair on a stale design", {
 
 test_that("the wrapper extractors raise no condition on a stale design", {
   d <- make_stale_metadata_design("taylor")
-  test_invariants(d)
 
   expect_no_condition(extract_vendor(d))
   expect_no_condition(extract_field_dates(d))
@@ -3877,7 +3696,6 @@ test_that("every wrapper extractor rejects a non-survey, non-frame x", {
 test_that("every wrapper setter rejects a survey_collection", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
   coll <- survey_collection(list(a = d, b = d))
 
   expect_error(
@@ -3905,7 +3723,6 @@ test_that("every wrapper setter rejects a survey_collection", {
 test_that("every wrapper extractor rejects a survey_collection", {
   df <- make_survey_data(n = 40L, n_psu = 6L, n_strata = 2L)
   d <- as_survey(df, weights = wt)
-  test_invariants(d)
   coll <- survey_collection(list(a = d, b = d))
 
   expect_error(
@@ -4041,7 +3858,6 @@ test_that("the wrapper extractors read raw attr()<- writes on a frame", {
 
 test_that("a distant unknown key renders the base unknown-key message", {
   d <- make_dataset_design("taylor", "none")
-  test_invariants(d)
 
   # `zzz` is far from every valid key, so no did-you-mean hint applies.
   expect_error(
@@ -4090,17 +3906,14 @@ test_that("as_survey_twophase() inherits the phase 1 dataset metadata", {
     fpc = fpc,
     nest = TRUE
   )
-  test_invariants(phase1)
   expect_identical(extract_dataset_metadata(phase1), full_keys)
 
   d <- as_survey_twophase(phase1, subset = subset, method = "approx")
-  test_invariants(d)
   expect_identical(extract_dataset_metadata(d), full_keys)
 })
 
 test_that("as_survey_twophase() reports no dataset metadata when phase 1 has none", {
   d <- make_dataset_design("twophase", "none")
-  test_invariants(d)
 
   expect_identical(extract_dataset_metadata(d), list())
 })
@@ -4125,7 +3938,6 @@ test_that("from_svydesign() produces a design with no dataset metadata", {
   expect_identical(attr(sv$variables, "vendor", exact = TRUE), full_keys$vendor)
 
   d <- from_svydesign(sv)
-  test_invariants(d)
 
   expect_identical(extract_dataset_metadata(d), list())
 })
@@ -4147,7 +3959,6 @@ test_that("from_tbl_svy() produces a design with no dataset metadata", {
   expect_identical(attr(ts$variables, "vendor", exact = TRUE), full_keys$vendor)
 
   d <- from_tbl_svy(ts)
-  test_invariants(d)
 
   expect_identical(extract_dataset_metadata(d), list())
 })
@@ -4156,7 +3967,6 @@ test_that("as_tbl_svy() accepts a design carrying dataset metadata", {
   skip_if_not_installed("survey")
   skip_if_not_installed("srvyr")
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
   expect_identical(extract_dataset_metadata(d), full_keys)
 
   ts <- as_tbl_svy(d)
@@ -4169,7 +3979,6 @@ test_that("as_tbl_svy() accepts a design carrying dataset metadata", {
 test_that("as_svydesign() accepts a design carrying dataset metadata", {
   skip_if_not_installed("survey")
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   sv <- as_svydesign(d)
   expect_true(inherits(sv, "survey.design"))
@@ -4198,7 +4007,6 @@ test_that("every key written by the frame setter promotes at construction", {
   df <- set_dataset_metadata(df, !!!full_keys)
 
   d <- .build_from_frame(df)
-  test_invariants(d)
 
   expect_identical(extract_dataset_metadata(d), full_keys)
 })
@@ -4213,7 +4021,6 @@ test_that("a date the frame setter coerced from a string promotes as a Date", {
   )
 
   d <- .build_from_frame(df)
-  test_invariants(d)
 
   expect_identical(
     extract_dataset_metadata(d),
@@ -4232,7 +4039,6 @@ test_that("deleting field_period on a frame is idempotent through construction",
   # Positive control: without the deletion the period does promote, so the
   # assertion below cannot pass vacuously.
   control <- .build_from_frame(df)
-  test_invariants(control)
   expect_identical(extract_field_period(control), "February-March 2026")
 
   cleaned <- set_dataset_metadata(df, field_period = NULL)
@@ -4240,7 +4046,6 @@ test_that("deleting field_period on a frame is idempotent through construction",
   expect_null(attr(cleaned, "dates", exact = TRUE))
 
   d <- .build_from_frame(cleaned)
-  test_invariants(d)
   expect_identical(extract_field_period(d), NA_character_)
   expect_false("field_period" %in% names(extract_dataset_metadata(d)))
 })
@@ -4250,12 +4055,10 @@ test_that("the dates = NULL alias is idempotent through construction too", {
   attr(df, "dates") <- "February-March 2026"
 
   control <- .build_from_frame(df)
-  test_invariants(control)
   expect_identical(extract_field_period(control), "February-March 2026")
 
   cleaned <- set_dataset_metadata(df, dates = NULL)
   d <- .build_from_frame(cleaned)
-  test_invariants(d)
 
   expect_identical(extract_field_period(d), NA_character_)
 })
@@ -4266,12 +4069,10 @@ test_that("set_field_period(df, NULL) is idempotent through construction", {
   attr(df, "dates") <- "an older period"
 
   control <- .build_from_frame(df)
-  test_invariants(control)
   expect_identical(extract_field_period(control), "February-March 2026")
 
   cleaned <- set_field_period(df, NULL)
   d <- .build_from_frame(cleaned)
-  test_invariants(d)
 
   expect_identical(extract_field_period(d), NA_character_)
 })

--- a/tests/testthat/test-methods-print.R
+++ b/tests/testthat/test-methods-print.R
@@ -117,7 +117,6 @@ test_that("print.survey_taylor default output matches snapshot", {
 
 test_that("print.survey_taylor full=TRUE output matches snapshot", {
   d <- make_taylor_design()
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
   expect_snapshot(print(d, full = TRUE))
 })
@@ -127,7 +126,6 @@ test_that("print.survey_taylor full=TRUE output matches snapshot", {
 
 test_that("print.survey_taylor design_info=TRUE shows design spec section", {
   d <- make_taylor_design()
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
   # cli output goes to message(), not stdout
   out <- capture.output(print(d, design_info = TRUE), type = "message")
@@ -138,7 +136,6 @@ test_that("print.survey_taylor design_info=TRUE shows design spec section", {
 
 test_that("print.survey_taylor weights_info=TRUE shows weight distribution and Weighted N", {
   d <- make_taylor_design()
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
   out <- capture.output(print(d, weights_info = TRUE), type = "message")
   expect_true(any(grepl("Weight distribution", out)))
@@ -164,7 +161,6 @@ test_that("print.survey_taylor metadata_info=TRUE shows labeled count", {
 
 test_that("print.survey_taylor default suppresses detail sections", {
   d <- make_taylor_design()
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
   out <- capture.output(print(d), type = "message")
   expect_false(any(grepl("Design specification", out)))
@@ -177,7 +173,6 @@ test_that("print.survey_taylor default suppresses detail sections", {
 
 test_that("print.survey_taylor returns x invisibly", {
   d <- make_taylor_design()
-  test_invariants(d)
   # capture.output suppresses stdout (tibble); cli msg goes to message
   result <- suppressMessages(print(d, n = 1L))
   expect_identical(result, d)
@@ -188,7 +183,6 @@ test_that("print.survey_taylor returns x invisibly", {
 
 test_that("print.survey_taylor design_info shows 'sampling weights' when weights given", {
   d <- make_taylor_design()
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
   out <- capture.output(print(d, design_info = TRUE), type = "message")
   expect_true(any(grepl("sampling weights", out)))
@@ -198,7 +192,6 @@ test_that("print.survey_taylor design_info shows 'probabilities (converted)' whe
   df <- make_survey_data(n = 50L, n_psu = 10L, n_strata = 2L, seed = 42L)
   df$prob <- 1 / df$wt
   d <- as_survey(df, ids = psu, probs = prob, strata = strata, nest = TRUE)
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
   out <- capture.output(print(d, design_info = TRUE), type = "message")
   expect_true(any(grepl("probabilities.*converted", out)))
@@ -209,7 +202,6 @@ test_that("print.survey_taylor design_info shows 'probabilities (converted)' whe
 
 test_that("print.survey_taylor SRS design omits 'Weights provided as:' line", {
   d <- make_srs_design()
-  test_invariants(d)
   # @variables$weights should be the internal auto-weight column
   expect_identical(d@variables$weights, "..surveycore_wt..")
   withr::local_options(list(width = 80L, cli.width = 80L))
@@ -223,7 +215,6 @@ test_that("print.survey_taylor SRS design omits 'Weights provided as:' line", {
 
 test_that("print.survey_replicate default output matches snapshot", {
   d <- make_rep_design()
-  test_invariants(d)
   expect_false(surveycore::SURVEYCORE_DOMAIN_COL %in% names(d@data))
   withr::local_options(list(width = 80L, cli.width = 80L))
   expect_snapshot(print(d))
@@ -234,7 +225,6 @@ test_that("print.survey_replicate default output matches snapshot", {
 
 test_that("print.survey_replicate full=TRUE output matches snapshot", {
   d <- make_rep_design()
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
   expect_snapshot(print(d, full = TRUE))
 })
@@ -244,7 +234,6 @@ test_that("print.survey_replicate full=TRUE output matches snapshot", {
 
 test_that("print.survey_replicate returns x invisibly", {
   d <- make_rep_design()
-  test_invariants(d)
   result <- suppressMessages(print(d, n = 1L))
   expect_identical(result, d)
 })
@@ -254,7 +243,6 @@ test_that("print.survey_replicate returns x invisibly", {
 
 test_that("print.survey_twophase default output matches snapshot", {
   d <- make_twophase_design()
-  test_invariants(d)
   expect_false(surveycore::SURVEYCORE_DOMAIN_COL %in% names(d@data))
   withr::local_options(list(width = 80L, cli.width = 80L))
   expect_snapshot(print(d))
@@ -265,7 +253,6 @@ test_that("print.survey_twophase default output matches snapshot", {
 
 test_that("print.survey_twophase full=TRUE output matches snapshot", {
   d <- make_twophase_design()
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
   expect_snapshot(print(d, full = TRUE))
 })
@@ -275,7 +262,6 @@ test_that("print.survey_twophase full=TRUE output matches snapshot", {
 
 test_that("print.survey_twophase returns x invisibly", {
   d <- make_twophase_design()
-  test_invariants(d)
   result <- suppressMessages(print(d, n = 1L))
   expect_identical(result, d)
 })
@@ -285,7 +271,6 @@ test_that("print.survey_twophase returns x invisibly", {
 
 test_that("summary.survey_taylor output matches snapshot", {
   d <- make_taylor_design()
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
   expect_snapshot(summary(d))
 })
@@ -295,7 +280,6 @@ test_that("summary.survey_taylor output matches snapshot", {
 
 test_that("summary.survey_taylor shows type, size, design, and metadata sections", {
   d <- make_taylor_design()
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
   out <- capture.output(summary(d), type = "message")
   expect_true(any(grepl("Taylor series linearization", out)))
@@ -308,7 +292,6 @@ test_that("summary.survey_taylor shows type, size, design, and metadata sections
 
 test_that("summary.survey_taylor SRS design shows 'none' for IDs and Strata", {
   d <- make_srs_design()
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
   out <- capture.output(summary(d), type = "message")
   expect_true(any(grepl("IDs: none", out)))
@@ -320,7 +303,6 @@ test_that("summary.survey_taylor SRS design shows 'none' for IDs and Strata", {
 
 test_that("summary.survey_taylor returns object invisibly", {
   d <- make_taylor_design()
-  test_invariants(d)
   result <- suppressMessages(summary(d))
   expect_identical(result, d)
 })
@@ -330,14 +312,12 @@ test_that("summary.survey_taylor returns object invisibly", {
 
 test_that("summary.survey_replicate output matches snapshot", {
   d <- make_rep_design()
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
   expect_snapshot(summary(d))
 })
 
 test_that("summary.survey_replicate returns object invisibly", {
   d <- make_rep_design()
-  test_invariants(d)
   result <- suppressMessages(summary(d))
   expect_identical(result, d)
 })
@@ -347,14 +327,12 @@ test_that("summary.survey_replicate returns object invisibly", {
 
 test_that("summary.survey_twophase output matches snapshot", {
   d <- make_twophase_design()
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
   expect_snapshot(summary(d))
 })
 
 test_that("summary.survey_twophase returns object invisibly", {
   d <- make_twophase_design()
-  test_invariants(d)
   result <- suppressMessages(summary(d))
   expect_identical(result, d)
 })
@@ -375,7 +353,6 @@ test_that("summary.survey_twophase returns object invisibly", {
 test_that("print.survey_taylor() shows domain line when domain column is present", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_taylor_design()
-  test_invariants(d)
   d@data[[surveycore::SURVEYCORE_DOMAIN_COL]] <- d@data$y1 > 0
   expect_snapshot(print(d))
 })
@@ -386,7 +363,6 @@ test_that("print.survey_taylor() shows domain line when domain column is present
 test_that("print.survey_taylor() domain count excludes NAs", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_taylor_design()
-  test_invariants(d)
   mask <- rep(c(TRUE, FALSE, NA), length.out = nrow(d@data))
   d@data[[surveycore::SURVEYCORE_DOMAIN_COL]] <- mask
   expect_snapshot(print(d))
@@ -398,7 +374,6 @@ test_that("print.survey_taylor() domain count excludes NAs", {
 test_that("print.survey_taylor() domain line appears before groups line", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_taylor_design()
-  test_invariants(d)
   d@data[[surveycore::SURVEYCORE_DOMAIN_COL]] <- d@data$y1 > 0
   d@groups <- "strata"
   expect_snapshot(print(d))
@@ -410,7 +385,6 @@ test_that("print.survey_taylor() domain line appears before groups line", {
 test_that("print.survey_replicate() shows domain line when domain column is present", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_rep_design()
-  test_invariants(d)
   d@data[[surveycore::SURVEYCORE_DOMAIN_COL]] <- d@data$y1 > 0
   expect_snapshot(print(d))
 })
@@ -421,7 +395,6 @@ test_that("print.survey_replicate() shows domain line when domain column is pres
 test_that("print.survey_twophase() shows domain line when domain column is present", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_twophase_design()
-  test_invariants(d)
   d@data[[surveycore::SURVEYCORE_DOMAIN_COL]] <- d@data$y1 > 0
   expect_snapshot(print(d))
 })
@@ -450,7 +423,6 @@ test_that("print.survey_nonprob() shows domain line when domain column is presen
   set.seed(123L)
   df$cal_wt <- df$wt * runif(nrow(df), 0.9, 1.1)
   d <- as_survey_nonprob(df, weights = cal_wt)
-  test_invariants(d)
   expect_true(S7::S7_inherits(d, survey_nonprob))
   d@data[[surveycore::SURVEYCORE_DOMAIN_COL]] <- d@data$y1 > 0
   expect_snapshot(print(d))
@@ -462,7 +434,6 @@ test_that("print.survey_nonprob() shows domain line when domain column is presen
 test_that("print.survey_taylor() shows domain line when zero rows are in domain", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_taylor_design()
-  test_invariants(d)
   d@data[[surveycore::SURVEYCORE_DOMAIN_COL]] <- FALSE
   expect_snapshot(print(d))
 })
@@ -472,7 +443,6 @@ test_that("print.survey_taylor() shows domain line when zero rows are in domain"
 test_that("print.survey_replicate() shows groups when @groups is set", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_rep_design()
-  test_invariants(d)
   d@groups <- "strata"
   out <- capture.output(print(d), type = "message")
   expect_true(any(grepl("Groups", out)))
@@ -481,7 +451,6 @@ test_that("print.survey_replicate() shows groups when @groups is set", {
 test_that("print.survey_replicate() with FPC covers FPC design_info block", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_rep_design()
-  test_invariants(d)
   # Add a synthetic FPC column to trigger the FPC design_info block
   d@data$fpc_rep <- rep(500L, nrow(d@data))
   d@variables$fpc <- "fpc_rep"
@@ -495,7 +464,6 @@ test_that("print.survey_replicate() with FPC covers FPC design_info block", {
 test_that("print.survey_twophase() shows groups when @groups is set", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_twophase_design()
-  test_invariants(d)
   d@groups <- "strata"
   out <- capture.output(print(d), type = "message")
   expect_true(any(grepl("Groups", out)))
@@ -504,7 +472,6 @@ test_that("print.survey_twophase() shows groups when @groups is set", {
 test_that("print.survey_twophase full=TRUE includes Phase 2 fields", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_twophase_design()
-  test_invariants(d)
   out <- capture.output(print(d, full = TRUE), type = "message")
   expect_true(any(grepl("Phase 2", out)))
 })
@@ -514,7 +481,6 @@ test_that("print.survey_twophase full=TRUE includes Phase 2 fields", {
 test_that("summary.survey_replicate() shows BRR type and replicate count", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_rep_design()
-  test_invariants(d)
   out <- capture.output(summary(d), type = "message")
   expect_true(any(grepl("BRR", out)))
   expect_true(any(grepl("Replicate", out, ignore.case = TRUE)))
@@ -525,7 +491,6 @@ test_that("summary.survey_replicate() shows BRR type and replicate count", {
 test_that("summary.survey_twophase() shows Phase 1 and Phase 2 sections", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_twophase_design()
-  test_invariants(d)
   out <- capture.output(summary(d), type = "message")
   expect_true(any(grepl("Phase 1", out)))
   expect_true(any(grepl("Phase 2", out)))
@@ -658,14 +623,12 @@ test_that("print.survey_taylor shows per-stage FPC for 2-stage design", {
     strata = strata,
     fpc = c(fpc, fpc2)
   )
-  test_invariants(sc)
   withr::local_options(list(width = 80L, cli.width = 80L))
   expect_snapshot(print(sc, design_info = TRUE))
 })
 
 test_that("print.survey_taylor shows single FPC line for 1-stage design", {
   d <- make_taylor_design()
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
   out <- capture.output(print(d, design_info = TRUE), type = "message")
   # Should show single "FPC: fpc" line, not "FPC (stage 1):"
@@ -789,7 +752,6 @@ test_that("print(survey_nonprob): JK1 header contains 'JK1' not 'BOOTSTRAP'", {
     repweights = c(r1, r2, r3, r4),
     type = "JK1"
   )
-  test_invariants(d)
   output <- capture.output(print(d), type = "message")
   expect_true(any(grepl("JK1", output)))
   expect_false(any(grepl("BOOTSTRAP", output)))
@@ -805,7 +767,6 @@ test_that("print(survey_nonprob): JK2 header contains 'JK2'", {
     type = "JK2",
     rscales = rep(0.75, 4)
   )
-  test_invariants(d)
   output <- capture.output(print(d), type = "message")
   expect_true(any(grepl("JK2", output)))
   expect_false(any(grepl("BOOTSTRAP", output)))
@@ -821,7 +782,6 @@ test_that("print(survey_nonprob): JKn header contains 'JKN'", {
     type = "JKn",
     rscales = rep(0.75, 4)
   )
-  test_invariants(d)
   output <- capture.output(print(d), type = "message")
   expect_true(any(grepl("JKN", output)))
   expect_false(any(grepl("BOOTSTRAP", output)))
@@ -836,7 +796,6 @@ test_that("print(survey_nonprob): bootstrap header still contains 'BOOTSTRAP' [r
     repweights = c(r1, r2, r3, r4),
     type = "bootstrap"
   )
-  test_invariants(d)
   output <- capture.output(print(d), type = "message")
   expect_true(any(grepl("BOOTSTRAP", output)))
 })
@@ -1030,7 +989,6 @@ capture_design_output <- function(expr) {
 
 test_that("print.survey_taylor shows a Dataset line holding data_name", {
   d <- make_dataset_design("taylor", "data_name")
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
 
   out <- capture_design_output(print(d))$cli
@@ -1042,7 +1000,6 @@ test_that("print.survey_taylor shows a Dataset line holding data_name", {
 
 test_that("print.survey_taylor Dataset line sits directly above Sample size", {
   d <- make_dataset_design("taylor", "data_name")
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
 
   out <- capture_design_output(print(d))$cli
@@ -1054,7 +1011,6 @@ test_that("print.survey_taylor Dataset line sits directly above Sample size", {
 
 test_that("print.survey_taylor Dataset line falls back to survey_name", {
   d <- make_dataset_design("taylor", "survey_name")
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
 
   out <- capture_design_output(print(d))$cli
@@ -1066,7 +1022,6 @@ test_that("print.survey_taylor Dataset line falls back to survey_name", {
 
 test_that("print.survey_taylor Dataset line prefers data_name to survey_name", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
 
   out <- capture_design_output(print(d))$cli
@@ -1079,7 +1034,6 @@ test_that("print.survey_taylor Dataset line prefers data_name to survey_name", {
 test_that("print.survey_taylor omits the Dataset line when nothing is set", {
   d_none <- make_dataset_design("taylor", "none")
   d_named <- make_dataset_design("taylor", "data_name")
-  test_invariants(d_none)
   withr::local_options(list(width = 80L, cli.width = 80L))
 
   none_out <- capture_design_output(print(d_none))
@@ -1105,7 +1059,6 @@ test_that("print.survey_taylor omits the Dataset line when nothing is set", {
 
 test_that("print.survey_replicate shows a Dataset line above Sample size", {
   d <- make_dataset_design("replicate", "data_name")
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
 
   out <- capture_design_output(print(d))$cli
@@ -1118,7 +1071,6 @@ test_that("print.survey_replicate shows a Dataset line above Sample size", {
 
 test_that("print.survey_twophase shows Dataset above Phase 1 sample size", {
   d <- make_dataset_design("twophase", "data_name")
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
 
   out <- capture_design_output(print(d))$cli
@@ -1131,7 +1083,6 @@ test_that("print.survey_twophase shows Dataset above Phase 1 sample size", {
 
 test_that("print.survey_nonprob puts Dataset after the variance bullet", {
   d <- make_dataset_design("nonprob", "data_name")
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
 
   out <- capture_design_output(print(d))$cli
@@ -1146,7 +1097,6 @@ test_that("print.survey_nonprob puts Dataset after the variance bullet", {
 
 test_that("print.survey_nonprob repweights puts Dataset after class line", {
   d <- make_dataset_design("nonprob_rep", "data_name")
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
 
   out <- capture_design_output(print(d))$cli
@@ -1165,7 +1115,6 @@ test_that("print falls back to survey_name in every design class", {
 
   for (design in designs) {
     d <- make_dataset_design(design, "survey_name")
-    test_invariants(d)
     out <- capture_design_output(print(d))$cli
     expect_identical(
       out[grepl("^Dataset: ", out)],
@@ -1182,7 +1131,6 @@ test_that("print output is unchanged in every class when nothing is set", {
   for (design in designs) {
     d_none <- make_dataset_design(design, "none")
     d_named <- make_dataset_design(design, "data_name")
-    test_invariants(d_none)
 
     none_out <- capture_design_output(print(d_none))
     named_out <- capture_design_output(print(d_named))
@@ -1205,7 +1153,6 @@ test_that("print output is unchanged in every class when nothing is set", {
 
 test_that("metadata_info block shows Survey, Vendor and Field dates in order", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
 
   out <- capture_design_output(print(d, metadata_info = TRUE))$cli
@@ -1223,7 +1170,6 @@ test_that("metadata_info block shows Survey, Vendor and Field dates in order", {
 
 test_that("metadata_info block sits above the labeled-count line", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
 
   out <- capture_design_output(print(d, metadata_info = TRUE))$cli
@@ -1238,7 +1184,6 @@ test_that("metadata_info block sits above the labeled-count line", {
 
 test_that("metadata_info block omits Survey when only survey_name is set", {
   d <- make_dataset_design("taylor", "survey_name")
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
 
   out <- capture_design_output(print(d, metadata_info = TRUE))$cli
@@ -1266,7 +1211,6 @@ test_that("metadata_info block omits Survey when the two names are identical", {
 
 test_that("metadata_info block shows Survey when the two names differ", {
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
 
   out <- capture_design_output(print(d, metadata_info = TRUE))$cli
@@ -1282,7 +1226,6 @@ test_that("metadata_info block shows Survey when the two names differ", {
 
 test_that("metadata_info block shows a one-sided range for a start date", {
   d <- make_dataset_design("taylor", "partial")
-  test_invariants(d)
   withr::local_options(list(width = 80L, cli.width = 80L))
 
   out <- capture_design_output(print(d, metadata_info = TRUE))$cli
@@ -1356,7 +1299,6 @@ test_that("metadata_info section is unchanged when no dataset keys are set", {
   for (design in designs) {
     d_none <- make_dataset_design(design, "none")
     d_full <- make_dataset_design(design, "full")
-    test_invariants(d_none)
 
     none_out <- capture_design_output(print(d_none, metadata_info = TRUE))
     full_out <- capture_design_output(print(d_full, metadata_info = TRUE))
@@ -1380,7 +1322,6 @@ test_that("full = TRUE shows the header and the block in every design class", {
 
   for (design in designs) {
     d <- make_dataset_design(design, "full")
-    test_invariants(d)
     out <- capture_design_output(print(d, full = TRUE))$cli
 
     expect_identical(
@@ -1413,7 +1354,6 @@ test_that("full = TRUE matches metadata_info = TRUE for the dataset lines", {
 
   for (design in designs) {
     d <- make_dataset_design(design, "full")
-    test_invariants(d)
     full_out <- capture_design_output(print(d, full = TRUE))$cli
     meta_out <- capture_design_output(print(d, metadata_info = TRUE))$cli
     expect_identical(
@@ -1434,7 +1374,6 @@ test_that("full = TRUE leaves output unchanged when nothing is set", {
   for (design in designs) {
     d_none <- make_dataset_design(design, "none")
     d_full <- make_dataset_design(design, "full")
-    test_invariants(d_none)
 
     none_out <- capture_design_output(print(d_none, full = TRUE))
     full_out <- capture_design_output(print(d_full, full = TRUE))
@@ -1457,7 +1396,6 @@ test_that("a stale design prints and summarises with every argument set", {
 
   for (cls in c("taylor", "replicate", "twophase", "nonprob")) {
     d <- make_stale_metadata_design(cls)
-    test_invariants(d)
 
     # Four calls per class: the default, the two metadata-bearing argument
     # combinations, and summary(). All read through the guarded reader, so
@@ -1495,7 +1433,6 @@ test_that("a stale design prints the same lines as an empty current design", {
   # but different row counts, so compare the shape of the metadata section
   # rather than the whole output.
   stale <- make_stale_metadata_design("taylor")
-  test_invariants(stale)
   out <- capture_design_output(print(stale, metadata_info = TRUE, n = 3))$cli
   meta_idx <- grep("^-- Metadata", out)
   expect_length(meta_idx, 1L)
@@ -1671,7 +1608,6 @@ test_that("summary shows the Dataset line directly above the Metadata line", {
 
   for (design in designs) {
     d <- make_dataset_design(design, "data_name")
-    test_invariants(d)
     out <- capture_design_output(summary(d))$cli
 
     idx <- grep("^Dataset: ", out)
@@ -1693,7 +1629,6 @@ test_that("summary falls back to survey_name", {
 
   for (design in designs) {
     d <- make_dataset_design(design, "survey_name")
-    test_invariants(d)
     out <- capture_design_output(summary(d))$cli
     expect_identical(
       out[grepl("^Dataset: ", out)],
@@ -1710,7 +1645,6 @@ test_that("summary output is unchanged when no dataset metadata is set", {
   for (design in designs) {
     d_none <- make_dataset_design(design, "none")
     d_named <- make_dataset_design(design, "data_name")
-    test_invariants(d_none)
 
     none_out <- capture_design_output(summary(d_none))
     named_out <- capture_design_output(summary(d_named))
@@ -1729,7 +1663,6 @@ test_that("summary output is unchanged when no dataset metadata is set", {
 test_that("summary shows no Survey, Vendor or Field dates lines", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
 
   out <- capture_design_output(summary(d))$cli
   # Only the one name line belongs in a summary (spec section X.4).
@@ -1740,7 +1673,6 @@ test_that("summary shows no Survey, Vendor or Field dates lines", {
 test_that("summary(survey_taylor): Dataset line snapshot", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_dataset_design("taylor", "data_name")
-  test_invariants(d)
   expect_snapshot(summary(d))
 })
 
@@ -1750,7 +1682,6 @@ test_that("summary(survey_taylor): Dataset line snapshot", {
 test_that("print(survey_taylor, metadata_info = TRUE): all six keys snapshot", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_dataset_design("taylor", "full")
-  test_invariants(d)
   expect_snapshot(print(d, metadata_info = TRUE, n = 3))
 })
 
@@ -1764,35 +1695,30 @@ test_that("print(survey_taylor, metadata_info = TRUE): period-only snapshot", {
 test_that("print(survey_taylor): survey_name fallback header snapshot", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_dataset_design("taylor", "survey_name")
-  test_invariants(d)
   expect_snapshot(print(d, n = 3))
 })
 
 test_that("print(survey_replicate): Dataset header snapshot", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_dataset_design("replicate", "data_name")
-  test_invariants(d)
   expect_snapshot(print(d, n = 3))
 })
 
 test_that("print(survey_twophase): Dataset header snapshot", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_dataset_design("twophase", "data_name")
-  test_invariants(d)
   expect_snapshot(print(d, n = 3))
 })
 
 test_that("print(survey_nonprob): Dataset header snapshot", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_dataset_design("nonprob", "data_name")
-  test_invariants(d)
   expect_snapshot(print(d, n = 3))
 })
 
 test_that("print(survey_nonprob) with repweights: Dataset header snapshot", {
   withr::local_options(list(width = 80L, cli.width = 80L))
   d <- make_dataset_design("nonprob_rep", "data_name")
-  test_invariants(d)
   expect_snapshot(print(d, n = 3))
 })
 
@@ -1803,7 +1729,6 @@ test_that("metadata_info block renders in every design class", {
 
   for (design in designs) {
     d <- make_dataset_design(design, "full")
-    test_invariants(d)
     out <- capture_design_output(print(d, metadata_info = TRUE))$cli
     expect_true(
       any(out == "Survey: Antisemitic Attitudes in America 2026"),

--- a/tests/testthat/test-nonprob-bootstrap-variance.R
+++ b/tests/testthat/test-nonprob-bootstrap-variance.R
@@ -43,7 +43,6 @@ test_that(".degf() returns Inf for survey_nonprob WITH repweights", {
     weights = wt,
     repweights = starts_with("repwt_")
   )
-  test_invariants(d)
   expect_equal(.degf(d), Inf)
 })
 

--- a/tests/testthat/test-s7-classes.R
+++ b/tests/testthat/test-s7-classes.R
@@ -186,7 +186,6 @@ test_that("survey_taylor() creates valid object for stratified cluster design", 
       nest = TRUE
     )
   )
-  test_invariants(d)
   expect_true(S7::S7_inherits(d, survey_taylor))
   expect_identical(d@variables$ids, "psu")
   expect_identical(d@variables$strata, "strata")
@@ -209,7 +208,6 @@ test_that("survey_taylor() creates valid object for two-stage cluster design", {
       ids = c("psu", "ssu")
     )
   )
-  test_invariants(d)
   expect_identical(d@variables$ids, c("psu", "ssu"))
 })
 
@@ -222,7 +220,6 @@ test_that("survey_taylor() allows NA weights (non-NA must be positive)", {
     data = df,
     variables = .taylor_vars(weights = "wt")
   )
-  test_invariants(d)
   expect_true(is.na(d@data$wt[2]))
 })
 
@@ -382,7 +379,6 @@ test_that("survey_replicate() creates valid BRR design", {
       type = "BRR"
     )
   )
-  test_invariants(d)
   expect_true(S7::S7_inherits(d, survey_replicate))
   expect_identical(d@variables$weights, "wt")
   expect_identical(d@variables$repweights, paste0("rw", 1:4))
@@ -400,7 +396,6 @@ test_that("survey_replicate() creates valid JK1 design", {
       type = "JK1"
     )
   )
-  test_invariants(d)
   expect_identical(d@variables$type, "JK1")
 })
 
@@ -502,7 +497,6 @@ test_that("survey_twophase() creates valid object with minimal spec", {
       visible_vars = NULL
     )
   )
-  test_invariants(d)
   expect_true(S7::S7_inherits(d, survey_twophase))
   expect_identical(d@variables$subset, "ph2")
   expect_identical(d@variables$method, "full")
@@ -531,7 +525,6 @@ test_that("survey_twophase() creates valid object with phase2 strata col", {
       visible_vars = NULL
     )
   )
-  test_invariants(d)
   expect_identical(d@variables$phase2$strata, "ph2_str")
 })
 
@@ -799,7 +792,6 @@ test_that("survey_nonprob validator accepts zero weights with at least one posit
       visible_vars = NULL
     )
   )
-  test_invariants(obj)
   expect_s3_class(obj@data, "data.frame")
   expect_equal(sum(obj@data$w == 0), 3L)
 })
@@ -963,7 +955,6 @@ test_that("survey_taylor @calibration accepts a list", {
   design <- as_survey(df, ids = psu, weights = wt, strata = strata)
   cd <- as_caldata(df$wt, rep(1.05, nrow(df)), matrix(1, nrow(df), 1))
   design@calibration <- list(cd)
-  test_invariants(design)
   expect_type(design@calibration, "list")
   expect_length(design@calibration, 1L)
 })
@@ -993,7 +984,6 @@ test_that("survey_replicate has @calibration == NULL by default", {
     repweights = starts_with("repwt_"),
     type = "BRR"
   )
-  test_invariants(design)
   expect_null(design@calibration)
 })
 
@@ -1007,7 +997,6 @@ test_that("survey_replicate @calibration accepts a list", {
   )
   cd <- as_caldata(df$wt, rep(1.05, nrow(df)), matrix(1, nrow(df), 1))
   design@calibration <- list(cd)
-  test_invariants(design)
   expect_type(design@calibration, "list")
   expect_length(design@calibration, 1L)
 })
@@ -1081,7 +1070,6 @@ test_that("survey_metadata() keeps other properties intact alongside @dataset_me
 test_that("as_survey() designs start with an empty @dataset_metadata", {
   df <- make_survey_data(n = 60, n_psu = 12, n_strata = 3, seed = 11)
   design <- as_survey(df, ids = psu, weights = wt, strata = strata)
-  test_invariants(design)
   expect_identical(design@metadata@dataset_metadata, list())
 })
 
@@ -1412,7 +1400,6 @@ test_that("survey_metadata assignment round-trips a valid dataset metadata list"
 test_that("a design's @metadata re-validates @dataset_metadata on assignment", {
   df <- make_survey_data(n = 60, n_psu = 12, n_strata = 3, seed = 12)
   design <- as_survey(df, ids = psu, weights = wt, strata = strata)
-  test_invariants(design)
   expect_error(
     design@metadata@dataset_metadata <- list(vendor = NA_character_),
     class = "surveycore_error_dataset_metadata_bad_type"

--- a/tests/testthat/test-update-design.R
+++ b/tests/testthat/test-update-design.R
@@ -21,7 +21,6 @@ test_that("update_design() updates strata on survey_taylor", {
   df$st2 <- df$strata
   d <- as_survey(df, weights = wt, strata = strata)
   d2 <- suppressMessages(update_design(d, strata = st2))
-  test_invariants(d2)
   expect_identical(d2@variables$strata, "st2")
 })
 
@@ -31,7 +30,6 @@ test_that("update_design() updates multiple vars on survey_taylor", {
   df$st2 <- df$strata
   d <- as_survey(df, weights = wt, strata = strata)
   d2 <- suppressMessages(update_design(d, weights = wt2, strata = st2))
-  test_invariants(d2)
   expect_identical(d2@variables$weights, "wt2")
   expect_identical(d2@variables$strata, "st2")
 })
@@ -41,7 +39,6 @@ test_that("update_design() updates ids on survey_taylor", {
   df$psu2 <- paste0("new_", df$psu)
   d <- as_survey(df, ids = psu, weights = wt)
   d2 <- suppressMessages(update_design(d, ids = psu2))
-  test_invariants(d2)
   expect_identical(d2@variables$ids, "psu2")
 })
 
@@ -50,7 +47,6 @@ test_that("update_design() updates fpc on survey_taylor", {
   df$fpc2 <- df$fpc + 10L
   d <- as_survey(df, weights = wt, strata = strata, fpc = fpc)
   d2 <- suppressMessages(update_design(d, fpc = fpc2))
-  test_invariants(d2)
   expect_identical(d2@variables$fpc, "fpc2")
 })
 
@@ -95,7 +91,6 @@ test_that("update_design() updates repweights on survey_replicate", {
   d2 <- suppressMessages(
     update_design(d, repweights = c(repwt_1, repwt_2, repwt_3))
   )
-  test_invariants(d2)
   expect_identical(d2@variables$repweights, c("repwt_1", "repwt_2", "repwt_3"))
 })
 
@@ -196,7 +191,6 @@ test_that("update_design() no-op (all NULL) returns object unchanged", {
   df <- make_survey_data(n = 200L, seed = 50L)
   d <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc)
   d2 <- update_design(d)
-  test_invariants(d2)
   expect_identical(d2@variables$ids, d@variables$ids)
   expect_identical(d2@variables$weights, d@variables$weights)
   expect_identical(d2@variables$strata, d@variables$strata)
@@ -223,7 +217,6 @@ test_that("update_design() preserves unchanged design vars", {
   df$wt2 <- df$wt * 1.1
   d <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc)
   d2 <- suppressMessages(update_design(d, weights = wt2))
-  test_invariants(d2)
   # Only weights changed; ids, strata, fpc preserved
   expect_identical(d2@variables$weights, "wt2")
   expect_identical(d2@variables$ids, d@variables$ids)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -140,13 +140,11 @@ test_that("survey_data() returns @data as a data.frame for survey_taylor", {
 
 test_that("survey_data() returns @data for survey_replicate", {
   d <- make_rep()
-  test_invariants(d)
   expect_identical(survey_data(d), d@data)
 })
 
 test_that("survey_data() returns @data for survey_twophase", {
   d <- make_twophase()
-  test_invariants(d)
   expect_identical(survey_data(d), d@data)
 })
 
@@ -179,7 +177,6 @@ test_that("survey_data() rejects a list", {
 
 test_that(".get_design_vars_flat() returns all design var names for survey_taylor", {
   d <- make_taylor()
-  test_invariants(d)
   flat <- surveycore:::.get_design_vars_flat(d)
   expect_true(is.character(flat))
   expect_true("psu" %in% flat)
@@ -199,7 +196,6 @@ test_that(".get_design_vars_flat() returns unique names only", {
 
 test_that(".get_design_vars_flat() returns weights and repweights for survey_replicate", {
   d <- make_rep()
-  test_invariants(d)
   flat <- surveycore:::.get_design_vars_flat(d)
   expect_true("wt" %in% flat)
   repwt_cols <- grep("^repwt_", names(d@data), value = TRUE)
@@ -211,7 +207,6 @@ test_that(".get_design_vars_flat() returns weights and repweights for survey_rep
 
 test_that(".get_design_vars_flat() returns phase1, phase2, and subset vars for survey_twophase", {
   d <- make_twophase()
-  test_invariants(d)
   flat <- surveycore:::.get_design_vars_flat(d)
   expect_true("psu" %in% flat)
   expect_true("wt" %in% flat)
@@ -290,7 +285,6 @@ test_that(".get_design_vars_flat() excludes fpc for SRS-style design without fpc
 
 test_that(".get_design_vars() returns a named list for survey_taylor", {
   d <- make_taylor()
-  test_invariants(d)
   vars <- surveycore:::.get_design_vars(d)
   expect_true(is.list(vars))
   expect_true("ids" %in% names(vars))
@@ -302,7 +296,6 @@ test_that(".get_design_vars() returns a named list for survey_taylor", {
 test_that(".get_design_vars() omits NULL slots for SRS design (survey_taylor)", {
   df <- data.frame(y = 1:5, w = runif(5, 0.5, 2))
   d <- suppressWarnings(as_survey(df, weights = w))
-  test_invariants(d)
   vars <- surveycore:::.get_design_vars(d)
   # ids, strata, fpc are NULL — they should be absent
   expect_false("ids" %in% names(vars))
@@ -323,7 +316,6 @@ test_that(".get_design_vars() can be unlist()ed to a char vector", {
 
 test_that(".get_design_vars() returns weights and repweights for survey_replicate", {
   d <- make_rep()
-  test_invariants(d)
   vars <- surveycore:::.get_design_vars(d)
   expect_true("weights" %in% names(vars))
   expect_true("repweights" %in% names(vars))
@@ -336,7 +328,6 @@ test_that(".get_design_vars() returns weights and repweights for survey_replicat
 
 test_that(".get_design_vars() returns phase1 vars and subset for survey_twophase", {
   d <- make_twophase()
-  test_invariants(d)
   vars <- surveycore:::.get_design_vars(d)
   expect_true("ids" %in% names(vars))
   expect_true("weights" %in% names(vars))

--- a/tests/testthat/test-variance-taylor.R
+++ b/tests/testthat/test-variance-taylor.R
@@ -710,7 +710,6 @@ test_that(
       strata = sdmvstra,
       nest = TRUE
     )
-    test_invariants(sc)
     sv <- survey::svydesign(
       id = ~sdmvpsu,
       weights = ~wtmec2yr,
@@ -747,7 +746,6 @@ test_that(
       strata = strata,
       fpc = fpc
     )
-    test_invariants(sc)
     inp <- surveycore:::.taylor_build_inputs(sc, "y1")
     expect_identical(ncol(inp$clusters), 1L)
     expect_identical(ncol(inp$stratas), 1L)
@@ -773,7 +771,6 @@ test_that(
       weights = wt,
       strata = strata
     )
-    test_invariants(sc)
     inp <- surveycore:::.taylor_build_inputs(sc, "y1")
     expect_identical(ncol(inp$clusters), 2L)
     expect_identical(ncol(inp$stratas), 2L)
@@ -842,7 +839,6 @@ test_that(
       weights = wt,
       strata = strata
     )
-    test_invariants(sc)
     sv <- survey::svydesign(
       id = ~ psu + ssu,
       strata = ~strata,
@@ -883,7 +879,6 @@ test_that(
       weights = wt,
       strata = strata
     )
-    test_invariants(sc)
     sv <- survey::svydesign(
       id = ~ psu + ssu,
       strata = ~strata,
@@ -974,7 +969,6 @@ test_that(
       ),
       class = "surveycore_warning_fpc_partial_stages"
     )
-    test_invariants(sc)
     # survey pkg needs one FPC column per stage; use Inf for
     # stages without FPC (= infinite population, no correction)
     df$fpc2_inf <- Inf
@@ -1021,7 +1015,6 @@ test_that(
       strata = strata,
       fpc = c(fpc, fpc2)
     )
-    test_invariants(sc)
     sv <- survey::svydesign(
       id = ~ psu + ssu,
       weights = ~wt,
@@ -1066,7 +1059,6 @@ test_that(
       weights = wt,
       strata = strata
     )
-    test_invariants(sc)
     sv <- survey::svydesign(
       id = ~ psu + ssu,
       weights = ~wt,
@@ -1105,7 +1097,6 @@ test_that(
       weights = wt,
       strata = strata
     )
-    test_invariants(sc)
     sv <- survey::svydesign(
       id = ~ psu + ssu,
       weights = ~wt,
@@ -1147,7 +1138,6 @@ test_that(
       weights = wt,
       strata = strata
     )
-    test_invariants(sc)
     sv <- survey::svydesign(
       id = ~ psu + ssu,
       weights = ~wt,
@@ -1185,7 +1175,6 @@ test_that(
       weights = wt,
       strata = strata
     )
-    test_invariants(sc)
     sv <- survey::svydesign(
       id = ~ psu + ssu,
       weights = ~wt,
@@ -1229,7 +1218,6 @@ test_that(
       weights = wt,
       strata = strata
     )
-    test_invariants(sc)
     sv <- survey::svydesign(
       id = ~ psu + ssu,
       weights = ~wt,
@@ -1277,7 +1265,6 @@ test_that(
       weights = wt,
       strata = strata
     )
-    test_invariants(sc)
     sv <- survey::svydesign(
       id = ~ psu + ssu + unit,
       weights = ~wt,
@@ -1324,7 +1311,6 @@ test_that(
       ),
       class = "surveycore_warning_fpc_partial_stages"
     )
-    test_invariants(sc)
     # survey pkg needs one FPC column per stage; use Inf for
     # stages without FPC (= infinite population, no correction)
     df$fpc2_inf <- Inf
@@ -1373,7 +1359,6 @@ test_that(
       strata = strata,
       fpc = c(fpc, fpc2, fpc3)
     )
-    test_invariants(sc)
     sv <- survey::svydesign(
       id = ~ psu + ssu + unit,
       weights = ~wt,
@@ -1424,7 +1409,6 @@ test_that(
       strata = strata,
       nest = TRUE
     )
-    test_invariants(sc)
     sv <- survey::svydesign(
       id = ~ psu + ssu,
       weights = ~wt,
@@ -1471,7 +1455,6 @@ test_that(
       strata = strata,
       nest = TRUE
     )
-    test_invariants(sc)
     sv <- survey::svydesign(
       id = ~ psu + ssu,
       weights = ~wt,
@@ -1516,7 +1499,6 @@ test_that(
       weights = wt,
       strata = strata
     )
-    test_invariants(sc)
     sv <- survey::svydesign(
       id = ~ psu + ssu,
       weights = ~wt,
@@ -1564,7 +1546,6 @@ test_that(
       weights = wt,
       strata = strata
     )
-    test_invariants(sc)
     sc_dom <- surveytidy::filter(sc, domain == 1L)
     sv <- survey::svydesign(
       id = ~ psu + ssu,
@@ -1618,7 +1599,6 @@ test_that(
       weights = wt,
       strata = strata
     )
-    test_invariants(sc)
     sc_dom <- surveytidy::filter(sc, domain == 1L)
     sv <- survey::svydesign(
       id = ~ psu + ssu,
@@ -1670,7 +1650,6 @@ test_that(
       weights = wt,
       strata = strata
     )
-    test_invariants(sc)
     sv <- survey::svydesign(
       id = ~ psu + ssu,
       weights = ~wt,
@@ -1719,7 +1698,6 @@ test_that(
       strata = strata,
       fpc = fpc
     )
-    test_invariants(sc)
     sv <- survey::svydesign(
       id = ~psu,
       weights = ~wt,


### PR DESCRIPTION
Acts on step 1 of #169 and closes #161.

## What changed

**Phase 1 — narrow `test_invariants()`.** 528 repeated calls removed across
16 test files. Each file keeps the call in the first block that builds with
a given constructor. The diff is line deletions only: 528 removed, 0 added.
`helper-test-data.R`, `test-invariants.R`, and all of `R/` are untouched.

**The rule that produced them.** `.claude/rules/testing-surveycore.md` now
says once per constructor per file. Left unchanged, the calls grow back.

**Phase 0 — snapshot line endings** (`513f5b7`, already on the branch).
`.gitattributes` pins `tests/testthat/_snaps/*.md` to LF. A full test run on
this branch now leaves `git status` empty; before it listed 38 files.

## Measured

Every figure below comes from a run on this branch, not from the plan.

| Measure | Before | After |
|---|---|---|
| Passing expectations | 19,314 | **9,847** |
| Package line coverage | 96.0938% | **96.0938%** |
| FAIL | 0 | **0** |
| SKIP | 4 | **4** |
| Sum of test time | 806.3 s | 878.8 s |

Coverage is identical to four decimal places. SKIP held at 4, so no block
lost its last expectation.

**Runtime is unchanged, and that is the correct result.** Phase 1 buys
legibility, not speed. Bloat and wall-time live in different files: the two
polychoric files take 42% of all test time while holding 1.1% of the
expectations. Speed is #177's job.

## One correction to the plan

The plan's Task 6 said a plain `devtools::test()` skips the 11
`skip_on_cran()` files and halves the run. It does not.
`devtools::test()` calls `withr::local_envvar(devtools:::r_env_vars())`, and
that list sets `NOT_CRAN = "true"` unconditionally, so the shell variable
never reaches the tests. Measured:

| Command | Expectations | SKIP | Time |
|---|---|---|---|
| `NOT_CRAN=true devtools::test()` | 9,847 | 4 | 879 s |
| plain `devtools::test()` | 9,847 | 4 | 756 s |
| `NOT_CRAN=false testthat::test_local()` | 8,841 | 500 | **384 s** |

The 2x lever is real, but it runs through `testthat::test_local()`, which
does not set the variable. The documented section says so. `covr` does not
set it either, which is why a coverage run still needs it (#159).

## Not done here

- Task 4 already ran; its result is #177.
- Task 5 is left alone — it saves about 33 s and may be moot once #177 lands.
- #169 stays open for its step 2.

## Note for review

`air format .` is not run in this PR. The repo is not currently air-clean:
formatting only the 16 touched files still produces 129 lines of change
unrelated to these deletions. Per `code-style.md`, reformat-only commits stay
separate from functional ones. Removing whole lines from conforming code
introduces no style violation.

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)
