### PR TITLE
test(utils): add haven-shaped column fixture builders

### DIFF
--- a/tests/testthat/helper-test-data.R
+++ b/tests/testthat/helper-test-data.R
@@ -4,6 +4,8 @@
 # file runs. Provides:
 #   - make_survey_data()  — synthetic survey data generator
 #   - test_invariants()   — formal invariant checker for survey objects
+#   - make_labelled(), make_labelled_spss(), make_tagged_na() — haven-shaped
+#     column fixtures, built with base R so they need no haven at runtime
 #
 # Dependency note: test_invariants() references S7 class objects
 # (survey_replicate, survey_metadata) and .get_design_vars_flat() from
@@ -550,6 +552,114 @@ make_survey_data <- function(
   }
 
   df
+}
+
+# ------------------------------------------------------------------------------
+# make_labelled(), make_labelled_spss(), make_tagged_na()
+# ------------------------------------------------------------------------------
+
+# The three column-level fixture builders for haven-shaped data. A
+# `haven_labelled` vector is attributes plus a class vector, so base R builds
+# one; `haven` is in Suggests and is not needed to construct a fixture.
+#
+# `make_survey_data(with_labels = TRUE)` cannot serve here. It attaches the
+# `label` and `labels` attributes but never sets a class, so nothing dispatches
+# on the column and the defect under test never fires.
+#
+# `tests/testthat/test-labelled-fixtures.R` pins all three against real `haven`
+# output. Change a builder only together with that file.
+
+#' Build a `haven_labelled` vector with base R
+#'
+#' Returns `x` carrying the value labels, the variable label, and the
+#' three-entry `haven_labelled` class vector. `typeof(x)` supplies the
+#' base-type marker, so double-, integer-, and character-backed columns need no
+#' special case.
+#'
+#' Attributes are attached in `haven`'s own order — `labels`, `label`, `class` —
+#' so the result is `identical()` to `haven::labelled()` output. A `NULL`
+#' argument attaches nothing, matching `haven`, which omits `label` entirely
+#' when no variable label is given.
+#'
+#' @param x      A double, integer, or character vector.
+#' @param labels A named vector of value labels, of the same type as `x`. The
+#'   names are the labels; the values are the codes. `NULL` attaches none.
+#' @param label  A length-1 character variable label, or `NULL` for none.
+#' @return `x` with class `c("haven_labelled", "vctrs_vctr", typeof(x))`.
+#' @keywords internal
+make_labelled <- function(x, labels = NULL, label = NULL) {
+  attr(x, "labels") <- labels
+  attr(x, "label") <- label
+  attr(x, "class") <- c("haven_labelled", "vctrs_vctr", typeof(x))
+  x
+}
+
+#' Build a `haven_labelled_spss` vector with base R
+#'
+#' The SPSS variant of [make_labelled()]. Adds the two SPSS missing-value
+#' attributes and puts `haven_labelled_spss` on the front of the class vector,
+#' which is why one `inherits(x, "haven_labelled")` call catches both shapes.
+#'
+#' Attributes are attached in `haven`'s own order — `labels`, `label`,
+#' `na_values`, `na_range`, `class` — so the result is `identical()` to
+#' `haven::labelled_spss()` output. Either missing-value argument may be `NULL`,
+#' and `NULL` attaches nothing.
+#'
+#' @param x         A double, integer, or character vector.
+#' @param labels    A named vector of value labels, of the same type as `x`.
+#'   `NULL` attaches none.
+#' @param na_values A vector of discrete user-missing codes, of the same type as
+#'   `x`, or `NULL` for none.
+#' @param na_range  A length-2 vector giving an inclusive user-missing range, of
+#'   the same type as `x`, or `NULL` for none.
+#' @param label     A length-1 character variable label, or `NULL` for none.
+#' @return `x` with class `c("haven_labelled_spss", "haven_labelled",
+#'   "vctrs_vctr", typeof(x))`.
+#' @keywords internal
+make_labelled_spss <- function(
+  x,
+  labels = NULL,
+  na_values = NULL,
+  na_range = NULL,
+  label = NULL
+) {
+  attr(x, "labels") <- labels
+  attr(x, "label") <- label
+  attr(x, "na_values") <- na_values
+  attr(x, "na_range") <- na_range
+  attr(x, "class") <- c(
+    "haven_labelled_spss",
+    "haven_labelled",
+    "vctrs_vctr",
+    typeof(x)
+  )
+  x
+}
+
+#' Build a `haven` tagged `NA` with base R
+#'
+#' A tagged `NA` is `NA_real_` with one character written into the unused part
+#' of the `NaN` payload. `haven` stores the tag in byte 5 of the eight-byte
+#' little-endian representation; `NA_real_` itself leaves bytes 5 and 6 zero, so
+#' the write disturbs nothing. The result stays `NA` to base R and reads its tag
+#' back through `haven::na_tag()`.
+#'
+#' `writeBin()` and `readBin()` take an explicit `endian` argument, so the
+#' builder produces the same double on a big-endian platform.
+#'
+#' @param tag A length-1 character string of exactly one character.
+#' @return A length-1 double that is `NA` and carries `tag`.
+#' @keywords internal
+make_tagged_na <- function(tag) {
+  stopifnot(
+    is.character(tag),
+    length(tag) == 1L,
+    !is.na(tag),
+    nchar(tag) == 1L
+  )
+  bytes <- writeBin(NA_real_, raw(), endian = "little")
+  bytes[5L] <- charToRaw(tag)
+  readBin(bytes, "double", n = 1L, endian = "little")
 }
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-labelled-fixtures.R
+++ b/tests/testthat/test-labelled-fixtures.R
@@ -1,0 +1,165 @@
+# tests/testthat/test-labelled-fixtures.R
+#
+# Pins the three haven-shaped column fixture builders in
+# `helper-test-data.R` against real `haven` output.
+#
+# The builders use base R only, because `haven` is in Suggests. That buys the
+# rest of the feature's tests the ability to construct a `haven_labelled`
+# column without `haven` installed, and it costs this file: nothing else proves
+# the hand-built class vectors and the tagged-`NA` byte pattern are the shapes
+# `haven` actually produces. F-3, F-5 and F-6 are that proof, so each carries a
+# block-level `skip_if_not_installed("haven")`. F-1, F-2 and F-4 assert base-R
+# properties of the builder output and need no guard.
+#
+# This file builds no survey design, so it makes no `test_invariants()` call.
+
+# ------------------------------------------------------------------------------
+# make_tagged_na() — base-R properties (F-1, F-2, F-4)
+# ------------------------------------------------------------------------------
+
+# F-1
+test_that("make_tagged_na() returns a value that base R reads as NA", {
+  expect_true(is.na(make_tagged_na("a")))
+})
+
+# F-2
+test_that("make_tagged_na() returns a length-1 double", {
+  result <- make_tagged_na("a")
+
+  expect_identical(typeof(result), "double")
+  expect_identical(length(result), 1L)
+})
+
+# F-4
+test_that("make_tagged_na() gives different tags different byte patterns", {
+  # `identical()` folds every NaN payload together under its default
+  # `single.NA = TRUE`, so two differently tagged NAs compare equal there.
+  # `single.NA = FALSE` is the setting that looks at the payload.
+  expect_false(
+    identical(make_tagged_na("a"), make_tagged_na("b"), single.NA = FALSE)
+  )
+  expect_identical(
+    writeBin(make_tagged_na("a"), raw(), endian = "little")[5L],
+    charToRaw("a")
+  )
+  expect_identical(
+    writeBin(make_tagged_na("b"), raw(), endian = "little")[5L],
+    charToRaw("b")
+  )
+})
+
+# ------------------------------------------------------------------------------
+# make_tagged_na() — pinned against haven (F-3)
+# ------------------------------------------------------------------------------
+
+# F-3
+test_that("make_tagged_na() output is identical to haven::tagged_na() output", {
+  skip_if_not_installed("haven")
+
+  expect_identical(haven::na_tag(make_tagged_na("a")), "a")
+  expect_identical(haven::na_tag(make_tagged_na("z")), "z")
+
+  # `expect_identical()` cannot see a NaN payload (see F-4), so compare the
+  # eight bytes directly. That is the check that pins the builder to `haven`.
+  expect_identical(
+    writeBin(make_tagged_na("a"), raw(), endian = "little"),
+    writeBin(haven::tagged_na("a"), raw(), endian = "little")
+  )
+  expect_identical(
+    writeBin(make_tagged_na("z"), raw(), endian = "little"),
+    writeBin(haven::tagged_na("z"), raw(), endian = "little")
+  )
+})
+
+# ------------------------------------------------------------------------------
+# make_labelled() — pinned against haven (F-5)
+# ------------------------------------------------------------------------------
+
+# F-5
+test_that("make_labelled() output is identical to haven::labelled() output", {
+  skip_if_not_installed("haven")
+
+  expect_identical(
+    make_labelled(
+      c(1, 2, 3),
+      labels = c(Low = 1, High = 3),
+      label = "Agreement"
+    ),
+    haven::labelled(
+      c(1, 2, 3),
+      labels = c(Low = 1, High = 3),
+      label = "Agreement"
+    )
+  )
+
+  expect_identical(
+    make_labelled(c(1L, 2L, 3L), labels = c(Low = 1L, High = 3L)),
+    haven::labelled(c(1L, 2L, 3L), labels = c(Low = 1L, High = 3L))
+  )
+
+  expect_identical(
+    make_labelled(c("a", "b"), labels = c(Alpha = "a"), label = "Letter"),
+    haven::labelled(c("a", "b"), labels = c(Alpha = "a"), label = "Letter")
+  )
+
+  expect_identical(
+    make_labelled(c(1, 2), labels = c(One = 1)),
+    haven::labelled(c(1, 2), labels = c(One = 1))
+  )
+})
+
+# ------------------------------------------------------------------------------
+# make_labelled_spss() — pinned against haven (F-6)
+# ------------------------------------------------------------------------------
+
+# F-6
+test_that("make_labelled_spss() matches haven::labelled_spss() output", {
+  skip_if_not_installed("haven")
+
+  expect_identical(
+    make_labelled_spss(
+      c(1, 2, 99),
+      labels = c(Low = 1, High = 2, Refused = 99),
+      na_values = 99,
+      label = "Agreement"
+    ),
+    haven::labelled_spss(
+      c(1, 2, 99),
+      labels = c(Low = 1, High = 2, Refused = 99),
+      na_values = 99,
+      label = "Agreement"
+    )
+  )
+
+  expect_identical(
+    make_labelled_spss(
+      c(1, 2, 98),
+      labels = c(Low = 1, High = 2),
+      na_range = c(90, 99),
+      label = "Agreement"
+    ),
+    haven::labelled_spss(
+      c(1, 2, 98),
+      labels = c(Low = 1, High = 2),
+      na_range = c(90, 99),
+      label = "Agreement"
+    )
+  )
+
+  expect_identical(
+    make_labelled_spss(
+      c(1, 98, 99),
+      labels = c(Low = 1),
+      na_values = 99,
+      na_range = c(90, 98),
+      label = "Agreement"
+    ),
+    haven::labelled_spss(
+      c(1, 98, 99),
+      labels = c(Low = 1),
+      na_values = 99,
+      na_range = c(90, 98),
+      label = "Agreement"
+    )
+  )
+})


