### PR TITLE
refactor(analysis): route the runtime haven check through .haven_available()

### DIFF
--- a/R/analysis-helpers.R
+++ b/R/analysis-helpers.R
@@ -5,6 +5,7 @@
 # functions live at the top of their respective source files.
 #
 # Contents:
+#   .haven_available()      — is the haven namespace installed?
 #   Meta-key constants (six character vectors)
 #   .extract_var_meta()     — variable/value label lookup for one variable
 #   .build_group_meta()     — metadata lookup for all group variables
@@ -86,6 +87,16 @@
 #'
 #' @noRd
 NULL
+
+
+# ── haven availability ────────────────────────────────────────────────────────
+
+# Is the haven namespace available? Wrapped in a helper so tests can stub it.
+# Behaviour is identical to calling requireNamespace() inline.
+#' @noRd
+.haven_available <- function() {
+  requireNamespace("haven", quietly = TRUE)
+}
 
 
 # ── Meta-key constants ────────────────────────────────────────────────────────
@@ -240,7 +251,7 @@ ANOVA_META_KEYS <- c("model", "method", "test", "terms")
       # Build a map from haven tagged-NA tag character to label string.
       # Requires haven at runtime; falls back gracefully when not installed:
       # tagged NAs without a resolvable tag remain NA in the factor output.
-      haven_ok <- requireNamespace("haven", quietly = TRUE)
+      haven_ok <- .haven_available()
       # Tagged NAs are always doubles (special NaN bit patterns). Build a map
       # from tag character to label string by checking double NA entries in
       # labels. Non-double NA entries (integer NA, etc.) are plain NAs.

--- a/tests/testthat/test-analysis-helpers.R
+++ b/tests/testthat/test-analysis-helpers.R
@@ -1715,3 +1715,88 @@ test_that(".make_result_tibble() computes p = nrow * length(estimate_cols) for d
   expect_equal(df_val, rep(Inf, 2L))
   expect_length(df_val, 2L)
 })
+
+
+# ── Category 15: .haven_available() stubbing ─────────────────────────────────
+
+# `haven` is in Suggests, so `.apply_group_labels()` asks whether the namespace
+# is there before it resolves a tagged `NA` to its label. The question goes
+# through `.haven_available()`, a named binding, so these rows can stub both
+# answers with `local_mocked_bindings()`. An inline `requireNamespace()` call
+# cannot be stubbed, which left the unavailable branch unreachable.
+# The fixtures reuse `.make_label_test_design()` from Category 13.
+
+test_that(".apply_group_labels() resolves a tagged-NA label when haven is available", {
+  skip_if_not_installed("haven")
+  local_mocked_bindings(.haven_available = function() TRUE)
+  tagged_r <- make_tagged_na("r")
+  labels_vec <- c("GroupA" = 1, "GroupB" = 2, "Refused" = tagged_r)
+  design <- .make_label_test_design(
+    extra_col = c(1, 2, tagged_r),
+    extra_labels = labels_vec,
+    col_name = "grp_stub_true"
+  )
+  gc <- data.frame(grp_stub_true = c(1, 2, tagged_r))
+  result <- .apply_group_labels(
+    gc,
+    "grp_stub_true",
+    design,
+    label_values = TRUE
+  )
+  expect_true(is.factor(result$grp_stub_true))
+  expect_true("Refused" %in% levels(result$grp_stub_true))
+  expect_identical(
+    as.character(result$grp_stub_true),
+    c("GroupA", "GroupB", "Refused")
+  )
+})
+
+test_that(".apply_group_labels() leaves a tagged NA unresolved when haven is unavailable", {
+  local_mocked_bindings(.haven_available = function() FALSE)
+  tagged_r <- make_tagged_na("r")
+  labels_vec <- c("GroupA" = 1, "GroupB" = 2, "Refused" = tagged_r)
+  design <- .make_label_test_design(
+    extra_col = c(1, 2, tagged_r),
+    extra_labels = labels_vec,
+    col_name = "grp_stub_false"
+  )
+  gc <- data.frame(grp_stub_false = c(1, 2, tagged_r))
+  expect_no_error(
+    result <- .apply_group_labels(
+      gc,
+      "grp_stub_false",
+      design,
+      label_values = TRUE
+    )
+  )
+  expect_true(is.factor(result$grp_stub_false))
+  # The tagged-NA row carries no group, and "Refused" is not a level.
+  expect_true(is.na(result$grp_stub_false[[3L]]))
+  expect_identical(levels(result$grp_stub_false), c("GroupA", "GroupB"))
+  # Every label that is not a tagged NA still resolves.
+  expect_identical(
+    as.character(result$grp_stub_false[1:2]),
+    c("GroupA", "GroupB")
+  )
+})
+
+test_that(".apply_group_labels() gives one result for both haven answers when no tagged NA is present", {
+  labels_vec <- c("GroupA" = 1L, "GroupB" = 2L)
+  design <- .make_label_test_design(
+    extra_col = c(1L, 2L),
+    extra_labels = labels_vec,
+    col_name = "grp_stub_both"
+  )
+  gc <- data.frame(grp_stub_both = c(1L, 2L))
+  label_with_stub <- function(available) {
+    local_mocked_bindings(.haven_available = function() available)
+    .apply_group_labels(gc, "grp_stub_both", design, label_values = TRUE)
+  }
+  result_available <- label_with_stub(TRUE)
+  result_unavailable <- label_with_stub(FALSE)
+  expect_identical(result_available, result_unavailable)
+  expect_identical(
+    as.character(result_available$grp_stub_both),
+    c("GroupA", "GroupB")
+  )
+})


### PR DESCRIPTION
## Summary

This is a refactor with no behavioural change.

`R/analysis-helpers.R` held an inline `requireNamespace("haven", quietly = TRUE)` whose result decided whether tagged-`NA` labels could be resolved. No test could stub an inline call, so the branch taken when `haven` is absent was unreachable in tests and therefore unverified. `haven` is in `Suggests`, not `Imports`, so that branch runs for any user without `haven` installed.

The check now goes through a named top-level `.haven_available()`, which `testthat::local_mocked_bindings()` can stub. The three sites that read `haven_ok` are unchanged in text and polarity. `R/` still contains exactly one `requireNamespace("haven"` call, now inside the helper.

## Tests

Three rows follow, in `tests/testthat/test-analysis-helpers.R`:

| Row | What it pins |
|---|---|
| H-1 | availability stubbed `TRUE` with `haven` installed — the tagged-`NA` label appears as a factor level |
| H-2 | availability stubbed `FALSE` — no error, tagged-`NA` rows carry an `NA` group, every non-tagged label still resolves |
| H-3 | with no tagged `NA` present, the result is identical under both stub values |

The three rows failed before the change, with `Can't find binding for .haven_available`. The seven pre-existing tagged-`NA` test blocks pass unmoved.

## Verification

| Measure | Before | After |
|---|---|---|
| failures | 0 | 0 |
| passes | 10025 | 10035 |
| coverage | 96.1543% | 96.16% |

`devtools::check()`: 0 errors, 0 warnings, 2 non-blocking notes. `pkgdown::check_pkgdown()`: clean.

## Scope

Two files: `R/analysis-helpers.R`, `tests/testthat/test-analysis-helpers.R`. No `DESCRIPTION`, `NAMESPACE`, `man/` or snapshot change.

Second of nine PRs implementing `plans/implementation-plan-haven-labelled.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
