### PR TITLE
fix(conversion): capture haven metadata on the from_svydesign() routes

### DIFF
--- a/R/methods-conversion.R
+++ b/R/methods-conversion.R
@@ -40,7 +40,10 @@
 #'
 #' @param x A `survey_taylor`, `survey_replicate`, or `survey_twophase` object.
 #' @return A `survey::svydesign`, `survey::svrepdesign`, or `survey::twophase`
-#'   object.
+#'   object. Value labels are not carried into the returned object — the
+#'   `survey` package has no metadata system. To read the data back with
+#'   `haven`-style classes rebuilt, use `survey_data(x, haven_class = TRUE)` on
+#'   the surveycore design instead.
 #'
 #' @examples
 #' d <- as_survey(
@@ -213,7 +216,10 @@ as_svydesign <- function(x) {
 #'
 #' @param x A `survey_taylor`, `survey_replicate`, or `survey_twophase` object.
 #'   `survey_nonprob` is not supported and will error.
-#' @return A `srvyr::tbl_svy` object.
+#' @return A `srvyr::tbl_svy` object. Value labels are not carried into the
+#'   returned object — the `survey` package has no metadata system. To read the
+#'   data back with `haven`-style classes rebuilt, use
+#'   `survey_data(x, haven_class = TRUE)` on the surveycore design instead.
 #'
 #' @examples
 #' d <- as_survey(
@@ -389,7 +395,7 @@ from_svydesign <- function(x) {
 # svydesign / tbl_svy → survey_taylor
 #' @noRd
 .from_svydesign_taylor <- function(x) {
-  data <- as.data.frame(x$variables)
+  data <- .strip_labelled_columns(as.data.frame(x$variables))
 
   # tbl_svy stores its call as srvyr's quoteless_text (not a language object).
   # Use tryCatch so atomic / non-language calls degrade to NULL gracefully.
@@ -426,7 +432,7 @@ from_svydesign <- function(x) {
   survey_taylor(
     data = data,
     variables = variables,
-    metadata = survey_metadata()
+    metadata = .extract_haven_metadata(data)
   )
 }
 
@@ -434,7 +440,7 @@ from_svydesign <- function(x) {
 # svyrep.design → survey_replicate
 #' @noRd
 .from_svydesign_replicate <- function(x) {
-  data <- as.data.frame(x$variables)
+  data <- .strip_labelled_columns(as.data.frame(x$variables))
   rep_cols <- colnames(x$repweights)
 
   # Weight column: find by matching pweights to data columns.
@@ -460,7 +466,7 @@ from_svydesign <- function(x) {
   survey_replicate(
     data = data,
     variables = variables,
-    metadata = survey_metadata()
+    metadata = .extract_haven_metadata(data)
   )
 }
 
@@ -512,7 +518,7 @@ from_svydesign <- function(x) {
   survey_twophase(
     data = phase1_data,
     variables = variables,
-    metadata = survey_metadata()
+    metadata = phase1_sc@metadata
   )
 }
 

--- a/man/as_svydesign.Rd
+++ b/man/as_svydesign.Rd
@@ -11,7 +11,10 @@ as_svydesign(x)
 }
 \value{
 A \code{survey::svydesign}, \code{survey::svrepdesign}, or \code{survey::twophase}
-object.
+object. Value labels are not carried into the returned object — the
+\code{survey} package has no metadata system. To read the data back with
+\code{haven}-style classes rebuilt, use \code{survey_data(x, haven_class = TRUE)} on
+the surveycore design instead.
 }
 \description{
 Converts a \code{survey_taylor}, \code{survey_replicate}, or \code{survey_twophase} object

--- a/man/as_tbl_svy.Rd
+++ b/man/as_tbl_svy.Rd
@@ -11,7 +11,10 @@ as_tbl_svy(x)
 \code{survey_nonprob} is not supported and will error.}
 }
 \value{
-A \code{srvyr::tbl_svy} object.
+A \code{srvyr::tbl_svy} object. Value labels are not carried into the
+returned object — the \code{survey} package has no metadata system. To read the
+data back with \code{haven}-style classes rebuilt, use
+\code{survey_data(x, haven_class = TRUE)} on the surveycore design instead.
 }
 \description{
 Converts a surveycore design object to an \code{srvyr} \code{tbl_svy} by first

--- a/plans/test-spec-haven-labelled.md
+++ b/plans/test-spec-haven-labelled.md
@@ -447,15 +447,34 @@ and the data-frame mode only when the mode changes what the row asserts.
 
 | Row | Scenario | Modes | Why |
 |---|---|---|---|
-| M-1 | `set_val_labels()` on a labelled column | **both** | The two modes are fixed by different mechanisms and take different code paths: the survey mode is fixed because the class is gone from storage, the data-frame mode is fixed inside the validation itself. A data frame is never normalised, so the frame row cannot be inferred from the survey row. This currently fails in both modes. |
+| M-1 | `set_val_labels()` on a labelled column | **both** | The two modes are fixed by different mechanisms and take different code paths: the survey mode is fixed because the class is gone from storage, the data-frame mode is fixed inside the validation itself. A data frame is never normalised, so the frame row cannot be inferred from the survey row. **Corrected 2026-09-01: this fails in the data-frame mode only.** The survey mode was fixed by the property setter that landed earlier in this feature, so by the time the frame fix is written the survey row is already green. Run both modes regardless — the Modes column governs which modes a row runs in, not which were red. |
 | M-2 | `set_val_labels()` on a labelled column where a code in the data has no label | **both** | Must still raise `surveycore_warning_missing_labels`. This warning is newly reachable, because the validation no longer aborts before it. Use `expect_warning(result <- ..., class = ...)`. |
-| M-3 | `extract_val_labels()` on a labelled column | **both** | The row asserts a value read back out of storage, and the two modes store it in different places |
+| M-3 | `extract_val_labels()` on a labelled column | **both** | The row asserts a value read back out of storage, and the two modes store it in different places. The same caution as M-1 applies: the survey mode may already be green when the frame fix is written. |
 | M-4 | `set_var_label()` then `extract_var_label()` on a labelled column | survey only | Passes today in both modes and neither path is touched. One mode is enough. |
 | M-5 | `extract_metadata()` on a labelled column | survey only | Same reasoning |
 | M-6 | `extract_missing_codes()`, `extract_higher_is()`, `extract_question_preface()`, `extract_var_note()` on a labelled column | survey only | Same reasoning. One block may cover all four. |
 | M-7 | `classify_question_type()` on labelled columns | survey only | Never reads a column value or class; its answer cannot change |
 | M-8 | A labelled SPSS column: after construction, read `na_values` and `na_range` back from the stored column | survey only | The frame mode does not store anything |
 | M-9 | `set_val_labels()` on a plain column | survey only | Regression fence: the fix must not change the plain path |
+
+**Note on the M-row red runs, corrected 2026-09-01.** The M-1 note originally
+said the row "currently fails in both modes". Measured on `develop` at
+`b7f8b45`, it failed in the **data-frame mode only** — four errors, all
+`vctrs_error_cast`. Three parties measured this independently and agreed: the
+builder, the tester, and the reviewer, the last from source.
+
+The reason is the same one that makes §4.11a's list unreliable. This document
+was written against `cf6f153`, before the feature split into nine PRs. The
+property setter on the design's `data` fixed the survey mode several merges
+before the one-line validation fix closed the frame mode, so by the time the
+M rows were written the survey mode was already green.
+
+**This does not change which modes a row runs in.** The Modes column still
+governs that, and the both-modes rule in
+`.claude/rules/testing-surveycore.md` is why: the two modes are fixed by
+different mechanisms on different code paths, and neither can be inferred
+from the other. A row being already green is not a reason to drop its
+variant.
 
 ### 4.7 Conversion round trips
 

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -1068,15 +1068,12 @@ test_that("as_survey() to as_svydesign() to from_svydesign() keeps the labels", 
   sv <- as_svydesign(d1)
   expect_identical(labelled_cols(sv$variables), character(0))
 
-  # The return leg aborts for a reason that has nothing to do with labels.
-  # `.as_svydesign_taylor()` calls `survey::svydesign(ids = ids_formula, ...)`,
-  # so `survey` records the local variable names in `$call`. `from_svydesign()`
-  # then reads those names back as design variables and the validator raises
-  # `surveycore_error_design_var_missing`. The defect predates this change and
-  # fires on an unlabelled frame too. Repairing it is a behavioural change to
-  # `as_svydesign()` that the spec does not authorise, so it is on HOLD.
-  skip("HOLD: as_svydesign() to from_svydesign() aborts, unrelated to labels.")
-
+  # The return leg used to abort for a reason unrelated to labels: `survey`
+  # recorded the local variable names in `$call`, so `from_svydesign()` read
+  # them back as design variables and raised
+  # `surveycore_error_design_var_missing`. Fixed separately in #195, which
+  # inlines the formulas into the stored call. This row asserts the whole
+  # round trip now.
   d2 <- from_svydesign(sv)
 
   expect_identical(labelled_cols(d2@data), character(0))

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -861,3 +861,267 @@ test_that("as_svydesign() stores a call naming real columns, not local variables
   expect_identical(all.vars(sv$call$strata), "strata")
   expect_identical(all.vars(sv$call$weights), "wt")
 })
+
+
+# ── C-0–C-9. haven-labelled data on the conversion routes ────────────────────
+#
+# Gate 10 (spec section XI.10): `@metadata@value_labels` is populated on every
+# route that builds a design from a frame carrying a `labels` attribute,
+# `from_svydesign()` included. C-3, C-5 and C-6 are the proof.
+#
+# `make_labelled()` is in `tests/testthat/helper-test-data.R`. It builds the
+# `haven_labelled` class vector with base R, so `haven` stays in Suggests.
+
+# A source frame with two labelled analysis columns and a plain weight.
+make_labelled_frame <- function(n = 40L, seed = 42L) {
+  set.seed(seed)
+  df <- data.frame(
+    psu = rep(seq_len(10L), each = n %/% 10L),
+    strata = rep(1:2, each = n %/% 2L),
+    wt = runif(n, 1, 3)
+  )
+  df$y1 <- make_labelled(rnorm(n), label = "Outcome variable 1")
+  df$y3 <- make_labelled(
+    rep(c(0, 1), n %/% 2L),
+    labels = c("No" = 0, "Yes" = 1),
+    label = "Outcome variable 3"
+  )
+  df
+}
+
+# Names of the columns of `data` that still carry the labelled class.
+labelled_cols <- function(data) {
+  names(data)[vapply(data, inherits, logical(1L), "haven_labelled")]
+}
+
+# The value labels y3 carries in every fixture below.
+y3_labels <- c("No" = 0, "Yes" = 1)
+
+
+# C-0. get_means(label_vars = TRUE) over a from_svydesign() design shows the
+#      variable label rather than the raw column name.
+test_that("get_means() on a from_svydesign() design reports the variable label", {
+  skip_if_not_installed("survey")
+  df <- make_labelled_frame()
+  sv <- survey::svydesign(
+    ids = ~psu,
+    weights = ~wt,
+    strata = ~strata,
+    data = df
+  )
+  d <- from_svydesign(sv)
+
+  res <- get_means(d, y1, variance = "se", label_vars = TRUE)
+  shown <- attr(res, ".meta")$x$y1$variable_label
+
+  expect_identical(shown, "Outcome variable 1")
+  expect_false(identical(shown, "y1"))
+})
+
+
+# C-1. as_svydesign() hands over plain columns that keep their attributes.
+test_that("as_svydesign() returns plain columns that keep their labels", {
+  skip_if_not_installed("survey")
+  df <- make_labelled_frame()
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+
+  sv <- as_svydesign(d)
+
+  expect_true(inherits(sv, "survey.design"))
+  expect_identical(labelled_cols(sv$variables), character(0))
+  expect_identical(attr(sv$variables$y3, "labels", exact = TRUE), y3_labels)
+  expect_identical(
+    attr(sv$variables$y1, "label", exact = TRUE),
+    "Outcome variable 1"
+  )
+})
+
+
+# C-2. The converted object estimates identically to the surveycore design.
+test_that("svymean() on the as_svydesign() output matches get_means() [numerical]", {
+  skip_if_not_installed("survey")
+  df <- make_labelled_frame()
+  d <- as_survey(df, ids = psu, weights = wt, strata = strata)
+  sv <- as_svydesign(d)
+
+  sc <- get_means(d, y1, variance = "se")
+  sm <- survey::svymean(~y1, sv)
+
+  expect_equal(sc$mean[[1L]], coef(sm)[["y1"]], tolerance = 1e-10)
+  expect_equal(sc$se[[1L]], as.numeric(survey::SE(sm)), tolerance = 1e-8)
+})
+
+
+# C-3. from_svydesign() harvests the labels into @metadata. Gate 10.
+test_that("from_svydesign() captures value labels from a labelled svydesign", {
+  skip_if_not_installed("survey")
+  df <- make_labelled_frame()
+  sv <- survey::svydesign(
+    ids = ~psu,
+    weights = ~wt,
+    strata = ~strata,
+    data = df
+  )
+
+  d <- from_svydesign(sv)
+
+  expect_true(S7::S7_inherits(d, survey_taylor))
+  expect_identical(labelled_cols(d@data), character(0))
+  expect_identical(extract_val_labels(d), list(y3 = y3_labels))
+  expect_identical(d@metadata@value_labels, list(y3 = y3_labels))
+  expect_identical(
+    extract_var_label(d),
+    c(y1 = "Outcome variable 1", y3 = "Outcome variable 3")
+  )
+})
+
+
+# C-4. A labelled weight column no longer aborts the Taylor route.
+test_that("from_svydesign() converts a design whose weight column is labelled", {
+  skip_if_not_installed("survey")
+  set.seed(11L)
+  n <- 40L
+  w <- runif(n, 1, 3)
+  # `probs` rather than `weights` keeps the weight formula out of the stored
+  # call, so the weight column is recovered by value. That reaches
+  # `.find_col_by_value()`, which casts each candidate with as.numeric().
+  df <- data.frame(y = rnorm(n), p = 1 / w)
+  df$wt <- make_labelled(w, label = "Sampling weight")
+
+  sv <- survey::svydesign(ids = ~1, probs = ~p, data = df)
+  d <- from_svydesign(sv)
+
+  expect_true(S7::S7_inherits(d, survey_taylor))
+  expect_identical(labelled_cols(d@data), character(0))
+  expect_identical(d@variables$weights, "wt")
+  expect_equal(d@data$wt, w, tolerance = 0, ignore_attr = TRUE)
+})
+
+
+# C-5. The replicate route captures labels. Gate 10.
+test_that("from_svydesign() captures value labels from a labelled svrepdesign", {
+  skip_if_not_installed("survey")
+  set.seed(12L)
+  n <- 20L
+  df <- data.frame(wt = runif(n, 1, 3))
+  df$y3 <- make_labelled(
+    rep(c(0, 1), n %/% 2L),
+    labels = y3_labels,
+    label = "Outcome variable 3"
+  )
+  rep_mat <- matrix(runif(n * 4L), ncol = 4L)
+  sv <- survey::svrepdesign(
+    data = df,
+    weights = ~wt,
+    repweights = rep_mat,
+    type = "BRR",
+    combined.weights = TRUE
+  )
+
+  d <- from_svydesign(sv)
+
+  expect_true(S7::S7_inherits(d, survey_replicate))
+  expect_identical(labelled_cols(d@data), character(0))
+  expect_identical(extract_val_labels(d), list(y3 = y3_labels))
+  expect_identical(extract_var_label(d), c(y3 = "Outcome variable 3"))
+})
+
+
+# C-6. The two-phase route carries the phase 1 metadata forward. Gate 10.
+test_that("from_svydesign() captures value labels from a labelled twophase", {
+  skip_if_not_installed("survey")
+  set.seed(13L)
+  n <- 30L
+  df <- data.frame(x = rnorm(n), wt = rep(1, n))
+  df$y3 <- make_labelled(
+    rep(c(0, 1), n %/% 2L),
+    labels = y3_labels,
+    label = "Outcome variable 3"
+  )
+  sub <- rep(c(TRUE, FALSE), n %/% 2L)
+  sv <- survey::twophase(
+    id = list(~1, ~1),
+    strata = list(NULL, NULL),
+    probs = list(NULL, NULL),
+    data = df,
+    subset = sub
+  )
+
+  d <- suppressWarnings(from_svydesign(sv))
+
+  expect_true(S7::S7_inherits(d, survey_twophase))
+  expect_identical(labelled_cols(d@data), character(0))
+  expect_identical(extract_val_labels(d), list(y3 = y3_labels))
+  expect_identical(extract_var_label(d), c(y3 = "Outcome variable 3"))
+})
+
+
+# C-7. Round trip out through survey and back keeps the labels at both ends.
+test_that("as_survey() to as_svydesign() to from_svydesign() keeps the labels", {
+  skip_if_not_installed("survey")
+  df <- make_labelled_frame()
+  d1 <- as_survey(df, ids = psu, weights = wt, strata = strata)
+
+  expect_identical(labelled_cols(d1@data), character(0))
+  expect_identical(extract_val_labels(d1), list(y3 = y3_labels))
+
+  sv <- as_svydesign(d1)
+  expect_identical(labelled_cols(sv$variables), character(0))
+
+  # The return leg aborts for a reason that has nothing to do with labels.
+  # `.as_svydesign_taylor()` calls `survey::svydesign(ids = ids_formula, ...)`,
+  # so `survey` records the local variable names in `$call`. `from_svydesign()`
+  # then reads those names back as design variables and the validator raises
+  # `surveycore_error_design_var_missing`. The defect predates this change and
+  # fires on an unlabelled frame too. Repairing it is a behavioural change to
+  # `as_svydesign()` that the spec does not authorise, so it is on HOLD.
+  skip("HOLD: as_svydesign() to from_svydesign() aborts, unrelated to labels.")
+
+  d2 <- from_svydesign(sv)
+
+  expect_identical(labelled_cols(d2@data), character(0))
+  expect_identical(extract_val_labels(d2), list(y3 = y3_labels))
+  expect_identical(
+    extract_var_label(d2),
+    c(y1 = "Outcome variable 1", y3 = "Outcome variable 3")
+  )
+})
+
+
+# C-8. The srvyr round trip behaves the same way.
+test_that("as_tbl_svy() to from_tbl_svy() keeps the labels", {
+  skip_if_not_installed("survey")
+  skip_if_not_installed("srvyr")
+  df <- make_labelled_frame()
+  d1 <- as_survey(df, ids = psu, weights = wt, strata = strata)
+
+  tbl <- as_tbl_svy(d1)
+  expect_identical(labelled_cols(tbl$variables), character(0))
+
+  d2 <- from_tbl_svy(tbl)
+
+  expect_identical(labelled_cols(d2@data), character(0))
+  expect_identical(extract_val_labels(d2), list(y3 = y3_labels))
+  expect_identical(
+    extract_var_label(d2),
+    c(y1 = "Outcome variable 1", y3 = "Outcome variable 3")
+  )
+})
+
+
+# C-9. A source frame with no labels harvests nothing and does not error.
+test_that("from_svydesign() on an unlabelled frame returns no value labels", {
+  skip_if_not_installed("survey")
+  df <- make_survey_data(n = 40L, n_psu = 10L, n_strata = 2L, seed = 42L)
+  sv <- survey::svydesign(
+    ids = ~psu,
+    weights = ~wt,
+    strata = ~strata,
+    data = df
+  )
+
+  d <- from_svydesign(sv)
+
+  expect_identical(extract_val_labels(d), stats::setNames(list(), character(0)))
+  expect_identical(d@metadata@value_labels, list())
+})


### PR DESCRIPTION
## Summary

A design built by `from_svydesign()` or `from_tbl_svy()` now carries the metadata harvested from its source frame. It previously stored an empty `survey_metadata()` object, so value labels and variable labels were lost on the way in from the `survey` package.

Three routes change. `.from_svydesign_taylor()` and `.from_svydesign_replicate()` now extract the metadata from the frame. `.from_svydesign_twophase()` reuses the phase-1 design's metadata, matching what `as_survey_twophase()` already does. Both readers also strip the `haven_labelled` class from the incoming frame, so the stored columns match the storage contract the rest of this series established.

After this change, no route in `R/` builds a design with an empty metadata object — `grep "metadata = survey_metadata()" R/` returns only roxygen lines.

## Verification

| Measure | Before | After |
|---|---|---|
| failures | 0 | 0 |
| passes | 10643 | 10680 |
| coverage | 96.18% | 96.18% |

Ten rows, C-0 to C-9, all guarded with `skip_if_not_installed("survey")` and one additionally with `skip_if_not_installed("srvyr")`. The numerical fence compares `get_means()` against `survey::svymean()` on the converted object: the point estimates differ by 1.39e-17 against a tolerance of 1e-10, and the standard errors are identical.

## One row needed a separate fix first

C-7 asserts the full round trip out through `as_svydesign()` and back. That aborted for every Taylor design, labelled columns or not, because `survey` stores its own call and R records the unevaluated argument expressions there — so `from_svydesign()` read back the name of a local variable instead of a column. That defect predated this work and was fixed on its own in #195. This branch is rebased onto it, and C-7 asserts the whole round trip with no skip.

## Files

Five. `R/methods-conversion.R`, two regenerated `man/` pages, `tests/testthat/test-conversion.R`, and `plans/test-spec-haven-labelled.md`.

The last is a documentation correction. The test-spec said one of the metadata rows "currently fails in both modes"; measured, it failed in the data-frame mode only, because an earlier PR in this series had already fixed the survey-object mode. Three parties measured that independently. It changes no test.

No `DESCRIPTION`, `NAMESPACE` or snapshot change. Eighth of nine PRs implementing `plans/implementation-plan-haven-labelled.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)