### PR TITLE
perf(analysis): vectorise the polychoric CDF grid and cut influence-refit overhead

### DIFF
--- a/R/analysis-corr-latent.R
+++ b/R/analysis-corr-latent.R
@@ -8,14 +8,19 @@
 #   .corr_canonicalize_polyserial()  — assign ordinal/continuous roles
 #   .corr_estimate_thresholds()      — weighted marginal threshold estimation
 #   .corr_weighted_standardize()     — weighted standardization (Cox 1974)
-#   .corr_bivnorm_cdf()              — bivariate-normal CDF wrapper
+#   .corr_bivnorm_cdf_grid()         — vectorised bivariate-normal CDF grid
+#   .corr_cell_prob_matrix()         — polychoric cell-probability matrix
 #   .corr_polychoric_loglik()        — weighted log-likelihood (polychoric)
 #   .corr_polyserial_loglik()        — weighted log-likelihood (polyserial)
 #   .corr_count_sparse_cells()       — detect sparse ordinal cells
+#   .corr_polychoric_fit_core()      — shared MLE core (full fit + delta refit)
 #   .corr_polychoric_mle()           — MLE for polychoric rho
 #   .corr_polyserial_mle()           — MLE for polyserial rho
 #   .corr_detect_boundary_rho()      — detect boundary rho values
 #   .corr_fisher_ci()                — Fisher-z CI construction
+#   .corr_polychoric_influence_setup() — delta-refit setup for influence loop
+#   .corr_polychoric_delta_refit()   — O(1) delta refit for one perturbed row
+#   .corr_influence_pc6_abort()      — shared PC-6 rethrow for influence refits
 #   .corr_numerical_influence()      — perturbation-based influence function
 #   .corr_taylor_variance_latent()   — Taylor variance for latent methods
 #   .corr_replicate_variance_latent() — replicate variance for latent methods
@@ -329,36 +334,100 @@
 }
 
 
-# ── .corr_bivnorm_cdf() ──────────────────────────────────────────────────────
+# ── .corr_bivnorm_cdf_grid() ─────────────────────────────────────────────────
 #
