### PR TITLE
test(metadata): guard the var_extra grep audit on source files, not the directory

### DIFF
--- a/tests/testthat/test-metadata-system.R
+++ b/tests/testthat/test-metadata-system.R
@@ -2933,11 +2933,18 @@ test_that("grep audit: @var_extra contents are read/written only by the intended
   # promotion block), and core-validators.R (.rename_metadata_keys()/
   # .delete_metadata_col()). No other file in R/ reads or branches on its
   # contents.
+  # Guard on source files, not on the directory. Under covr the package
+  # installs into a temporary library and the tests run from
+  # <lib>/surveycore/surveycore-tests/testthat, so "../../R" resolves to
+  # <lib>/surveycore/R. That directory exists, but it holds the lazy-load
+  # database rather than .R files, so dir.exists() is TRUE and the grep
+  # finds nothing. list.files() on a missing directory returns character(0)
+  # without erroring, so no dir.exists() call is needed.
   r_dir <- testthat::test_path("..", "..", "R")
-  if (!dir.exists(r_dir)) {
+  r_files <- list.files(r_dir, pattern = "\\.R$", full.names = TRUE)
+  if (length(r_files) == 0L) {
     skip("R/ source tree not available (installed-package test layout)")
   }
-  r_files <- list.files(r_dir, pattern = "\\.R$", full.names = TRUE)
   hits <- vapply(
     r_files,
     function(f) any(grepl("var_extra", readLines(f, warn = FALSE))),


### PR DESCRIPTION
## What was broken

`covr::package_coverage()` produced no figure for this package. The `var_extra` grep audit in `tests/testthat/test-metadata-system.R` failed under instrumentation, and `covr` halts on a test failure, so the whole run aborted:

```
[ FAIL 1 | WARN 256 | SKIP 4 | PASS 10024 ]
Error:
! Test failures.
```

The failure:

```
── Failure ('test-metadata-system.R:2947'): grep audit: @var_extra contents ...
Expected `hit_basenames` to have the same values as
  c("core-classes.R", "core-metadata.R", "core-validators.R").
Actual:
Absent: "core-classes.R", "core-metadata.R", "core-validators.R"
```

## Why

The test's own skip guard tested the wrong condition:

```r
r_dir <- testthat::test_path("..", "..", "R")
if (!dir.exists(r_dir)) {
  skip("R/ source tree not available (installed-package test layout)")
}
r_files <- list.files(r_dir, pattern = "\.R$", full.names = TRUE)
```

`covr` installs the package into a temporary library and runs the tests from `<lib>/surveycore/surveycore-tests/testthat`. So `../../R` resolves to `<lib>/surveycore/R` — a directory that **does** exist, but which holds the lazy-load database (`surveycore.rdb`, `surveycore.rdx`) rather than `.R` source files.

`dir.exists()` was therefore `TRUE`, the skip never fired, `list.files()` matched no `.R` file, and `expect_setequal()` compared three expected basenames against `character(0)`.

## The change

Move the check after `list.files()` and test for source files:

```r
r_files <- list.files(r_dir, pattern = "\.R$", full.names = TRUE)
if (length(r_files) == 0L) {
  skip("R/ source tree not available (installed-package test layout)")
}
```

`list.files()` on a missing directory returns `character(0)` without erroring, so the `dir.exists()` call was redundant as well as wrong. A comment above the guard records the `covr` layout that defeated the old check, so the next reader does not restore it.

## Verification

| Check | Result |
|---|---|
| `covr::package_coverage()` | **96.1543%** — was `! Test failures.` |
| `test_local(filter = "metadata-system")` | all blocks pass, `R/` present so the audit still runs |
| `air` on the changed block | byte-identical; longest added line 75 chars |
| Write surface | one file, 9 insertions, 2 deletions |

The audit still does its job: with `R/` present the guard does not fire and the grep runs as before. It now skips where it always intended to.

## Scope

One test file. No `R/`, `NAMESPACE`, `DESCRIPTION` or `man/` change.

`air format` also wanted to rewrite about 45 lines of pre-existing over-length code from #185 elsewhere in this file. Those are left alone — `.claude/rules/code-style.md` keeps reformat-only changes in their own commit.

Found while running the Step 0 baseline for `plans/implementation-plan-haven-labelled.md`, whose gate 6 sets a coverage floor that could not be measured until this was fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)