### PR TITLE
fix(conversion): store real column names in the survey call so the round trip works

### DIFF
--- a/R/methods-conversion.R
+++ b/R/methods-conversion.R
@@ -102,14 +102,24 @@ as_svydesign <- function(x) {
     ~1
   }
 
-  survey::svydesign(
-    ids = ids_formula,
-    strata = .to_formula(strata_var),
-    weights = .to_formula(weights_var),
-    fpc = .to_formula(fpc_var),
+  # Inline the formulas into the call rather than passing the variables that
+  # hold them. survey::svydesign() stores its own call, and R records the
+  # unevaluated argument expressions there. Passing `ids = ids_formula` records
+  # the symbol `ids_formula`, and passing `strata = .to_formula(strata_var)`
+  # records that call. from_svydesign() reads those back with all.vars(), which
+  # then yields "ids_formula" and "strata_var" instead of the column names, and
+  # the design fails to rebuild. bquote() substitutes the formula objects
+  # themselves, so the stored call names real columns and the round trip works.
+  # `data` is left as an expression on purpose: it is not read back, and
+  # inlining a whole data frame into a stored call is wasteful.
+  eval(bquote(survey::svydesign(
+    ids = .(ids_formula),
+    strata = .(.to_formula(strata_var)),
+    weights = .(.to_formula(weights_var)),
+    fpc = .(.to_formula(fpc_var)),
     data = x@data,
-    nest = isTRUE(x@variables$nest)
-  )
+    nest = .(isTRUE(x@variables$nest))
+  )))
 }
 
 

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -785,3 +785,79 @@ test_that("from_svydesign() warns surveycore_warning_twophase_method_unknown for
   expect_true(S7::S7_inherits(d, survey_twophase))
   expect_identical(d@variables$method, "approx")
 })
+
+
+# ── Round trip through the survey package ────────────────────────────────────
+#
+# as_svydesign() builds a survey::svydesign() object, and survey stores its own
+# call. R records the unevaluated argument expressions there, so passing a
+# variable that holds a formula recorded the variable's name rather than the
+# formula. from_svydesign() reads those back with all.vars() to recover the
+# design column names, so every Taylor design failed to rebuild. These rows
+# pin the repair.
+
+test_that("from_svydesign() rebuilds a Taylor design that as_svydesign() made", {
+  skip_if_not_installed("survey")
+  df <- make_survey_data(seed = 3L)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc)
+
+  back <- from_svydesign(as_svydesign(d))
+
+  expect_identical(back@variables$ids, d@variables$ids)
+  expect_identical(back@variables$strata, d@variables$strata)
+  expect_identical(back@variables$weights, d@variables$weights)
+  expect_identical(back@variables$fpc, d@variables$fpc)
+})
+
+test_that("the survey round trip preserves the estimate and its standard error", {
+  skip_if_not_installed("survey")
+  df <- make_survey_data(seed = 3L)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata, fpc = fpc)
+
+  back <- from_svydesign(as_svydesign(d))
+  before <- suppressWarnings(get_means(d, y1, variance = "se"))
+  after <- suppressWarnings(get_means(back, y1, variance = "se"))
+
+  expect_equal(after$mean, before$mean, tolerance = 0)
+  expect_equal(after$se, before$se, tolerance = 0)
+})
+
+test_that("the survey round trip works for every Taylor design shape", {
+  skip_if_not_installed("survey")
+  df <- make_survey_data(seed = 4L)
+  # A constant FPC. make_survey_data() varies fpc by PSU, which makes survey
+  # warn that it varies within a stratum. That warning is about the fixture,
+  # not about the round trip under test.
+  df$fpc_const <- 1000
+
+  shapes <- list(
+    ids_only = as_survey(df, ids = psu, weights = wt),
+    with_strata = as_survey(df, ids = psu, weights = wt, strata = strata),
+    with_fpc = as_survey(df, ids = psu, weights = wt, fpc = fpc_const),
+    srs = as_survey(df, weights = wt)
+  )
+
+  for (nm in names(shapes)) {
+    back <- from_svydesign(as_svydesign(shapes[[nm]]))
+    expect_identical(
+      back@variables$weights,
+      shapes[[nm]]@variables$weights,
+      label = paste("shape:", nm)
+    )
+  }
+})
+
+test_that("as_svydesign() stores a call naming real columns, not local variables", {
+  skip_if_not_installed("survey")
+  df <- make_survey_data(seed = 5L)
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+
+  sv <- as_svydesign(d)
+
+  # The regression this guards: these read "ids_formula" and "strata_var"
+  # before the fix, because R recorded the argument expressions rather than
+  # the formulas they evaluated to.
+  expect_identical(all.vars(sv$call$ids), "psu")
+  expect_identical(all.vars(sv$call$strata), "strata")
+  expect_identical(all.vars(sv$call$weights), "wt")
+})


### PR DESCRIPTION
## What was broken

`from_svydesign(as_svydesign(d))` aborted for **every Taylor design**, labelled columns or not:

```
ABORTS: surveycore_error_design_var_missing
✖ Design variable(s) not found in `data`: ids_formula, weights_var,
  strata_var, and fpc_var
```

Those are names of local variables inside `.as_svydesign_taylor()`, not columns of anyone's data.

## Why

`survey::svydesign()` stores its own call, and R records the **unevaluated** argument expressions there. The helper passed:

```r
survey::svydesign(
  ids = ids_formula,
  strata = .to_formula(strata_var),
  ...
)
```

so the stored call held the symbol `ids_formula` and the unevaluated call `.to_formula(strata_var)`. `from_svydesign()` reads those back at `R/methods-conversion.R:393` with `.vars_from_formula()`, which is `all.vars()`. That returns `"ids_formula"` and `"strata_var"` — treated as column names, and no such column exists.

A user's own `survey::svydesign(ids = ~psu, ...)` records a real formula and reads back fine, so the defect was on the write side only.

## The change

`eval(bquote(...))` substitutes the formula objects into the call before evaluating it, so the stored call names real columns.

`data` is deliberately left as an expression: `from_svydesign()` does not read it back, and inlining a whole data frame into a stored call is wasteful.

## Measured, before and after

| Taylor shape | Before | After |
|---|---|---|
| ids only | aborts | round trips |
| with strata | aborts | round trips |
| with fpc | aborts | round trips |
| SRS, no ids | aborts | round trips |

The design variables come back identical — `psu → psu`, `strata → strata`, `wt → wt`, `fpc → fpc` — and so do the point estimate and the standard error.

**Replicate designs were never affected.** `.from_svydesign_replicate()` recovers its columns from `colnames(x$repweights)` and value matching, not from the stored call.

## Tests

Four rows in `tests/testthat/test-conversion.R`, all guarded with `skip_if_not_installed("survey")`. One pins the defect rather than the symptom:

```r
expect_identical(all.vars(sv$call$ids), "psu")
```

That read `"ids_formula"` before this change. A row that only checks the round trip succeeds would pass again if the stored call broke but some other route happened to rebuild the design.

## Verification

| Measure | Before | After |
|---|---|---|
| failures | 0 | 0 |
| passes | 10630 | 10643 |
| warnings | 256 | 256 |
| skips | 4 | 4 |
| `check()` | 0 errors, 0 warnings | 0 errors, 0 warnings |

Two files. No `DESCRIPTION`, `NAMESPACE` or `man/` change.

Found while implementing `plans/implementation-plan-haven-labelled.md` PR 5, whose row C-7 asserts this round trip. The defect predates that work and is unrelated to `haven_labelled` columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)