-# Thin wrapper over pbivnorm::pbivnorm with Inf-handling conventions:
-#   Φ_2(+∞, b; ρ) = Φ(b)
-#   Φ_2(a, +∞; ρ) = Φ(a)
-#   Φ_2(a, -∞; ρ) = 0
-#   Φ_2(-∞, b; ρ) = 0
-# pbivnorm itself does not accept infinite arguments.
-.corr_bivnorm_cdf <- function(a, b, rho) {
-  # NA / NaN arguments propagate as NA (pbivnorm does not accept them).
-  if (is.na(a) || is.na(b) || is.na(rho)) {
-    return(NA_real_)
+# Vectorised bivariate-normal CDF over a full grid of thresholds, at a single
+# rho. One call replaces the four scalar `.corr_bivnorm_cdf()` calls per cell
+# that both `.corr_polychoric_loglik()` and `.corr_count_sparse_cells()` used
+# to make: the (k_x + 1) x (k_y + 1) grid holds every distinct corner, and
+# neighbouring cells share corners instead of recomputing them.
+#
+# Inf-handling conventions (checked in this precedence order — NA beats
+# -Inf, so a pair of -Inf and NA gives NA, not 0):
+#   1. NA / NaN in a, b, or rho -> NA
+#   2. a == -Inf or b == -Inf   -> 0
+#   3. a == +Inf and b == +Inf  -> 1
+#   4. a == +Inf                -> Φ(b)
+#   5. b == +Inf                -> Φ(a)
+#   6. otherwise                -> one pbivnorm::pbivnorm() call
+# pbivnorm itself does not accept infinite or NA arguments.
+#
+# Arguments:
+#   tx_full — length (k_x + 1) numeric vector of x thresholds, including the
+#             -Inf / +Inf sentinels.
+#   ty_full — length (k_y + 1) numeric vector of y thresholds, including the
+#             -Inf / +Inf sentinels.
+#   rho     — scalar correlation.
+#
+# Returns: (k_x + 1) x (k_y + 1) numeric matrix, grid[i, j] = Φ2(tx_full[i],
+# ty_full[j]; rho).
+.corr_bivnorm_cdf_grid <- function(tx_full, ty_full, rho) {
+  n_a <- length(tx_full)
+  n_b <- length(ty_full)
+  a_mat <- matrix(tx_full, nrow = n_a, ncol = n_b)
+  b_mat <- matrix(ty_full, nrow = n_a, ncol = n_b, byrow = TRUE)
+
+  out <- matrix(NA_real_, nrow = n_a, ncol = n_b)
+
+  # Rule 1: NA / NaN in a, b, or rho -> NA (the default `out` value already).
+  assigned <- is.na(a_mat) | is.na(b_mat) | is.na(rho)
+
+  # Rule 2: -Inf on either side -> 0. `!assigned` filters out any position
+  # already resolved by rule 1; NA & FALSE evaluates to FALSE in R, so a
+  # comparison against an NA-holding cell never overrides its rule-1 result.
+  mask <- !assigned & (a_mat == -Inf | b_mat == -Inf)
+  out[mask] <- 0
+  assigned <- assigned | mask
+
+  # Rule 3: both sides +Inf -> 1.
+  mask <- !assigned & (a_mat == Inf & b_mat == Inf)
+  out[mask] <- 1
+  assigned <- assigned | mask
+
+  # Rule 4: a == +Inf -> Φ(b).
+  mask <- !assigned & (a_mat == Inf)
+  out[mask] <- stats::pnorm(b_mat[mask])
+  assigned <- assigned | mask
+
+  # Rule 5: b == +Inf -> Φ(a).
+  mask <- !assigned & (b_mat == Inf)
+  out[mask] <- stats::pnorm(a_mat[mask])
+  assigned <- assigned | mask
+
+  # Rule 6: everything remaining is finite. One vectorised pbivnorm() call.
+  remaining <- !assigned
+  if (any(remaining)) {
+    out[remaining] <- pbivnorm::pbivnorm(
+      a_mat[remaining],
+      b_mat[remaining],
+      rho = rho
+    )
   }
-  # Handle -Inf first (dominates).
-  if (is.infinite(a) && a < 0) {
-    return(0)
-  }
-  if (is.infinite(b) && b < 0) {
-    return(0)
-  }
-  if (is.infinite(a) && a > 0 && is.infinite(b) && b > 0) {
-    return(1)
-  }
-  if (is.infinite(a) && a > 0) {
-    return(stats::pnorm(b))
-  }
-  if (is.infinite(b) && b > 0) {
-    return(stats::pnorm(a))
-  }
-  pbivnorm::pbivnorm(a, b, rho = rho)
+
+  out
+}
+
+
+# ── .corr_cell_prob_matrix() ─────────────────────────────────────────────────
+#
+# Forms the k_x x k_y polychoric cell-probability matrix by differencing four
+# shifted sub-matrices of a CDF grid from `.corr_bivnorm_cdf_grid()`:
+#   π_{m,p} = grid[m+1, p+1] - grid[m, p+1] - grid[m+1, p] + grid[m, p]
+# Shared by `.corr_polychoric_loglik()` and `.corr_count_sparse_cells()` so
+# neither carries its own copy of the differencing.
+#
+# Arguments:
+#   grid — (k_x + 1) x (k_y + 1) matrix from `.corr_bivnorm_cdf_grid()`.
+#
+# Returns: k_x x k_y numeric matrix of cell probabilities.
+.corr_cell_prob_matrix <- function(grid) {
+  k_x <- nrow(grid) - 1L
+  k_y <- ncol(grid) - 1L
+  hi_hi <- grid[2:(k_x + 1L), 2:(k_y + 1L), drop = FALSE]
+  lo_hi <- grid[1:k_x, 2:(k_y + 1L), drop = FALSE]
+  hi_lo <- grid[2:(k_x + 1L), 1:k_y, drop = FALSE]
+  lo_lo <- grid[1:k_x, 1:k_y, drop = FALSE]
+  hi_hi - lo_hi - hi_lo + lo_lo
 }
 
 
@@ -383,38 +452,35 @@
   thresholds_y,
   cell_prob_floor = 1e-300
 ) {
-  k_x <- nrow(cell_weights)
-  k_y <- ncol(cell_weights)
   # Full threshold vectors with -Inf / +Inf sentinels.
   tx_full <- c(-Inf, thresholds_x, Inf)
   ty_full <- c(-Inf, thresholds_y, Inf)
 
-  ll <- 0
-  any_floor_active <- FALSE
+  grid <- .corr_bivnorm_cdf_grid(tx_full, ty_full, rho)
+  cell_prob <- .corr_cell_prob_matrix(grid)
 
-  for (m in seq_len(k_x)) {
-    for (p in seq_len(k_y)) {
-      w_cell <- cell_weights[m, p]
-      if (w_cell == 0) {
-        # 0 * log(anything) treated as 0. Skip to avoid log(0) on floored cell.
-        next
-      }
-      # π_{m,p}(ρ) = Φ2(t_{m+1}, t'_{p+1}) − Φ2(t_m, t'_{p+1})
-      #            − Φ2(t_{m+1}, t'_p) + Φ2(t_m, t'_p)
-      a_hi <- tx_full[[m + 1L]]
-      a_lo <- tx_full[[m]]
-      b_hi <- ty_full[[p + 1L]]
-      b_lo <- ty_full[[p]]
-      p_mp <- .corr_bivnorm_cdf(a_hi, b_hi, rho) -
-        .corr_bivnorm_cdf(a_lo, b_hi, rho) -
-        .corr_bivnorm_cdf(a_hi, b_lo, rho) +
-        .corr_bivnorm_cdf(a_lo, b_lo, rho)
-      if (is.na(p_mp) || p_mp < cell_prob_floor) {
-        any_floor_active <- TRUE
-        p_mp <- cell_prob_floor
-      }
-      ll <- ll + w_cell * log(p_mp)
-    }
+  # 0 * log(anything) treated as 0: cells with zero weight contribute nothing
+  # to `ll` and never set `any_floor_active`, floored or not.
+  w_pos <- cell_weights > 0
+  floor_mask <- is.na(cell_prob) | cell_prob < cell_prob_floor
+  cell_prob[floor_mask] <- cell_prob_floor
+  any_floor_active <- any(floor_mask & w_pos)
+
+  # Accumulate in the same (row m outer, column p inner) order, with the
+  # same double-precision `+=` steps, that the original per-cell loop used.
+  # `sum()` runs a long-double accumulator internally and would move `ll`
+  # by about 1 ULP — inside the 1e-8 tolerance the direct tests pin `ll`
+  # at, but the influence loop divides by `eps_pert` (1e-4), so even a
+  # last-bit shift in the full-sample fit gets amplified 1e4x across every
+  # perturbation. The explicit loop keeps `ll`, and everything downstream
+  # of it, bit-identical to the pre-vectorisation code.
+  w_t <- t(cell_weights)
+  p_t <- t(cell_prob)
+  pos_t <- t(w_pos)
+  terms <- w_t[pos_t] * log(p_t[pos_t])
+  ll <- 0
+  for (term in terms) {
+    ll <- ll + term
   }
 
   list(ll = ll, any_floor_active = any_floor_active)
@@ -527,7 +593,8 @@
   active_domain,
   eps = 1e-6,
   x_name = "x",
-  y_name = "y"
+  y_name = "y",
+  refit = FALSE
 ) {
   th_x <- .corr_estimate_thresholds(
     ord_x_vec,
@@ -578,45 +645,109 @@
     )
   }
 
+  core <- .corr_polychoric_fit_core(
+    cell_counts = cell_counts,
+    thresholds_x = th_x$thresholds,
+    thresholds_y = th_y$thresholds,
+    eps = eps,
+    refit = refit,
+    x_name = x_name,
+    y_name = y_name
+  )
+
+  list(
+    rho = core$rho,
+    converged = TRUE,
+    thresholds_x = th_x$thresholds,
+    thresholds_y = th_y$thresholds,
+    levels_x = th_x$levels_used,
+    levels_y = th_y$levels_used,
+    cell_counts = cell_counts,
+    n_cells_obs = as.integer(n_cells_obs),
+    n_sparse_cells = core$n_sparse_cells,
+    log_lik = core$log_lik,
+    any_floor_active = core$any_floor_active,
+    dropped_levels_x = th_x$dropped_levels,
+    dropped_levels_y = th_y$dropped_levels
+  )
+}
+
+
+# ── .corr_polychoric_fit_core() ──────────────────────────────────────────────
+#
+# Shared objective + probe + optimize + error-handling core for the
+# polychoric MLE. `.corr_polychoric_mle()` calls this for the full fit; the
+# delta refit in `.corr_numerical_influence()` (Step 3) calls it again with
+# delta-updated `cell_counts` / thresholds, so both paths run the identical
+# optimization code.
+#
+# Arguments:
+#   cell_counts             — K_x × K_y weighted matrix.
+#   thresholds_x, thresholds_y — interior threshold vectors.
+#   eps                     — boundary offset for the optimizer bounds.
+#   refit                   — when TRUE, skip the 5-point probe and the
+#                              sparse-cell count (Step 2); `n_sparse_cells`
+#                              comes back `NA_integer_`.
+#   x_name, y_name          — for diagnostics and error messages.
+#
+# Returns: list(rho, log_lik, any_floor_active, n_sparse_cells).
+#
+# Errors:
+#   PC-6 surveycore_error_polychoric_optim_failed if the optimizer returns
+#        non-finite / boundary results or the objective is not finite at a
+#        sentinel test point.
+.corr_polychoric_fit_core <- function(
+  cell_counts,
+  thresholds_x,
+  thresholds_y,
+  eps,
+  refit,
+  x_name,
+  y_name
+) {
   # Objective: weighted log-likelihood as a function of ρ.
   objective <- function(rho) {
     out <- .corr_polychoric_loglik(
       rho,
       cell_weights = cell_counts,
-      thresholds_x = th_x$thresholds,
-      thresholds_y = th_y$thresholds
+      thresholds_x = thresholds_x,
+      thresholds_y = thresholds_y
     )
     out$ll
   }
 
-  # Guard: objective must be finite somewhere before we hand off to optimize().
-  probe <- vapply(
-    c(-0.9, -0.5, 0, 0.5, 0.9),
-    function(r) objective(r),
-    numeric(1)
-  )
-  # nocov start
-  # Defensive: with cell_prob_floor = 1e-300, log(floor) ≈ -690 is finite,
-  # so objective(r) is finite for any r in the probe set on any realistic
-  # cell_weights. This branch is only reachable if future changes remove
-  # the floor or callers pass non-finite thresholds directly.
-  if (!any(is.finite(probe))) {
-    cli::cli_abort(
-      c(
-        "x" = paste0(
-          "Numerical optimization did not converge for pair ",
-          "({.field {x_name}}, {.field {y_name}})."
-        ),
-        "i" = "Optimizer message: {.val objective not finite at any probe point}.",
-        "v" = paste0(
-          "Inspect the pair for extreme weight skew, sparse cells, ",
-          "or degenerate ordinal coding."
-        )
-      ),
-      class = "surveycore_error_polychoric_optim_failed"
+  if (!refit) {
+    # Guard: objective must be finite somewhere before handing off to
+    # optimize(). Skipped on a refit — Step 0.5 (check B) confirmed the
+    # refit caller reads nothing this guard feeds.
+    probe <- vapply(
+      c(-0.9, -0.5, 0, 0.5, 0.9),
+      function(r) objective(r),
+      numeric(1)
     )
+    # nocov start
+    # Defensive: with cell_prob_floor = 1e-300, log(floor) ≈ -690 is finite,
+    # so objective(r) is finite for any r in the probe set on any realistic
+    # cell_weights. This branch is only reachable if future changes remove
+    # the floor or callers pass non-finite thresholds directly.
+    if (!any(is.finite(probe))) {
+      cli::cli_abort(
+        c(
+          "x" = paste0(
+            "Numerical optimization did not converge for pair ",
+            "({.field {x_name}}, {.field {y_name}})."
+          ),
+          "i" = "Optimizer message: {.val objective not finite at any probe point}.",
+          "v" = paste0(
+            "Inspect the pair for extreme weight skew, sparse cells, ",
+            "or degenerate ordinal coding."
+          )
+        ),
+        class = "surveycore_error_polychoric_optim_failed"
+      )
+    }
+    # nocov end
   }
-  # nocov end
 
   fit <- tryCatch(
     stats::optimize(
@@ -651,34 +782,30 @@
   opt_out <- .corr_polychoric_loglik(
     rho_hat,
     cell_weights = cell_counts,
-    thresholds_x = th_x$thresholds,
-    thresholds_y = th_y$thresholds
+    thresholds_x = thresholds_x,
+    thresholds_y = thresholds_y
   )
 
   # Count cells whose modeled probability at ρ̂ is below the sparse tolerance
-  # (1e-12 per spec). Cells with zero weight are ignored.
-  n_sparse <- .corr_count_sparse_cells(
-    rho_hat,
-    cell_counts,
-    th_x$thresholds,
-    th_y$thresholds,
-    tol = 1e-12
-  )
+  # (1e-12 per spec). Cells with zero weight are ignored. Skipped on a
+  # refit — the influence loop reads only `$rho` (Step 0.5, check B).
+  n_sparse <- if (refit) {
+    NA_integer_
+  } else {
+    as.integer(.corr_count_sparse_cells(
+      rho_hat,
+      cell_counts,
+      thresholds_x,
+      thresholds_y,
+      tol = 1e-12
+    ))
+  }
 
   list(
     rho = rho_hat,
-    converged = TRUE,
-    thresholds_x = th_x$thresholds,
-    thresholds_y = th_y$thresholds,
-    levels_x = th_x$levels_used,
-    levels_y = th_y$levels_used,
-    cell_counts = cell_counts,
-    n_cells_obs = as.integer(n_cells_obs),
-    n_sparse_cells = as.integer(n_sparse),
     log_lik = opt_out$ll,
     any_floor_active = opt_out$any_floor_active,
-    dropped_levels_x = th_x$dropped_levels,
-    dropped_levels_y = th_y$dropped_levels
+    n_sparse_cells = n_sparse
   )
 }
 
@@ -692,29 +819,14 @@
   thresholds_y,
   tol = 1e-12
 ) {
-  k_x <- nrow(cell_counts)
-  k_y <- ncol(cell_counts)
   tx_full <- c(-Inf, thresholds_x, Inf)
   ty_full <- c(-Inf, thresholds_y, Inf)
-  n_sparse <- 0L
-  for (m in seq_len(k_x)) {
-    for (p in seq_len(k_y)) {
-      if (cell_counts[m, p] == 0) {
-        next
-      }
-      a_hi <- tx_full[[m + 1L]]
-      a_lo <- tx_full[[m]]
-      b_hi <- ty_full[[p + 1L]]
-      b_lo <- ty_full[[p]]
-      p_mp <- .corr_bivnorm_cdf(a_hi, b_hi, rho) -
-        .corr_bivnorm_cdf(a_lo, b_hi, rho) -
-        .corr_bivnorm_cdf(a_hi, b_lo, rho) +
-        .corr_bivnorm_cdf(a_lo, b_lo, rho)
-      if (is.na(p_mp) || p_mp < tol) {
-        n_sparse <- n_sparse + 1L
-      }
-    }
-  }
+  grid <- .corr_bivnorm_cdf_grid(tx_full, ty_full, rho)
+  cell_prob <- .corr_cell_prob_matrix(grid)
+
+  w_pos <- cell_counts > 0
+  sparse_mask <- w_pos & (is.na(cell_prob) | cell_prob < tol)
+  n_sparse <- as.integer(sum(sparse_mask))
   n_sparse
 }
 
@@ -732,6 +844,8 @@
 #   active_domain  — 0/1 numeric mask, row-aligned
 #   eps            — boundary offset for the optimizer bounds
 #   ord_name, cont_name — for diagnostics and error messages
+#   refit          — when TRUE, skip the 5-point probe (Step 2). The
+#                     influence loop's refits pass TRUE.
 #
 # Returns: list(
 #   rho, converged, thresholds, levels_used, mean_w, sd_w, z,
@@ -748,7 +862,8 @@
   active_domain,
   eps = 1e-6,
   ord_name = "ordinal",
-  cont_name = "continuous"
+  cont_name = "continuous",
+  refit = FALSE
 ) {
   th <- .corr_estimate_thresholds(
     ordinal_vec,
@@ -776,31 +891,34 @@
     out$ll
   }
 
-  probe <- vapply(
-    c(-0.9, -0.5, 0, 0.5, 0.9),
-    function(r) objective(r),
-    numeric(1)
-  )
-  # nocov start
-  # Defensive: with cell_prob_floor = 1e-300, the objective is always finite
-  # on realistic inputs; only reachable if callers pass NaN thresholds.
-  if (!any(is.finite(probe))) {
-    cli::cli_abort(
-      c(
-        "x" = paste0(
-          "Numerical optimization did not converge for pair ",
-          "({.field {ord_name}}, {.field {cont_name}})."
-        ),
-        "i" = "Optimizer message: {.val objective not finite at any probe point}.",
-        "v" = paste0(
-          "Inspect the pair for extreme weight skew, sparse cells, ",
-          "or degenerate ordinal coding."
-        )
-      ),
-      class = "surveycore_error_polychoric_optim_failed"
+  if (!refit) {
+    probe <- vapply(
+      c(-0.9, -0.5, 0, 0.5, 0.9),
+      function(r) objective(r),
+      numeric(1)
     )
+    # nocov start
+    # Defensive: with cell_prob_floor = 1e-300, the objective is always
+    # finite on realistic inputs; only reachable if callers pass NaN
+    # thresholds.
+    if (!any(is.finite(probe))) {
+      cli::cli_abort(
+        c(
+          "x" = paste0(
+            "Numerical optimization did not converge for pair ",
+            "({.field {ord_name}}, {.field {cont_name}})."
+          ),
+          "i" = "Optimizer message: {.val objective not finite at any probe point}.",
+          "v" = paste0(
+            "Inspect the pair for extreme weight skew, sparse cells, ",
+            "or degenerate ordinal coding."
+          )
+        ),
+        class = "surveycore_error_polychoric_optim_failed"
+      )
+    }
+    # nocov end
   }
-  # nocov end
 
   fit <- tryCatch(
     stats::optimize(
@@ -920,11 +1038,202 @@
 }
 
 
+# ── .corr_polychoric_influence_setup() ───────────────────────────────────────
+#
+# Delta-refit setup for the polychoric path of `.corr_numerical_influence()`
+# (Step 3). Computed once, from the unperturbed data, so each of the n
+# refits below touches only what perturbing one row changes: one level sum
+# per margin and one cell, instead of rebuilding both O(n) threshold
+# estimations and the O(n) cell-count loop from scratch.
+#
+# Arguments:
+#   vec_a, vec_b — full-length ordinal x / ordinal y vectors.
+#   w_full       — full-length raw weight vector.
+#   active_lgl   — full-length logical active-domain mask.
+#
+# Returns: list(
+#   codes_x, codes_y     — full-length remapped level codes (NA excluded).
+#   w_eff                — full-length effective weight (w_full * active,
+#                           NA -> 0).
+#   level_sum_x, level_sum_y — base per-level weight sums, length K_x / K_y.
+#   idx_level_x, idx_level_y — list of row-index vectors per level.
+#   cell_counts          — base K_x x K_y weighted cell-count matrix.
+#   cell_members         — K_x x K_y list-matrix of row-index vectors, in
+#                           increasing row order.
+#   thresholds_x, thresholds_y — base interior threshold vectors.
+# )
+.corr_polychoric_influence_setup <- function(vec_a, vec_b, w_full, active_lgl) {
+  th_x <- .corr_estimate_thresholds(vec_a, w_full, active_lgl, var_name = "x")
+  th_y <- .corr_estimate_thresholds(vec_b, w_full, active_lgl, var_name = "y")
+
+  k_x <- length(th_x$levels_used)
+  k_y <- length(th_y$levels_used)
+  codes_x <- th_x$codes
+  codes_y <- th_y$codes
+
+  w_eff <- w_full * active_lgl
+  w_eff[is.na(w_eff)] <- 0
+
+  idx_level_x <- lapply(seq_len(k_x), function(k) which(codes_x == k))
+  idx_level_y <- lapply(seq_len(k_y), function(k) which(codes_y == k))
+
+  use_cell <- !is.na(codes_x) & !is.na(codes_y) & w_eff > 0
+  cell_counts <- matrix(0, nrow = k_x, ncol = k_y)
+  cell_members <- vector("list", k_x * k_y)
+  dim(cell_members) <- c(k_x, k_y)
+  for (i in which(use_cell)) {
+    m <- codes_x[[i]]
+    p <- codes_y[[i]]
+    cell_counts[m, p] <- cell_counts[m, p] + w_eff[[i]]
+    cell_members[[m, p]] <- c(cell_members[[m, p]], i)
+  }
+
+  list(
+    codes_x = codes_x,
+    codes_y = codes_y,
+    w_eff = w_eff,
+    level_sum_x = th_x$level_weights_used,
+    level_sum_y = th_y$level_weights_used,
+    idx_level_x = idx_level_x,
+    idx_level_y = idx_level_y,
+    cell_counts = cell_counts,
+    cell_members = cell_members,
+    thresholds_x = th_x$thresholds,
+    thresholds_y = th_y$thresholds
+  )
+}
+
+
+# ── .corr_polychoric_delta_refit() ───────────────────────────────────────────
+#
+# O(1) (per row, not O(n)) refit for one perturbed row, using the setup from
+# `.corr_polychoric_influence_setup()`. Perturbing row `i` by `w * (1 +
+# eps_pert)` changes at most one level sum per margin and one cell; recompute
+# only those, rebuild the two small (length K) threshold vectors, and hand
+# the delta-updated `cell_counts` / thresholds to the same
+# `.corr_polychoric_fit_core()` the full fit uses.
+#
+# Edge rows:
+#   - NA code on one margin: update only the other margin's level sum, no
+#     cell.
+#   - NA code on both margins, or zero effective weight: no updates at all.
+#     The optimizer still runs on the (numerically unchanged) perturbed
+#     data, so the result equals the full fit exactly rather than being
+#     shortcut to an assumed IF = 0.
+#
+# The affected level sum is recomputed via `sum()` over the (small) subset
+# of `w_eff` values for that level, with row `i`'s entry replaced — the same
+# call shape `.corr_estimate_thresholds()` uses today. The affected cell is
+# recomputed via an explicit `+=` loop over its member indices in increasing
+# row order, not `sum()`: Step 0.5 (check C) showed `sum()` diverges from
+# the `+=` loop on lognormal weights.
+#
+# Arguments:
+#   setup    — list from `.corr_polychoric_influence_setup()`.
+#   i        — integer(1), the perturbed row's index into `w_full`.
+#   w_full   — full-length raw weight vector (unperturbed).
+#   eps_pert — perturbation magnitude.
+#
+# Returns: list(rho, log_lik, any_floor_active, n_sparse_cells) — the
+# `.corr_polychoric_fit_core()` contract, always with `refit = TRUE`.
+.corr_polychoric_delta_refit <- function(setup, i, w_full, eps_pert) {
+  m <- setup$codes_x[[i]]
+  p <- setup$codes_y[[i]]
+  w_eff_i <- setup$w_eff[[i]]
+
+  thresholds_x <- setup$thresholds_x
+  thresholds_y <- setup$thresholds_y
+  cell_counts <- setup$cell_counts
+
+  if (w_eff_i > 0 && (!is.na(m) || !is.na(p))) {
+    w_eff_pert_i <- w_full[[i]] * (1 + eps_pert)
+
+    if (!is.na(m)) {
+      idx_m <- setup$idx_level_x[[m]]
+      w_sub <- setup$w_eff[idx_m]
+      w_sub[idx_m == i] <- w_eff_pert_i
+      level_sum_x <- setup$level_sum_x
+      level_sum_x[[m]] <- sum(w_sub, na.rm = TRUE)
+      total_w_x <- sum(level_sum_x)
+      cum_prop_x <- cumsum(level_sum_x) / total_w_x
+      thresholds_x <- stats::qnorm(cum_prop_x[-length(cum_prop_x)])
+    }
+
+    if (!is.na(p)) {
+      idx_p <- setup$idx_level_y[[p]]
+      w_sub <- setup$w_eff[idx_p]
+      w_sub[idx_p == i] <- w_eff_pert_i
+      level_sum_y <- setup$level_sum_y
+      level_sum_y[[p]] <- sum(w_sub, na.rm = TRUE)
+      total_w_y <- sum(level_sum_y)
+      cum_prop_y <- cumsum(level_sum_y) / total_w_y
+      thresholds_y <- stats::qnorm(cum_prop_y[-length(cum_prop_y)])
+    }
+
+    if (!is.na(m) && !is.na(p)) {
+      members <- setup$cell_members[[m, p]]
+      total <- 0
+      for (j in members) {
+        total <- total + if (identical(j, i)) w_eff_pert_i else setup$w_eff[[j]]
+      }
+      cell_counts[m, p] <- total
+    }
+  }
+
+  .corr_polychoric_fit_core(
+    cell_counts = cell_counts,
+    thresholds_x = thresholds_x,
+    thresholds_y = thresholds_y,
+    eps = 1e-6,
+    refit = TRUE,
+    x_name = "x",
+    y_name = "y"
+  )
+}
+
+
+# ── .corr_influence_pc6_abort() ──────────────────────────────────────────────
+#
+# Shared PC-6 rethrow for `.corr_numerical_influence()`: both the polychoric
+# and the polyserial refit loop catch an inner MLE failure and re-raise it
+# pointing at the perturbed row.
+#
+# Arguments:
+#   fit_pert — the caught condition object (an "error").
+#   i        — integer(1), the row index that failed.
+.corr_influence_pc6_abort <- function(fit_pert, i) {
+  cli::cli_abort(
+    c(
+      "x" = paste0(
+        "Numerical optimization did not converge during ",
+        "influence-function computation."
+      ),
+      "i" = paste0(
+        "Perturbation at row {.val {i}} failed: ",
+        "{.val {conditionMessage(fit_pert)}}"
+      ),
+      "v" = paste0(
+        "Inspect the pair for extreme weight skew, sparse cells, ",
+        "or degenerate ordinal coding."
+      )
+    ),
+    class = "surveycore_error_polychoric_optim_failed"
+  )
+}
+
+
 # ── .corr_numerical_influence() ──────────────────────────────────────────────
 #
 # Perturbation-based numerical influence function on the Fisher-z scale:
 #   IF_i ≈ (atanh(ρ̂_pert_i) - atanh(ρ̂_full)) / ε
 # where ρ̂_pert_i is the MLE with w_i replaced by w_i * (1 + ε).
+#
+# The polychoric path (Step 3) uses a delta refit — `.corr_polychoric_
+# influence_setup()` once, then `.corr_polychoric_delta_refit()` per row —
+# instead of calling `.corr_polychoric_mle()` from scratch for every row.
+# The polyserial path is unchanged except that its MLE call now passes
+# `refit = TRUE` (Step 2): its likelihood is already O(n) per evaluation by
+# nature, so a delta setup would not save anything there.
 #
 # Arguments:
 #   design          — survey_taylor (used for @data and @variables$weights)
@@ -956,54 +1265,46 @@
   n_active <- length(active_idx)
 
   rho_z_full <- atanh(rho_hat_full)
-
   ifs <- numeric(n_active)
+
+  if (identical(method, "polychoric")) {
+    setup <- .corr_polychoric_influence_setup(vec_a, vec_b, w_full, active_lgl)
+
+    for (k in seq_len(n_active)) {
+      i <- active_idx[[k]]
+      fit_pert <- tryCatch(
+        .corr_polychoric_delta_refit(setup, i, w_full, eps_pert),
+        error = function(e) e
+      )
+      if (inherits(fit_pert, "error")) {
+        .corr_influence_pc6_abort(fit_pert, i)
+      }
+      rho_z_pert <- atanh(fit_pert$rho)
+      ifs[[k]] <- (rho_z_pert - rho_z_full) / eps_pert
+    }
+
+    return(ifs)
+  }
+
   for (k in seq_len(n_active)) {
     i <- active_idx[[k]]
     w_pert <- w_full
     w_pert[[i]] <- w_pert[[i]] * (1 + eps_pert)
 
     fit_pert <- tryCatch(
-      if (identical(method, "polychoric")) {
-        .corr_polychoric_mle(
-          vec_a,
-          vec_b,
-          w_pert,
-          active_lgl,
-          x_name = "x",
-          y_name = "y"
-        )
-      } else {
-        .corr_polyserial_mle(
-          vec_a,
-          vec_b,
-          w_pert,
-          active_lgl,
-          ord_name = "ord",
-          cont_name = "cont"
-        )
-      },
+      .corr_polyserial_mle(
+        vec_a,
+        vec_b,
+        w_pert,
+        active_lgl,
+        ord_name = "ord",
+        cont_name = "cont",
+        refit = TRUE
+      ),
       error = function(e) e
     )
     if (inherits(fit_pert, "error")) {
-      # Re-throw as PC-6 pointing at the full-sample context.
-      cli::cli_abort(
-        c(
-          "x" = paste0(
-            "Numerical optimization did not converge during ",
-            "influence-function computation."
-          ),
-          "i" = paste0(
-            "Perturbation at row {.val {i}} failed: ",
-            "{.val {conditionMessage(fit_pert)}}"
-          ),
-          "v" = paste0(
-            "Inspect the pair for extreme weight skew, sparse cells, ",
-            "or degenerate ordinal coding."
-          )
-        ),
-        class = "surveycore_error_polychoric_optim_failed"
-      )
+      .corr_influence_pc6_abort(fit_pert, i)
     }
     rho_z_pert <- atanh(fit_pert$rho)
     ifs[[k]] <- (rho_z_pert - rho_z_full) / eps_pert
@@ -1120,7 +1421,8 @@
           w_r,
           active_lgl,
           x_name = "x",
-          y_name = "y"
+          y_name = "y",
+          refit = TRUE
         )
       } else {
         .corr_polyserial_mle(
@@ -1129,7 +1431,8 @@
           w_r,
           active_lgl,
           ord_name = "ord",
-          cont_name = "cont"
+          cont_name = "cont",
+          refit = TRUE
         )
       },
       error = function(e) NULL
@@ -1243,7 +1546,8 @@
             w_r_srs,
             active_lgl,
             x_name = "x",
-            y_name = "y"
+            y_name = "y",
+            refit = TRUE
           )
         } else {
           .corr_polyserial_mle(
@@ -1252,7 +1556,8 @@
             w_r_srs,
             active_lgl,
             ord_name = "ord",
-            cont_name = "cont"
+            cont_name = "cont",
+            refit = TRUE
           )
         },
         error = function(e) NULL

--- a/changelog/fix-polychoric-performance.md
+++ b/changelog/fix-polychoric-performance.md
@@ -1,0 +1,64 @@
+# Changelog: fix/polychoric-performance
+
+**Branch:** `fix/polychoric-performance`
+**Status:** Complete
+**Date:** 2026-08-27
+
+## Summary
+
+Fixes #177: `get_corr(method = "polychoric")` was ~247x slower than
+`polycor::polychor()` on the same data (29.69 s vs 0.12 s on a 6x7 table,
+n = 300). The result was correct; only the speed was wrong.
+
+Three changes, each verified bit-identical to the old code before
+implementation (all reported estimates, SEs, and CI bounds reproduce the
+baseline digit for digit):
+
+1. **Vectorised CDF grid.** The scalar `.corr_bivnorm_cdf()` wrapper made
+   168 separate `pbivnorm` entries per log-likelihood evaluation — ~55% of
+   the run was the wrapper's per-call entry overhead. One vectorised call
+   per rho over the threshold grid replaces them.
+2. **Lean refit mode.** The influence-function and replicate refits read
+   only `$rho`, but each refit still paid a 5-point objective probe (5 of
+   16 evaluations) and a sparse-cell count it discarded. A `refit = TRUE`
+   internal argument skips both.
+3. **Delta refit setup.** Each of the n influence refits rebuilt thresholds
+   and cell counts from all n rows — O(n^2) across the loop. A perturbation
+   touches one level sum per margin and one cell; the delta path recomputes
+   only those, with the same accumulation order, so the results are
+   bit-identical.
+
+Measured after the fix: the 6x7 benchmark runs in 0.99 s (30x), and the two
+slow polychoric test files fell from 355.4 s to 77.5 s. All existing test
+tolerances are untouched. Follow-ups (refit dedup by cell/weight key, and
+an analytic influence function) are out of scope and tracked separately.
+
+## Files Modified
+
+- `R/analysis-corr-latent.R` — added `.corr_bivnorm_cdf_grid()`,
+  `.corr_cell_prob_matrix()`, `.corr_polychoric_fit_core()`,
+  `.corr_polychoric_influence_setup()`, `.corr_polychoric_delta_refit()`,
+  and `.corr_influence_pc6_abort()`; deleted `.corr_bivnorm_cdf()`;
+  rewrote `.corr_polychoric_loglik()` and `.corr_count_sparse_cells()`
+  over the grid helpers; added `refit = FALSE` to the two MLE functions;
+  `.corr_estimate_thresholds()` also returns its per-level weight sums
+- `tests/testthat/test-analysis-corr-latent-primitives.R` — six new tests:
+  grid precedence rules, grid vs scalar reference, cell-probability sums,
+  sparse-cell parity, `refit = TRUE` identity, and the delta refit pinned
+  `expect_identical()` against a brute-force full rebuild
+- `tests/testthat/_snaps/analysis-corr-latent-primitives.md` — one snapshot
+  header updated (`.corr_polychoric_mle()` → `.corr_polychoric_fit_core()`);
+  message and error class unchanged
+- `plans/implementation-plan-polychoric-performance.md` — the implementation
+  plan, including the baseline measurements and the bit-identity
+  verification record
+
+## Changes
+
+- Evaluate the polychoric bivariate-normal CDF grid in one vectorised
+  `pbivnorm` call per rho instead of four scalar calls per cell
+- Skip the objective probe and the sparse-cell count in influence and
+  replicate refits (`refit = TRUE`), which consume only `$rho`
+- Delta-update thresholds and cell counts across influence refits instead
+  of rebuilding them from all n rows per refit
+- Pin the refit paths bit-identical to the full rebuild in tests

--- a/plans/implementation-plan-polychoric-performance.md
+++ b/plans/implementation-plan-polychoric-performance.md
@@ -1,0 +1,433 @@
+# Implementation Plan — polychoric speed fix (issue #177)
+
+**Issue:** #177 — `get_corr(method = "polychoric")` is ~164x slower than
+`polycor::polychor()`.
+**Branch:** `fix/polychoric-performance` → `develop`
+**Tier:** 2 (plan only) — the behaviour is fixed, the approach is not.
+**Status:** Amended 2026-08-27 after the Step 0.5 verification run. Steps 1–3
+are verified bit-identical in advance.
+
+---
+
+## 1. What must not change
+
+The two implementations agree to 6.4e-12. This is a speed defect only.
+
+- No estimate, standard error, or confidence bound may move beyond the
+  tolerances already in the suite.
+- No test tolerance may be relaxed. The issue states this. Treat it as a
+  hard gate.
+- Every exported signature stays as it is. No user-facing change.
+- `.corr_polychoric_loglik()` keeps its argument list and its return
+  contract `list(ll, any_floor_active)`. Four tests in
+  `test-analysis-corr-latent-primitives.R` call it directly.
+
+## 2. Cost structure
+
+The cost has two layers. The issue names the first one.
+
+**Layer 1 — the inner constant.** `.corr_bivnorm_cdf()`
+(`R/analysis-corr-latent.R:340`) takes scalars only. Both cell loops call it
+four times per cell:
+
+| Site | Lines |
+|---|---|
+| `.corr_polychoric_loglik()` | 408–411 |
+| `.corr_count_sparse_cells()` | 709–712 |
+
+For a 6x7 table that is 42 cells x 4 = 168 entries into the `pbivnorm`
+wrapper for each log-likelihood evaluation. The wrapper runs four
+`replace()` calls and one `sapply()` on every entry. The profile in the
+issue shows this: `replace` 13.7% self, `simplify2array` 8.7% self, and only
+16.8% self in `pbivnorm` itself.
+
+The 168 entries read a grid of just `(k_x + 1)` x `(k_y + 1)` = 56 distinct
+threshold pairs. Neighbouring cells recompute the same corner up to four
+times.
+
+**Layer 2 — the outer multiplier.** `.corr_numerical_influence()`
+(`R/analysis-corr-latent.R:944`) refits the complete MLE once for every
+active observation, to build the influence function. Line 1573 calls it on
+every `survey_taylor` design. There is no option to skip it.
+
+Step 0 instrumented one `get_corr()` call on the 6x7 fixture, n = 300:
+
+```
+301 MLE fits  ->  4,816 loglik evaluations  ->  809,088 wrapper entries
+                                            +   50,568 from the sparse-cell loop
+```
+
+`polycor::polychor()` runs one fit and computes no variance. That is the
+real source of the ratio: 29.69 s / 301 fits = 98.6 ms per fit, against
+120 ms for `polycor`'s one fit. The per-fit speeds already match.
+`polycor::binBvn()` loops `mvtnorm::pmvnorm()` cell by cell, so it is not
+vectorised either. Layer 1 divides the whole product by a large constant;
+Steps 2–3 attack the multiplier.
+
+The 4,816 loglik evaluations split exactly: 301 × 16, of which 5 per fit
+are the pre-`optimize()` probe and 11 are `optimize()` itself.
+
+`.corr_estimate_thresholds()` and the cell-count loop also run once per
+refit, which makes them O(n^2) across the influence loop. Step 3 removes
+them from the refits with a delta update.
+
+## 3. Steps
+
+### Step 0 — record the baseline — DONE
+
+Measured on this branch at `95d9ddd`, R 4.6.1, `pbivnorm` 0.6.0,
+`polycor` 0.8.2. Scripts stay in the scratchpad; they are not committed.
+
+| Measure | Issue | Measured here |
+|---|---|---|
+| 6x7 table, n = 300 | 36.09 s | **29.69 s** |
+| `polycor` on the same data | 0.22 s | **0.12 s** |
+| Ratio | 164x | **247x** |
+| 3x3 table, n = 200 | 4.39 s | **3.81 s** |
+| `polycor` on the same data | 0.03 s | **0.02 s** |
+| Ratio | 146x | **191x** |
+
+Both machines agree on the shape. This machine is faster in absolute terms
+and `polycor` gains more from that, so the ratio here is higher.
+
+Test-file wall time, `NOT_CRAN = true`, all pass:
+
+| File | Time | Expectations |
+|---|---|---|
+| `test-analysis-corr-latent.R` | **306.7 s** | 126 |
+| `test-analysis-corr-latent-variance.R` | **48.7 s** | 86 |
+| `test-analysis-corr-latent-primitives.R` | 4.4 s | 86 |
+| Two slow files | **355.4 s** | 212 |
+
+**Pinned values.** Step 1 must reproduce these to 1e-10 or better — not
+bit for bit, because the `ll` sum-order change moves the objective in its
+last bits, so `optimize()` may move `r`'s trailing digits. Record the
+post-Step-1 values; Steps 2 and 3 must then reproduce those exactly
+(`identical()`), because both are bit-identical given the Step 1 objective.
+
+6x7 fixture, n = 300, seed 87:
+
+| Field | Value |
+|---|---|
+| `r` | `-0.01243641783992804` |
+| `ci_low` | `-0.1400506894810396` |
+| `ci_high` | `0.11558427081546385` |
+| `p_value` | `0.84959233507917253` |
+| `statistic` | `-0.18963860322111747` |
+| `polycor` rho | `-0.012436417833492502` |
+| Difference | 6.4e-12 — matches the issue |
+
+3x3 fixture, n = 200, seed 87:
+
+| Field | Value |
+|---|---|
+| `r` | `-0.017920077145335597` |
+| `ci_low` | `-0.18251303814298397` |
+| `ci_high` | `0.14764990104790368` |
+| `p_value` | `0.8330680248080119` |
+| `statistic` | `-0.21076836534021023` |
+
+**Call counts, instrumented on the 6x7 fit.** These confirm both layers:
+
+| Count | Value |
+|---|---|
+| `.corr_polychoric_mle()` fits per `get_corr()` call | **301** (1 + 300 refits) |
+| `.corr_polychoric_loglik()` evaluations per call | **4,816** |
+| Scalar `pbivnorm` entries from the loglik loop | **809,088** |
+| Scalar `pbivnorm` entries from the sparse-cell loop | 50,568 (301 x 42 x 4) |
+
+**Baseline profile, 20.4 s sampled.** Self time, grouped:
+
+| Group | Self % |
+|---|---|
+| `pbivnorm` wrapper plumbing — `replace`, `sapply`, `simplify2array`, `unique`, `lapply`, `unlist`, `%in%`, `match.fun`, `max`, `isFALSE`, `lengths` | **≈ 55%** |
+| `pbivnorm::pbivnorm` itself | 17.1% |
+| `.Fortran` — the real numerical work | **6.3%** |
+| `.corr_bivnorm_cdf` | 6.3% |
+| `.corr_polychoric_loglik` | 4.4% |
+
+By total time: `.corr_numerical_influence` **99.1%**,
+`.corr_bivnorm_cdf` 93.2%, `pbivnorm::pbivnorm` 84.7%.
+
+About 55% of the run is per-call entry overhead inside the `pbivnorm`
+wrapper. Only 6.3% is the Fortran routine. Step 1 removes almost all of the
+55%.
+
+### Step 0.5 — verify the bit-identity claims — DONE
+
+Four checks ran on 2026-08-27. The scripts live in the session scratchpad
+(`check_A.R` … `check_D.R`); they are not committed.
+
+| Check | Claim | Result |
+|---|---|---|
+| A | One vectorised `pbivnorm` call gives the same doubles as scalar calls | **PASS** — `identical()` on a 168-pair grid × 10 rho values, including ±8, ±37, and rho = ±(1 − 1e-6) |
+| A | The `ll` sum-order change stays inside the 1e-8 pin | **PASS** — max relative difference 4.0e-16 |
+| B | Influence refits consume only `$rho`; the probe and the sparse-cell count feed nothing there | **PASS** — static read confirmed (probe → unreachable guard only; sparse count runs after `rho_hat` is fixed; the loop reads `fit_pert$rho` once). 10 refits rebuilt without both gave `identical()` rho |
+| C | The delta recompute equals the full rebuild, bit for bit | **PASS** — 300 rows × 2 weight fixtures; level sums, thresholds, and cell counts all `identical()`, max difference exactly 0 |
+| C | `sum()` is a safe substitute for the `+=` cell loop | **REFUTED** — `sum()` diverges from the `+=` loop on 130/300 rows with lognormal weights. The delta path must use the `+=` style |
+| D | Rows with the same (cell x, cell y, weight) key give the same IF value | **MEASURED** — wt = 1 fixture: 42 distinct keys, within-key spread exactly 0. Lognormal weights: 300 distinct keys, so dedup never triggers |
+
+Consequences:
+
+- Step 1 is safe as specified.
+- The probe and the sparse-cell count can leave the refits with no numeric
+  change — that is Step 2.
+- The delta refit is bit-identical only with `+=` accumulation in
+  increasing row order — that is Step 3.
+- Refit dedup is exactly free on equal weights and inert on continuous
+  weights. It stays a follow-up (Step 5): mixed weights — duplicate values
+  among varied ones — were not measured.
+
+### Step 1 — one vectorised grid call per rho
+
+Add one internal helper. Both loops then call it.
+
+```r
+# Returns the (k_x + 1) x (k_y + 1) matrix of bivariate-normal CDF values
+# over the grid tx_full x ty_full, at a single rho.
+.corr_bivnorm_cdf_grid <- function(tx_full, ty_full, rho) { ... }
+```
+
+Rules the helper applies element-wise, in this precedence order. The order
+is the same one `.corr_bivnorm_cdf()` uses today, and it matters — a pair of
+`-Inf` and `NA` must give `NA`, not `0`.
+
+1. `NA` or `NaN` in `a`, `b`, or `rho` → `NA_real_`
+2. `a == -Inf` or `b == -Inf` → `0`
+3. `a == +Inf` and `b == +Inf` → `1`
+4. `a == +Inf` → `pnorm(b)`
+5. `b == +Inf` → `pnorm(a)`
+6. otherwise → one `pbivnorm::pbivnorm()` call over all remaining entries
+
+Interior thresholds are not always finite. `qnorm()` returns `±Inf` when a
+cumulative proportion reaches 0 or 1, and the `NaN` threshold test at
+`test-analysis-corr-latent-primitives.R:732` passes `NaN` in. So the helper
+applies all six rules across the whole grid. It must not assume that only
+the border carries a sentinel.
+
+Implement the six rules with base logical masks (`out[mask] <- value`).
+Do not use `ifelse()`, `dplyr::if_else()`, or `dplyr::case_when()` — the
+grid is small (56 values) but the helper runs ~4,800 times per call, so
+per-call overhead dominates throughput.
+
+Then replace both loops:
+
+- `.corr_polychoric_loglik()` — build the grid once, form the whole
+  `k_x` x `k_y` cell-probability matrix by differencing four shifted
+  sub-matrices, floor it, and sum `w * log(p)` over cells with positive
+  weight.
+- `.corr_count_sparse_cells()` — same cell-probability matrix, then count
+  entries below `tol` among cells with positive weight.
+
+The cell probabilities come out bit-identical: the same `pbivnorm` Fortran
+routine loops over its input element by element, so a vector of 30 gives the
+same doubles as 30 calls of length 1, and the differencing is element-wise
+arithmetic on those same doubles. Only the order of the final `ll` sum
+changes, from row-major accumulation to `sum()` over a matrix. That moves
+`ll` by about 1e-16 relative. The direct test pins `ll` at `1e-8`, so it
+absorbs this. Step 0.5 (check A) confirmed both claims empirically; test 2
+in section 5 keeps the grid-vs-scalar comparison as the regression guard.
+
+Extract the shared cell-probability construction into one helper. The two
+call sites must not each carry their own copy of the differencing — that is
+the DRY rule in `.claude/rules/engineering-preferences.md`, and it is how
+the duplicate loop at line 709 came to exist.
+
+Delete `.corr_bivnorm_cdf()`. Nothing else calls it, and leaving it in place
+leaves uncovered lines behind. Update the helper index in the file header at
+lines 11–21.
+
+### Step 2 — lean refit mode for the influence loop
+
+Each fit spends 5 of its 16 loglik evaluations on the pre-`optimize()`
+probe (`.corr_polychoric_mle()` lines 592–597). The probe feeds only a
+guard the code's own nocov comment calls unreachable. The sparse-cell count
+(lines 660–666) runs after `rho_hat` is fixed. The influence loop reads
+only `fit_pert$rho` (line 1008). Step 0.5 (check B) verified all three
+facts, statically and dynamically.
+
+Add an internal argument `refit = FALSE` to `.corr_polychoric_mle()` and
+`.corr_polyserial_mle()`. When `TRUE`:
+
+- skip the 5-point probe;
+- skip `.corr_count_sparse_cells()` (polychoric only) and return
+  `n_sparse_cells = NA_integer_`.
+
+`.corr_numerical_influence()` passes `refit = TRUE`. So does
+`.corr_replicate_variance_latent()` for its per-replicate refits — it also
+consumes only `$rho` (lines 44–45, 128–132, 167–168 of that function), so
+the same bit-identity argument holds. Its full-sample fits stay
+`refit = FALSE`. No exported signature changes, and
+`.corr_polychoric_loglik()` keeps its pinned contract — the new argument
+lives on the MLE functions, which no test pins.
+
+Bit-identical by construction: the skipped work feeds no value the refit
+caller uses. Cuts refit loglik evaluations from 16 to 11 and removes one
+grid evaluation per refit.
+
+### Step 3 — O(1) refit setup by delta update
+
+This replaces the earlier `rowsum()` idea. `rowsum()` changes the
+summation order, so it is not bit-identical; the delta update is, and it is
+also faster — O(1) per refit instead of O(n).
+
+Each refit changes one weight, then rebuilds everything from all n rows:
+two threshold estimations with a per-level `sum(w_eff[codes_all == k])`
+pass (`.corr_estimate_thresholds()` 231–235) and the O(n) cell-count `+=`
+loop (`.corr_polychoric_mle()` 552–557). Across n refits that is O(n^2).
+But perturbing row i touches exactly one level sum per margin and one cell.
+
+Change the polychoric path of `.corr_numerical_influence()`:
+
+1. Compute once, from the unperturbed data: per-level row-index vectors
+   for each margin, per-cell member-index vectors in increasing row order,
+   the base level sums, and the base cell counts.
+2. Per refit, recompute only what row i touches:
+   - the affected level sum per margin, via the same
+     `sum(w_eff_pert[idx_level])` call the source uses today;
+   - the affected cell, via an R-level `+=` loop over its member indices
+     in increasing row order. Not `sum()` — check C showed `sum()`
+     diverges on 130/300 rows with lognormal weights, because `sum()`
+     accumulates in extended precision and the `+=` loop rounds each step.
+3. Rebuild `cum_prop` and the `qnorm()` thresholds from the updated level
+   sums — O(K).
+
+   Handle the rows a perturbation does not fully touch: a row with an NA
+   code on one margin updates only the other margin and no cell; a row
+   with NA on both margins, or with zero effective weight, updates
+   nothing. Level and cell membership never changes — `w * (1 + 1e-4)`
+   keeps zero at zero and positive at positive.
+4. Optimize exactly as the full fit does. Extract the objective-plus-
+   `optimize()` core of `.corr_polychoric_mle()` into one shared internal
+   helper so the full fit and the delta refit run the same code (the DRY
+   rule in `.claude/rules/engineering-preferences.md`).
+
+Error classes stay intact. A perturbation multiplies one weight by
+`1 + 1e-4`, so level and cell membership cannot change: a refit cannot
+newly hit PC-4 or PC-5 when the full fit passed. The PC-6 rethrow in the
+influence loop keeps its existing test.
+
+The polyserial path stays as it is. Its likelihood is O(n) per evaluation
+by nature, so setup does not dominate there; it still gains from Steps 1–2.
+
+Step 0.5 (check C) verified the delta path bit-identical on 300 rows × 2
+weight fixtures. Test 6 in section 5 pins it in the suite.
+
+### Step 4 — verify, then measure
+
+Run the gates in section 4. Re-run the Step 0 benchmark. Report the new
+time and ratio.
+
+**Resolved in Step 0.** The `unique` entry in the profile — 11.4% self in
+the issue, 10.6% here — is not surveycore code. `pbivnorm::pbivnorm()` runs
+`sapply(list(x, y, rho), length)`, `sapply()` calls `simplify2array()`, and
+`simplify2array()` opens with `unique(lengths(x))`. So `unique`, `lengths`,
+`unlist`, `%in%`, `match.fun`, and `isFALSE` all belong to the wrapper's own
+entry cost. Step 1 removes them.
+
+### Step 5 — profile again and hand off the follow-ups
+
+Re-run `Rprof()` on the 6x7 fit. Then open two follow-up issues and stop:
+
+1. **Refit dedup.** Group refits by the key (cell x, cell y, weight,
+   NA pattern) and compute one IF value per key. Step 0.5 (check D)
+   measured the gate: on equal weights the within-key spread is exactly 0
+   and 300 refits collapse to 42; on continuous weights keys are unique
+   and the change is inert. Before implementing, measure the one unproven
+   shape: duplicate weights among varied ones. The wt = 1 parity fixtures
+   in `test-analysis-corr-latent.R` are the main beneficiary.
+2. **Analytic influence function.** The true fix for the 301-fit
+   multiplier, and how lavaan solves the same problem. It replaces a
+   perturbation approximation, so standard errors would move, and the
+   tolerance rule above forbids that here. It needs a spec — Tier 1 work.
+
+Both are out of scope for this PR. Say so in the PR body.
+
+## 4. Verification gates
+
+All four must pass before the PR opens.
+
+| # | Gate | Command |
+|---|---|---|
+| G1 | Parity — the two corr-latent test files pass, no tolerance edited | `Rscript -e 'testthat::test_local(filter = "corr")'` |
+| G2 | Full suite passes | `Rscript -e 'devtools::test()'` |
+| G3 | Package check clean — 0 errors, 0 warnings, ≤2 approved notes | `Rscript -e 'devtools::check()'` |
+| G4 | Coverage not below the 96.0938% baseline | `NOT_CRAN=true Rscript -e 'covr::package_coverage()'` |
+
+`git diff` on `tests/testthat/` must show no change to any `tolerance =`
+argument. Check this by eye before pushing.
+
+Speed targets, against the Step 0 measurements on this machine:
+
+| Target | Baseline | Goal |
+|---|---|---|
+| 6x7 fit, n = 300 | 29.69 s | ≤ 3.0 s (10x); expected 1.5–2.5 s |
+| Ratio against `polycor` | 247x | under 25x |
+| The two slow test files | 355.4 s | ≤ 145 s (60% cut) |
+
+The goal comes from the profile, not from hope. Step 1 removes the ~55%
+wrapper entry overhead and shrinks the Fortran work (the grid holds 30
+finite pairs where the cell loop reads 168) — that alone is ~7x. Step 2
+cuts refit evaluations from 16 to 11 and drops one grid call per refit.
+Step 3 removes the O(n) setup from every refit. The expected range carries
+one estimate, not a measurement: the residual R cost per grid evaluation
+(~200 µs assumed). If that residual is heavier, Steps 2–3 gain more
+relative weight, not less.
+
+The ratio will not reach 1x. surveycore runs 301 fits and computes a
+design-based variance; `polycor` runs one fit and computes none. The
+per-fit speeds already match (Step 0), so the remaining gap is the fit
+count, which only the Step 5 follow-ups can shrink. Do not treat parity
+with `polycor` as the bar.
+
+## 5. Tests to add
+
+`tests/testthat/test-analysis-corr-latent-primitives.R`:
+
+1. `.corr_bivnorm_cdf_grid()` returns the documented value for each of the
+   six precedence rules, including `NA` beating `-Inf`.
+2. The grid matches an element-by-element `pbivnorm` reference on a finite
+   grid, `expect_equal()`, tolerance 1e-12.
+3. The shared cell-probability helper returns a matrix that sums to 1 over
+   all cells when every threshold is finite.
+4. `.corr_count_sparse_cells()` returns the same count as before on a
+   fixture with one deliberately tiny cell.
+5. `.corr_polychoric_mle(refit = TRUE)` returns a `rho` that is
+   `expect_identical()` to the `refit = FALSE` result on the same inputs,
+   and returns `n_sparse_cells = NA_integer_`. Same for the polyserial
+   probe skip.
+6. The delta refit path: `.corr_numerical_influence()` output is
+   `expect_identical()` — not tolerance — to a brute-force reference
+   (the full-rebuild loop, written as a local helper in the test) on a
+   small fixture with lognormal weights. Lognormal, because equal weights
+   cannot expose an accumulation-order mistake (check C). The fixture
+   includes at least one row with NA on one margin, one with NA on both,
+   and one with zero weight.
+
+Keep the existing four `.corr_polychoric_loglik()` tests as they are. They
+are the parity guard for this rewrite.
+
+## 6. Risks
+
+| Risk | Handling |
+|---|---|
+| A rewritten guard changes an edge case silently | Step 1 fixes the precedence order in writing and tests all six rules |
+| The `ll` sum order moves a snapshot or a pinned value | Step 0 records the values first; G1 and G2 catch a move |
+| The delta path accumulates with `sum()` where the source uses `+=` | Check C measured the divergence (130/300 rows); test 6 pins bit-identity on lognormal weights |
+| The delta refit bypasses the MLE's error classes | Membership is invariant under a `1 + 1e-4` weight scale, so PC-4/PC-5 cannot fire in a refit when the full fit passed; the PC-6 rethrow keeps its test |
+| The `refit = TRUE` branches lower coverage | Every existing influence and variance test exercises them; tests 5–6 cover the rest |
+| Scope creep into the variance restructure | Step 5 hands dedup and the analytic IF to new issues |
+| Deleting `.corr_bivnorm_cdf()` breaks a caller | `grep` shows the two loops are the only callers, and no test calls it |
+
+## 7. Commits
+
+One PR against `develop`. Conventional Commits:
+
+- `perf(analysis): evaluate the polychoric CDF grid in one vectorised call`
+- `test(analysis): cover the vectorised bivariate-normal grid helper`
+- `perf(analysis): skip the probe and sparse-cell count in influence refits`
+- `perf(analysis): delta-update thresholds and cell counts across influence refits`
+- `test(analysis): pin influence refits bit-identical to the full rebuild`
+
+Squash message:
+`perf(analysis): vectorise the polychoric CDF grid and cut influence-refit overhead (#177)`.

--- a/tests/testthat/_snaps/analysis-corr-latent-primitives.md
+++ b/tests/testthat/_snaps/analysis-corr-latent-primitives.md
@@ -47,7 +47,7 @@
         d$y, ordered = TRUE), weights = w, active_domain = dom, eps = 1.5, x_name = "xvar",
       y_name = "yvar")
     Condition
-      Error in `.corr_polychoric_mle()`:
+      Error in `.corr_polychoric_fit_core()`:
       x Numerical optimization did not converge for pair (xvar, yvar).
       i Optimizer message: "stats::optimize() returned a non-finite result".
       v Inspect the pair for extreme weight skew, sparse cells, or degenerate ordinal coding.

--- a/tests/testthat/test-analysis-corr-latent-primitives.R
+++ b/tests/testthat/test-analysis-corr-latent-primitives.R
@@ -825,3 +825,267 @@ test_that(".corr_polyserial_mle() weighted correctness: zero-weight rows do not 
   )
   expect_equal(out_zero$rho, out_base$rho, tolerance = 1e-8)
 })