### PR DESCRIPTION
## Summary

This PR adds three fixture builders to `tests/testthat/helper-test-data.R` — `make_labelled()`, `make_labelled_spss()` and `make_tagged_na()` — and a new test file `tests/testthat/test-labelled-fixtures.R` holding rows F-1 to F-6.

The builders construct `haven`-shaped columns with base R, so tests can use them when `haven` is absent. `haven` is in `Suggests`, not `Imports`. `make_survey_data(with_labels = TRUE)` cannot serve, because it attaches the label attributes without ever setting a class.

F-5 and F-6 pin the builders against real `haven` output with `identical()`, guarded by `skip_if_not_installed("haven")`, so the hand-written class vectors cannot drift from what `haven` produces.

## Scope

Two files, 275 insertions, 0 deletions. No `R/` file, `NAMESPACE`, `DESCRIPTION` or `man/` page changes.

This is the first of nine PRs implementing `plans/implementation-plan-haven-labelled.md`.

## Test results

Six blocks, 17 expectations, all passing. `haven` 2.5.5 is installed here, so the three guarded rows ran rather than skipped.

| Measure | Baseline `0be2f3a` | This tree |
|---|---|---|
| failures | 0 | 0 |
| passes | 10008 | 10025 |
| warnings | 256 | 256 |
| skips | 4 | 4 |

`devtools::check()`: 0 errors, 0 warnings, 1 note. The note is `checking for hidden files and directories ... .git`, which comes from running `check()` inside a git worktree. CI does not report it.

`pkgdown::check_pkgdown()`: no problems found.

## Spec coverage

See `review.md` — verdict PASS. The write surface touches none of the spec's write surface, and all six test-spec §2.2 rows exist and pass.

## Artifacts

- Implementation: `.surveycore-workspace/runs/2026-08-27-haven-labelled/prs/pr-1-haven-labelled-fixtures/implementation.md`
- Audit: `.surveycore-workspace/runs/2026-08-27-haven-labelled/prs/pr-1-haven-labelled-fixtures/audit.md`
- Review: `.surveycore-workspace/runs/2026-08-27-haven-labelled/prs/pr-1-haven-labelled-fixtures/review.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)