### PR TITLE
docs(testing): measure the both-modes rule and write it down (#169)

### DIFF
--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -77,7 +77,8 @@ Follow `artifact-schemas.md` §test-spec.md exactly. Key rules:
 - Tolerances default to point 1e-10, SE 1e-8, CI 1e-6 per `rules/testing-surveycore.md`. Deviations require written justification.
 - Every named error class from spec gets an `expect_error(class = ...)` test AND a snapshot test (dual pattern — `rules/testing-standards.md` §3).
 - Every edge case from spec gets a test.
-- `test_invariants(design)` is the first assertion of every test that constructs a survey object.
+- `test_invariants(design)` runs once per constructor per test FILE, in the first block that builds with it — not in every constructing block (`rules/testing-surveycore.md`).
+- A row runs in both input modes only when the mode changes what it asserts (`rules/testing-surveycore.md` §both-modes rule).
 - Profile gates list (document, test, run_examples, R CMD check --as-cran, pkgdown, covr) is always included verbatim.
 
 Test-spec is for tester. Do not write about what the code looks like.

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -71,7 +71,7 @@ For each function in `test-spec.md §Per-function test plan`:
 - Run each happy path test with the specified oracle (usually `survey` package). Compare estimate, SE, CI against the tolerance.
 - Run each error path test. Verify the correct `class = ...` is thrown AND the snapshot matches.
 - Run each edge case test.
-- Verify `test_invariants(design)` is the first assertion where applicable.
+- Verify `test_invariants(design)` runs once per constructor per test file, not in every constructing block.
 
 Record one row per scenario in the Per-Test Result Table in `audit.md`:
 

--- a/.claude/references/testing-detail.md
+++ b/.claude/references/testing-detail.md
@@ -211,16 +211,30 @@ test_that("Taylor variance matches survey::svymean for NHANES [numerical]", {
 })
 ```
 
-Constructor test with invariants first:
+Constructor test — the invariants call goes in the FILE's first block that
+builds with that constructor, and nowhere else in the file:
 
 ```r
+# First block in the file that calls as_survey() — carries the invariants.
 test_that("as_survey() creates a survey_taylor object for stratified design", {
   d <- as_survey(nhanes_2017, ids = sdmvpsu, weights = wtmec2yr, strata = sdmvstra)
-  test_invariants(d)   # always first
+  test_invariants(d)   # once per constructor per FILE, not per block
   expect_true(S7::inherits(d, survey_taylor))
   expect_equal(d@variables$strata, "sdmvstra")
 })
+
+# Every later as_survey() block in the same file omits it.
+test_that("as_survey() records the strata column it was given", {
+  d <- as_survey(nhanes_2017, ids = sdmvpsu, weights = wtmec2yr, strata = sdmvstra)
+  expect_identical(d@variables$strata, "sdmvstra")
+})
 ```
+
+A file that also builds with `as_survey_rep()` carries one more call, in its
+first replicate block. The S7 validators in `R/core-classes.R` enforce the
+same invariants on construction and on every property assignment, so the
+repeat calls bought no coverage — measured at 0.0000 points across all 46
+files in `R/` (issue #169).
 
 ---
 

--- a/.claude/rules/testing-surveycore.md
+++ b/.claude/rules/testing-surveycore.md
@@ -1,6 +1,6 @@
 # surveycore Testing: Package-Specific Standards
 
-**Version:** 1.1
+**Version:** 1.2
 **Status:** Decided — extends `testing-standards.md`; read that first. This
 file covers only what is specific to surveycore.
 
@@ -9,6 +9,7 @@ file covers only what is specific to surveycore.
 | Decision | Choice |
 |----------|--------|
 | Invariant checks | `test_invariants(design)` once per constructor per test FILE — not per block |
+| Both input modes | A behavioural row runs in both modes only when the mode changes what it asserts |
 | Layer 1 errors (S7 validators) | `class=` only — no snapshot |
 | Layer 3 errors (constructors) | Dual: `expect_error(class=)` + `expect_snapshot(error=TRUE)` |
 | Variance numerical tolerance | Point: 1e-10, SE/variance: 1e-8, CI bounds: 1e-6 |
@@ -84,6 +85,78 @@ invariants:
 3. All `@variables` keys are present (never absent, may be `NULL`)
 4. Named design columns exist in `@data`
 5. `@metadata` is a `survey_metadata` object
+
+## The both-modes rule — run the second mode when it changes the answer
+
+Some surveycore functions take either a survey design object or a plain data
+frame. `extract_dataset_metadata()`, `set_dataset_metadata()` and the ten
+dataset-metadata wrappers are the whole current set.
+
+Write the second mode when the mode changes what the row asserts. Skip it
+when the row's answer is fixed before the function looks at `x`.
+
+Run the row in **both** modes when it asserts:
+
+- a value read back out of storage — a survey object keeps dataset metadata
+  in `@metadata@dataset_metadata`, a data frame keeps it in one whole-object
+  attribute per key, so a round trip is a different act in each mode;
+- a state left behind after the call, including "the call wrote nothing";
+- anything that depends on state already stored, such as the field-date pair
+  check against a stored `field_end`;
+- behaviour that exists in one mode only — the legacy `dates` attribute, the
+  frame reader's silent drops, promotion at construction.
+
+Run the row in **one** mode when the function raises before it reads `x`.
+Every argument check in `extract_dataset_metadata()` fires before
+`.get_dataset_metadata_list(x)`, and every rule 1–11 check in
+`set_dataset_metadata()` fires before the same call. A frame variant of such
+a row runs the identical lines with the identical arguments and cannot
+disagree with the survey variant.
+
+Keep the second mode where it already exists. This rule sets the bar for new
+test rows; it is not a reason to delete passing tests. The measurement below
+says the whole rule is too cheap to be worth that churn.
+
+### Measured rationale (issue #169, step 2)
+
+The rule was never written down repo-wide. It appeared in exactly one
+test-spec — `archive/dataset-level-metadata/` §3 "Mode default" — and the
+tests it produced sit almost entirely in one file.
+
+Issue #169 called it "the other 2x multiplier". It is not one:
+
+| Measure | Count |
+|---|---|
+| Mode-variant blocks in `test-dataset-metadata.R` | 102 |
+| Expectations they carry | 132 |
+| Share of the 9,847-expectation suite | 1.3% |
+| Mode-variant blocks in every other test file | 0 |
+
+Deleting all 102 and re-measuring:
+
+| Run | R/ expressions reached | Package coverage |
+|---|---|---|
+| Baseline | 698 | 96.0938% |
+| All 102 mode variants deleted | 698 | 96.0938% |
+
+Identical expression sets, not just identical totals. Two instruments agree:
+`covr::package_coverage(type = "none")` scoped to that one test file, so no
+other file could mask a loss, and a full `covr::package_coverage()` run,
+which held every one of the 46 per-file figures unchanged. The frame branches
+stay covered because the frame-only rows keep reaching them.
+
+`test-metadata-system.R` already works this way. It gives each of the twelve
+variable-level metadata functions one data-frame block — the read path, the
+write path — and runs everything else once. That file is the house norm; the
+one that fans out every row is the exception.
+
+Line coverage proves the second mode reaches no new code. It does not prove
+it could never catch a regression, and the property that makes it redundant —
+every abort preceding the mode branch — is a fact about today's source that
+nothing enforces. At 1.3% of the suite the guard is worth more than the
+saving, so the rows stay.
+
+Measured 2026-08-27 on `develop` at `e7493f0`.
 
 ## S7 error testing layers
 

--- a/.claude/rules/testing-surveycore.md
+++ b/.claude/rules/testing-surveycore.md
@@ -212,7 +212,7 @@ Packages requiring `skip_if_not_installed()`:
 - `haven` — metadata roundtrip tests (prefer `with_labels = TRUE` when possible)
 
 ---
-Worked examples (invariants-first test, layer examples, numerical
+Worked examples (where the invariants call goes, layer examples, numerical
 comparison, test-file section templates):
 `.claude/references/testing-detail.md`. Read it when writing a new
 surveycore test file.

--- a/.claude/skills/auto-ship/references/section-subagent.md
+++ b/.claude/skills/auto-ship/references/section-subagent.md
@@ -108,8 +108,8 @@ re-run `devtools::test()` + `devtools::check()`.
 - [ ] No `UseMethod()` on S7 objects — uses `S7::S7_inherits()` instead
 - [ ] `class=` on every `cli_abort()` and `cli_warn()` call
 - [ ] No `@importFrom` anywhere — all external calls use `::`
-- [ ] `test_invariants(design)` is the first assertion in every constructor
-      test block
+- [ ] `test_invariants(design)` called once per constructor per test FILE,
+      not in every constructing block
 - [ ] Dual pattern (`class=` + snapshot) on all Layer 3 errors
 
 ---

--- a/.claude/skills/implementation-workflow/references/stage-2-review.md
+++ b/.claude/skills/implementation-workflow/references/stage-2-review.md
@@ -69,7 +69,7 @@ For every PR:
   - Changelog entry written and committed on this branch
 - Are function-specific criteria present and complete?
   (e.g., for constructors: all three design types tested, `test_invariants()`
-  as first assertion; for analysis functions: oracle values verified)
+  once per constructor per file; for analysis functions: oracle values verified)
 - Is the 98%+ line coverage requirement stated?
 - Is `plans/error-messages.md` update listed as a criterion where new error
   classes are introduced?

--- a/.claude/skills/pipeline-shared/references/artifact-schemas.md
+++ b/.claude/skills/pipeline-shared/references/artifact-schemas.md
@@ -108,7 +108,8 @@ No test cases. No tolerances. No references to test-spec.md.
 - **Happy path**: {scenario, dataset, oracle call, tolerance}
 - **Error paths**: one row per named error class
 - **Edge cases**: one row per edge case from spec
-- **Invariants**: `test_invariants(design)` first assertion
+- **Invariants**: `test_invariants(design)` once per constructor per file
+- **Input modes**: name a mode per row only where the mode changes the answer
 
 ## Tolerances
 - Point estimates: 1e-10

--- a/.claude/skills/r-implement/SKILL.md
+++ b/.claude/skills/r-implement/SKILL.md
@@ -146,7 +146,7 @@ checks before marking it `[x]`:
 - No `UseMethod()` on S7 objects? No S7 class string comparisons?
 - `class=` on every `cli_abort()` and `cli_warn()`?
 - No `@importFrom` anywhere; all external calls use `::`?
-- `test_invariants(design)` first assertion in every constructor test block?
+- `test_invariants(design)` called once per constructor per test file, not per block?
 - Dual pattern (snapshot + `class=`) on all Layer 3 errors?
 
 If either check reveals a gap, fix it before moving to the next sub-task.

--- a/.claude/skills/r-implement/references/mode-c-subagent.md
+++ b/.claude/skills/r-implement/references/mode-c-subagent.md
@@ -82,7 +82,7 @@ After spec compliance is PASS, dispatch a code quality reviewer:
 > (1) no `UseMethod()` on S7 objects — uses `S7::S7_inherits()` instead,
 > (2) `class=` on every `cli_abort()` and `cli_warn()` call,
 > (3) no `@importFrom` — all external calls use `::`,
-> (4) `test_invariants(design)` is first assertion in every constructor test block,
+> (4) `test_invariants(design)` called once per constructor per test FILE, not per block,
 > (5) dual pattern (class= + snapshot) on all Layer 3 errors.
 > Report PASS or list violations."
 

--- a/.claude/skills/spec-reviewer/SKILL.md
+++ b/.claude/skills/spec-reviewer/SKILL.md
@@ -71,8 +71,8 @@ for each of these categories:
     is that tested?
 
 Also check the mechanic rules:
-- Is `test_invariants()` specified as the first assertion in every
-  constructor test block?
+- Is `test_invariants()` specified once per constructor per test file,
+  rather than in every constructing block?
 - Is the dual pattern (class= + snapshot) specified for all Layer 3 errors?
 - Is `class=` required on every error class in the spec?
 

--- a/.claude/skills/spec-workflow/references/stage-1-draft.md
+++ b/.claude/skills/spec-workflow/references/stage-1-draft.md
@@ -126,8 +126,11 @@ Required sections:
   `expect_snapshot(error = TRUE)` (dual pattern from `testing-surveycore.md §Layer 3`)
 - S7 validator errors (Layer 1) get `expect_error(class = ...)` ONLY — no snapshot
 - Every edge case in the spec gets a test row
-- `test_invariants(obj)` is the first assertion for every test that constructs
-  a `survey_taylor`, `survey_replicate`, or `survey_twophase` object
+- `test_invariants(obj)` runs once per constructor per test FILE — in the
+  first block that builds with `as_survey()`, `as_survey_rep()`,
+  `as_survey_twophase()` or `as_survey_nonprob()`, not in every such block
+- A row runs in both input modes only where the mode changes what it asserts
+  (`rules/testing-surveycore.md` §both-modes rule)
 - Every numerical oracle test cites the oracle function (e.g., `survey::svymean`)
   and states the tolerance
 - If `comprehension.md` exists: every gotcha listed there gets a test row or

--- a/.claude/skills/spec-workflow/references/stage-3-review.md
+++ b/.claude/skills/spec-workflow/references/stage-3-review.md
@@ -89,7 +89,8 @@ why it's N/A, it probably applies.
 
 Also check mechanic rules:
 
-- `test_invariants()` specified as first assertion in every constructor test block?
+- `test_invariants()` specified once per constructor per test file, not per block?
+- Second input mode specified only where the mode changes what the row asserts?
 - Dual pattern (class= + snapshot) specified for all Layer 3 (constructor) errors?
 - `class=` only for Layer 1 (S7 validator) errors — no snapshot?
 - `class=` required on every error and warning in the spec?

--- a/plans/implementation-plan-test-suite-simplification.md
+++ b/plans/implementation-plan-test-suite-simplification.md
@@ -854,12 +854,14 @@ So the speed ranking is:
 Issue #169 lists four investigation steps. This plan acts on step 1 and
 leaves two others alone, on purpose:
 
-- **The both-modes rule (issue step 2) - not measured yet.** Test-spec
-  conventions run most behavioural rows in both survey-object and data-frame
-  mode, a 2x multiplier. Whether the two modes share a code path after
-  argument resolution has not been tested. It needs its own stub-and-measure
-  experiment, exactly like the one run for `test_invariants()`. Do not trim
-  it on suspicion.
+- **The both-modes rule (issue step 2) - measured, and it stays.** The rule
+  turned out to be unwritten repo-wide: it lived in one test-spec,
+  `archive/dataset-level-metadata/` §3, and its tests sit almost entirely in
+  `test-dataset-metadata.R`. It is not a 2x multiplier - 102 mode-variant
+  blocks carry 132 expectations, 1.3% of the suite. Deleting all 102 left the
+  set of reached `R/` expressions identical and package coverage at 96.0938%.
+  At that price the rows are worth keeping, so the rule is now written down
+  in `.claude/rules/testing-surveycore.md` with the bar it sets for new rows.
 - **The dual pattern (issue step 3) - leave it.** `expect_error(class = )`
   and `expect_snapshot(error = TRUE)` test different things: the condition
   class and the rendered message. Message regressions have been caught by


### PR DESCRIPTION
Issue #169 step 2. Runs the same stub-and-measure experiment that settled
step 1 in #178, on the both-modes rule.

Result: the rule is not a 2x multiplier, and it was never written down.
The rows stay; the rule gets documented instead.

## 1. Where the rule lives

#169 attributes it to "test-spec conventions" but gives no path. A grep of
`.claude/` for "both modes", "input mode" and every near variant finds
nothing. It is unwritten convention, not a documented rule.

It appears in exactly one place in the repo:
`archive/dataset-level-metadata/test-spec-dataset-level-metadata.md` §3,
under "Mode default" — a per-feature convention in one shipped test-spec.

That changes the fix. There was no repo-wide rule to amend, and no rule
telling the next feature to repeat the pattern.

## 2. What the second mode costs

| Measure | Count |
|---|---|
| Mode-variant blocks in `test-dataset-metadata.R` | 102 |
| Expectations they carry | 132 |
| Share of the 9,847-expectation suite | 1.3% |
| Mode-variant blocks in every other test file | 0 |

The 4,254 expectations #169 attributes to `test-dataset-metadata.R` were
almost entirely `test_invariants()`, not the both-modes rule — and none of
them sat inside a mode-variant block, because a frame-mode block builds a
data frame and never calls the helper. PR #178 already collected that
saving: the file now runs **692** expectations.

`test-metadata-system.R` is the counter-example that proves the rule never
spread. It gives each of the twelve variable-level metadata functions one
data-frame block and runs everything else once.

## 3. Stub and re-measure

Deleted all 102 mode-variant blocks and measured on two instruments.

| Run | R/ expressions reached | Package coverage |
|---|---|---|
| Baseline | 698 | 96.0938% |
| All 102 deleted | 698 | 96.0938% |

The first is `covr::package_coverage(type = "none")` scoped to that one
test file — the sharper instrument, because no other test file can mask a
loss. The **expression sets are identical, not merely equal in size**: zero
expressions reached only by the deleted blocks, zero gained.

The second is a full `covr::package_coverage()` run per arm. Both read
96.0938%, and all 46 per-file figures matched exactly.

## 4. Why the two modes share a path

`R/core-metadata.R` makes the reason plain. The extractor's mode divergence
is one four-line dispatcher:

```r
.get_dataset_metadata_list <- function(x) {
  if (S7::S7_inherits(x, survey_base)) {
    return(.dataset_metadata_or_empty(x@metadata))
  }
  .read_dataset_attributes(x)$values
}
```

Every argument check in `extract_dataset_metadata()` fires before that
call, and every rule 1–11 check in `set_dataset_metadata()` fires before
it too. The setter's own comment says so: "The effective key-value list of
`x`, read the same way in both input modes." The frame branches stay
covered because the frame-only rows — the frame reader, the legacy `dates`
attribute, promotion at construction — keep reaching them.

## 5. Decision: keep the tests, write the rule down

Line coverage proves the second mode reaches no new code. It does not
prove it could never catch a regression, and the property that makes it
redundant — every abort preceding the mode branch — is a fact about
today's source that nothing enforces. At 1.3% of the suite the guard costs
less than the churn of removing it.

So this PR ships documentation, not deletions:

- **`.claude/rules/testing-surveycore.md`** (1.1 → 1.2) gains a both-modes
  section: the bar for new test rows, the four cases that genuinely need
  both modes, and the measurement above.
- **Five agent-facing docs** still told the planner and the tester to put
  `test_invariants(design)` first in EVERY constructing block — the rule
  #178 removed. Left alone, the next feature PR would put the 528 deleted
  calls straight back. `planner.md`, `tester.md`, `r-implement/SKILL.md`,
  `spec-reviewer/SKILL.md` and `artifact-schemas.md` now state the
  per-file rule; the planner and the schema also carry the mode rule.
- **The implementation plan** records step 2 as measured and settled.

## Scope

No file under `R/`, `tests/`, `man/`, `NAMESPACE` or `DESCRIPTION`
changes. Verified with `git diff --stat origin/develop -- R/ tests/ man/`.

## Gates

| Gate | Baseline | This branch |
|---|---|---|
| `devtools::test()` | FAIL 0, SKIP 4, PASS 9,847 | FAIL 0, SKIP 4, PASS 9,847 |
| `covr::package_coverage()` with `NOT_CRAN=true` | 96.0938% | 96.0938% |

No tolerance was loosened. Nothing was skipped to make a gate pass.

Refs #169. Note that "Closes" does not auto-close against `develop`;
#169 is closed by hand once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