+
+
+# =============================================================================
+# Polychoric performance rewrite (issue #177): vectorised CDF grid, lean
+# refit mode, and the delta-refit influence path.
+# =============================================================================
+
+# ── .corr_bivnorm_cdf_grid() ──────────────────────────────────────────────────
+
+test_that(".corr_bivnorm_cdf_grid() applies the six precedence rules in order", {
+  # tx_full / ty_full deliberately mix every sentinel so a single grid call
+  # exercises all six rules, including NA beating -Inf and NA beating +Inf.
+  tx_full <- c(-Inf, NaN, 0.5, Inf)
+  ty_full <- c(-Inf, 0, Inf)
+  rho <- 0.3
+  out <- .corr_bivnorm_cdf_grid(tx_full, ty_full, rho)
+
+  # Rule 2: -Inf on either side -> 0 (including a = -Inf, b = +Inf, where
+  # rule 2 must win over rule 3).
+  expect_identical(out[1L, 1L], 0)
+  expect_identical(out[1L, 2L], 0)
+  expect_identical(out[1L, 3L], 0)
+  expect_identical(out[3L, 1L], 0)
+  expect_identical(out[4L, 1L], 0)
+
+  # Rule 1: NA/NaN beats every other rule, including -Inf and +Inf.
+  expect_true(is.na(out[2L, 1L]))
+  expect_true(is.na(out[2L, 2L]))
+  expect_true(is.na(out[2L, 3L]))
+
+  # Rule 3: both sides +Inf -> 1.
+  expect_identical(out[4L, 3L], 1)
+
+  # Rule 4: a = +Inf, b finite -> Φ(b).
+  expect_equal(out[4L, 2L], stats::pnorm(0), tolerance = 1e-12)
+
+  # Rule 5: b = +Inf, a finite -> Φ(a).
+  expect_equal(out[3L, 3L], stats::pnorm(0.5), tolerance = 1e-12)
+
+  # Rule 6: both finite -> one pbivnorm() call.
+  expect_equal(
+    out[3L, 2L],
+    pbivnorm::pbivnorm(0.5, 0, rho = rho),
+    tolerance = 1e-12
+  )
+
+  # NA rho propagates everywhere (rule 1).
+  out_na_rho <- .corr_bivnorm_cdf_grid(c(-0.5, 0.5), c(-0.5, 0.5), NA_real_)
+  expect_true(all(is.na(out_na_rho)))
+})
+
+test_that(".corr_bivnorm_cdf_grid() matches an element-by-element pbivnorm reference", {
+  tx_full <- c(-1.2, -0.3, 0.4, 1.1)
+  ty_full <- c(-0.8, 0.1, 0.9)
+  rho <- -0.4
+  out <- .corr_bivnorm_cdf_grid(tx_full, ty_full, rho)
+
+  expected <- matrix(NA_real_, length(tx_full), length(ty_full))
+  for (i in seq_along(tx_full)) {
+    for (j in seq_along(ty_full)) {
+      expected[i, j] <- pbivnorm::pbivnorm(
+        tx_full[[i]],
+        ty_full[[j]],
+        rho = rho
+      )
+    }
+  }
+  expect_equal(out, expected, tolerance = 1e-12)
+})
+
+
+# ── .corr_cell_prob_matrix() ──────────────────────────────────────────────────
+
+test_that(".corr_cell_prob_matrix() sums to 1 over all cells when every threshold is finite", {
+  tx_full <- c(-Inf, -0.5, 0.5, Inf) # k_x = 3
+  ty_full <- c(-Inf, 0, Inf) # k_y = 2
+  rho <- 0.35
+  grid <- .corr_bivnorm_cdf_grid(tx_full, ty_full, rho)
+  cell_prob <- .corr_cell_prob_matrix(grid)
+  expect_identical(dim(cell_prob), c(3L, 2L))
+  expect_equal(sum(cell_prob), 1, tolerance = 1e-12)
+})
+
+
+# ── .corr_count_sparse_cells() ────────────────────────────────────────────────
+
+test_that(".corr_count_sparse_cells() matches a scalar per-cell reference on a fixture with one tiny cell", {
+  # Pre-vectorisation reference: one scalar pbivnorm() call per corner.
+  old_bivnorm_cdf <- function(a, b, rho) {
+    if (is.na(a) || is.na(b) || is.na(rho)) {
+      return(NA_real_)
+    }
+    if (is.infinite(a) && a < 0) return(0)
+    if (is.infinite(b) && b < 0) return(0)
+    if (is.infinite(a) && a > 0 && is.infinite(b) && b > 0) return(1)
+    if (is.infinite(a) && a > 0) return(stats::pnorm(b))
+    if (is.infinite(b) && b > 0) return(stats::pnorm(a))
+    pbivnorm::pbivnorm(a, b, rho = rho)
+  }
+  old_count_sparse <- function(rho, cell_counts, thresholds_x, thresholds_y,
+                                tol = 1e-12) {
+    k_x <- nrow(cell_counts)
+    k_y <- ncol(cell_counts)
+    tx_full <- c(-Inf, thresholds_x, Inf)
+    ty_full <- c(-Inf, thresholds_y, Inf)
+    n_sparse <- 0L
+    for (m in seq_len(k_x)) {
+      for (p in seq_len(k_y)) {
+        if (cell_counts[m, p] == 0) {
+          next
+        }
+        p_mp <- old_bivnorm_cdf(tx_full[[m + 1L]], ty_full[[p + 1L]], rho) -
+          old_bivnorm_cdf(tx_full[[m]], ty_full[[p + 1L]], rho) -
+          old_bivnorm_cdf(tx_full[[m + 1L]], ty_full[[p]], rho) +
+          old_bivnorm_cdf(tx_full[[m]], ty_full[[p]], rho)
+        if (is.na(p_mp) || p_mp < tol) {
+          n_sparse <- n_sparse + 1L
+        }
+      }
+    }
+    n_sparse
+  }
+
+  # 2x2 with mass only in the off-diagonal cells; extreme thresholds and a
+  # near-boundary rho drive one cell's modeled probability below tol.
+  cc <- matrix(c(0, 1, 1, 0), nrow = 2)
+  tx <- 4
+  ty <- -4
+  rho <- 0.999999
+
+  expected <- old_count_sparse(rho, cc, tx, ty)
+  actual <- .corr_count_sparse_cells(rho, cc, tx, ty)
+  expect_identical(actual, expected)
+  expect_true(actual >= 1L)
+})
+
+
+# ── refit = TRUE (lean refit mode) ────────────────────────────────────────────
+
+test_that(".corr_polychoric_mle(refit = TRUE) matches refit = FALSE and skips the sparse-cell count", {
+  d <- make_ordinal_pair(rho = 0.4, n = 300, k_x = 3, k_y = 3, seed = 11)
+  w <- rep(1, nrow(d))
+  dom <- rep(1, nrow(d))
+  out_full <- .corr_polychoric_mle(
+    factor(d$x, ordered = TRUE),
+    factor(d$y, ordered = TRUE),
+    w,
+    dom
+  )
+  out_refit <- .corr_polychoric_mle(
+    factor(d$x, ordered = TRUE),
+    factor(d$y, ordered = TRUE),
+    w,
+    dom,
+    refit = TRUE
+  )
+  expect_identical(out_refit$rho, out_full$rho)
+  expect_identical(out_refit$n_sparse_cells, NA_integer_)
+})
+
+test_that(".corr_polyserial_mle(refit = TRUE) matches refit = FALSE, skipping the probe", {
+  d <- make_polyserial_pair(rho = 0.5, n = 500, k_ord = 3, seed = 21)
+  w <- rep(1, nrow(d))
+  dom <- rep(1, nrow(d))
+  out_full <- .corr_polyserial_mle(
+    factor(d$ord, ordered = TRUE),
+    d$cont,
+    w,
+    dom
+  )
+  out_refit <- .corr_polyserial_mle(
+    factor(d$ord, ordered = TRUE),
+    d$cont,
+    w,
+    dom,
+    refit = TRUE
+  )
+  expect_identical(out_refit$rho, out_full$rho)
+})
+
+
+# ── .corr_numerical_influence() delta refit ──────────────────────────────────
+
+test_that(".corr_numerical_influence() delta refit matches a brute-force full rebuild bit-for-bit", {
+  # Brute-force reference: the pre-Step-3 refit loop. For every active row,
+  # rebuild thresholds and cell counts from scratch (full .corr_polychoric_
+  # mle() call) rather than delta-updating the unperturbed setup.
+  brute_force_influence <- function(
+    design,
+    vec_a,
+    vec_b,
+    active_domain,
+    rho_hat_full,
+    eps_pert = 1e-4
+  ) {
+    w_full <- design@data[[design@variables$weights]]
+    active_lgl <- as.logical(active_domain)
+    active_idx <- which(active_lgl)
+    n_active <- length(active_idx)
+    rho_z_full <- atanh(rho_hat_full)
+    ifs <- numeric(n_active)
+    for (k in seq_len(n_active)) {
+      i <- active_idx[[k]]
+      w_pert <- w_full
+      w_pert[[i]] <- w_pert[[i]] * (1 + eps_pert)
+      fit_pert <- .corr_polychoric_mle(
+        vec_a,
+        vec_b,
+        w_pert,
+        active_lgl,
+        x_name = "x",
+        y_name = "y"
+      )
+      rho_z_pert <- atanh(fit_pert$rho)
+      ifs[[k]] <- (rho_z_pert - rho_z_full) / eps_pert
+    }
+    ifs
+  }
+
+  set.seed(51L)
+  n <- 40L
+  wt <- stats::rlnorm(n, sdlog = 0.6)
+  o1 <- factor(sample(1:3, n, replace = TRUE), levels = 1:3, ordered = TRUE)
+  o2 <- factor(sample(1:3, n, replace = TRUE), levels = 1:3, ordered = TRUE)
+
+  # Required edge rows: NA on one margin only, NA on both margins, and a
+  # zero-effective-weight row. Survey weights must be non-negative and
+  # non-zero when non-NA, so a genuine zero-effective-weight row comes from
+  # an NA weight (the NA -> 0 conversion inside `.corr_estimate_thresholds()`
+  # / `.corr_polychoric_mle()`), not a literal `0`.
+  o1[1] <- NA
+  o1[2] <- NA
+  o2[2] <- NA
+  wt[3] <- NA_real_
+
+  df <- data.frame(id = seq_len(n), wt = wt, o1 = o1, o2 = o2)
+  d <- as_survey(df, weights = wt)
+
+  fit_full <- .corr_polychoric_mle(
+    df$o1,
+    df$o2,
+    df$wt,
+    rep(TRUE, n),
+    x_name = "x",
+    y_name = "y"
+  )
+
+  expected <- brute_force_influence(
+    d,
+    df$o1,
+    df$o2,
+    rep(TRUE, n),
+    fit_full$rho
+  )
+  actual <- .corr_numerical_influence(
+    design = d,
+    method = "polychoric",
+    vec_a = df$o1,
+    vec_b = df$o2,
+    active_domain = rep(TRUE, n),
+    rho_hat_full = fit_full$rho
+  )
+  expect_identical(actual, expected)
+})


### PR DESCRIPTION
## What

Fixes #177: `get_corr(method = "polychoric")` was ~247x slower than `polycor::polychor()`; the 6x7 benchmark (n = 300) drops from 29.69 s to 0.99 s (30x) with every reported estimate, SE, and CI bound bit-identical to the previous code.

## How

Three changes, each verified bit-identical in advance (verification record in `plans/implementation-plan-polychoric-performance.md`, Step 0.5):

1. **Vectorised CDF grid** — one `pbivnorm` call per rho over the threshold grid replaces 168 scalar wrapper entries per log-likelihood evaluation (~55% of the run was wrapper entry overhead). The log-likelihood total keeps the original `+=` accumulation order, so `rho` does not move even in the last bit.
2. **Lean refit mode** — the influence and replicate refits read only `$rho`, so `refit = TRUE` (internal argument) skips the 5-point objective probe and the sparse-cell count they discarded.
3. **Delta refit setup** — a perturbation of one weight touches one level sum per margin and one cell; the influence loop now recomputes only those (same members, same order, same accumulation style) instead of rebuilding thresholds and cell counts from all n rows per refit, removing an O(n^2).

The two slow polychoric test files fall from 355.4 s to 77.5 s. No exported signature changes; `.corr_polychoric_loglik()` keeps its pinned contract; no test tolerance was touched. The one snapshot change is the error call name after extracting the shared fit core — message and class unchanged.

Out of scope, tracked as follow-ups per the plan (Step 5): refit dedup by (cell, weight) key, and an analytic influence function (Tier 1).

## Checklist

- [x] Tests written and passing (`devtools::test()` — 9,869 pass, 0 fail)
- [x] R CMD check: 0 errors, 0 warnings (1 note: `.git` file in the worktree checkout — local artifact, absent on CI)
- [x] Roxygen docs updated and `devtools::document()` run (no roxygen content changed; internal helpers use the file's comment-header style)
- [x] `plans/error-messages.md` updated (no new errors or warnings)
- [x] `VENDORED.md` updated (no vendored code)
- [x] PR title is a valid Conventional Commit
- [x] PR targets `develop`, not `main`

Coverage: 96.113% (baseline 96.0938%); `R/analysis-corr-latent.R` at 99.9%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)