### PR TITLE
docs(metadata): correct the nhanes_2017 value-label claim

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -178,6 +178,15 @@
   construction. The behaviour is unchanged and the documentation now matches
   it. (#207)
 
+* The `nhanes_2017` documentation said every column carries value labels, and
+  gave two `attr(nhanes_2017$<col>, "labels")` calls to read them with. No
+  column carries value labels. NHANES publishes the data as SAS XPORT files,
+  and that format stores a label for each variable but no labels for the codes
+  inside a variable. Both calls returned `NULL`, and `NULL` is a legal result,
+  so the examples ran clean and `R CMD check` passed. `?nhanes_2017` now
+  records that the dataset carries variable labels only and points to its
+  Format section for the code meanings. The dataset is unchanged. (#214)
+
 ## Notes
 
 * **Reading objects saved under surveycore 1.1.0 or earlier.** A design saved

--- a/R/data.R
+++ b/R/data.R
@@ -54,16 +54,18 @@
 #' (e.g., income, education).
 #'
 #' **Metadata:**
-#' All columns carry variable labels and value labels as R attributes,
-#' automatically extracted into surveycore's metadata system when you call
-#' `as_survey()`.
+#' All columns carry a variable label as an R attribute, automatically
+#' extracted into surveycore's metadata system when you call `as_survey()`.
+#' No column carries value labels.
 #'
 #' - **Variable labels** (`"label"` attribute): A human-readable description of
 #'   each column. Example: `attr(nhanes_2017$riagendr, "label")` returns
 #'   `"Gender"`.
-#' - **Value labels** (`"labels"` attribute): A named numeric vector mapping
-#'   each code to its meaning. Example: `attr(nhanes_2017$riagendr, "labels")`
-#'   returns `c(Male = 1, Female = 2)`.
+#' - **Value labels** (`"labels"` attribute): None. NHANES publishes the data
+#'   as SAS XPORT files. That format stores a label for each variable, but it
+#'   does not store labels for the codes inside a variable. The code meanings
+#'   are in the Format section above and in the NHANES codebooks. Use
+#'   `set_val_labels()` to attach them if you need them.
 #'
 #' **Source files:** DEMO_J.xpt (demographics) merged with BPX_J.xpt (blood
 #' pressure) on `seqn`. Prepared by `data-raw/download-nhanes.R`.
@@ -83,11 +85,8 @@
 #' # Inspect variable label
 #' attr(nhanes_2017$riagendr, "label")
 #'
-#' # Inspect value labels
-#' attr(nhanes_2017$riagendr, "labels")
-#'
-#' # Inspect value labels for race/ethnicity
-#' attr(nhanes_2017$ridreth3, "labels")
+#' # Inspect variable label for race/ethnicity
+#' attr(nhanes_2017$ridreth3, "label")
 "nhanes_2017"
 
 

--- a/data-raw/README.md
+++ b/data-raw/README.md
@@ -40,15 +40,19 @@ data is faster, fully controlled, and has no file I/O overhead.
 
 ## Metadata system integration
 
-All six datasets carry column-level metadata attributes that plug directly into
-surveycore's metadata system:
+All eight datasets carry column-level metadata attributes that plug directly
+into surveycore's metadata system. Not every dataset carries all three:
 
 - **`label`** — A human-readable variable description (e.g.,
   `attr(nhanes_2017$riagendr, "label")` → `"Gender"`). Set by haven on import
   for NHANES, ANES, GSS, and Pew datasets; manually assigned for ACS PUMS
   (no labels in CSV source).
 - **`labels`** — A named numeric vector mapping codes to their meaning (e.g.,
-  `attr(gss_2024$sex, "labels")` → `c(male = 1, female = 2, ...)`).
+  `attr(gss_2024$sex, "labels")` → `c(male = 1, female = 2, ...)`). Absent from
+  `nhanes_2017` and `acs_pums_wy`. NHANES publishes SAS XPORT files, which
+  store a label for each variable but no labels for the codes inside a
+  variable, and the ACS PUMS source is a plain CSV with no labels at all. Both
+  datasets document their code meanings in `?nhanes_2017` and `?acs_pums_wy`.
 - **`question_preface`** — Set only on battery and select-all-that-apply
   variables (see `pew_jewish_2020` and `pew_npors_2025` below). Contains the
   shared question stem; `label` holds only the unique item text.

--- a/data-raw/download-nhanes.R
+++ b/data-raw/download-nhanes.R
@@ -96,9 +96,12 @@ nhanes_merged <- restore_col_attrs(nhanes_merged, c(attrs_demo, attrs_bpx))
 ## ---- 5. Strip haven class if present, keeping label/labels attributes ----
 ##
 ## haven::read_xpt() on NHANES returns plain numeric columns (not haven_labelled)
-## but with "label" and "labels" attributes. The as_plain() call below is a no-op
-## for NHANES since columns aren't haven_labelled, but is included for
-## consistency with the BRFSS script and as a safeguard for future file changes.
+## with a "label" attribute. No column carries a "labels" attribute: the SAS
+## XPORT format stores a label for each variable but no labels for the codes
+## inside a variable, so the NHANES code meanings live only in the published
+## codebooks. The as_plain() call below is a no-op for NHANES since columns
+## aren't haven_labelled, but is included for consistency with the BRFSS script
+## and as a safeguard for future file changes.
 
 as_plain <- function(df) {
   df[] <- lapply(df, function(x) {

--- a/man/nhanes_2017.Rd
+++ b/man/nhanes_2017.Rd
@@ -67,16 +67,18 @@ Use \code{wtint2yr} instead of \code{wtmec2yr} for interview-only variables
 (e.g., income, education).
 
 \strong{Metadata:}
-All columns carry variable labels and value labels as R attributes,
-automatically extracted into surveycore's metadata system when you call
-\code{as_survey()}.
+All columns carry a variable label as an R attribute, automatically
+extracted into surveycore's metadata system when you call \code{as_survey()}.
+No column carries value labels.
 \itemize{
 \item \strong{Variable labels} (\code{"label"} attribute): A human-readable description of
 each column. Example: \code{attr(nhanes_2017$riagendr, "label")} returns
 \code{"Gender"}.
-\item \strong{Value labels} (\code{"labels"} attribute): A named numeric vector mapping
-each code to its meaning. Example: \code{attr(nhanes_2017$riagendr, "labels")}
-returns \code{c(Male = 1, Female = 2)}.
+\item \strong{Value labels} (\code{"labels"} attribute): None. NHANES publishes the data
+as SAS XPORT files. That format stores a label for each variable, but it
+does not store labels for the codes inside a variable. The code meanings
+are in the Format section above and in the NHANES codebooks. Use
+\code{set_val_labels()} to attach them if you need them.
 }
 
 \strong{Source files:} DEMO_J.xpt (demographics) merged with BPX_J.xpt (blood
@@ -92,10 +94,7 @@ exam_only <- nhanes_2017[nhanes_2017$ridstatr == 2, ]
 # Inspect variable label
 attr(nhanes_2017$riagendr, "label")
 
-# Inspect value labels
-attr(nhanes_2017$riagendr, "labels")
-
-# Inspect value labels for race/ethnicity
-attr(nhanes_2017$ridreth3, "labels")
+# Inspect variable label for race/ethnicity
+attr(nhanes_2017$ridreth3, "label")
 }
 \keyword{datasets}

--- a/tests/testthat/test-datasets.R
+++ b/tests/testthat/test-datasets.R
@@ -17,11 +17,64 @@ test_that("datasets load and have expected dimensions", {
   expect_equal(ncol(pew_jewish_2020), 130)
 })
 
-test_that("nhanes_2017 carries variable labels", {
-  # NHANES XPT files embed variable labels but not value labels (value codes
-  # are documented in external NHANES codebooks, not as SAS formats in the
-  # XPT files themselves).
+test_that("every column of nhanes_2017 carries a variable label", {
+  has_label <- vapply(
+    nhanes_2017,
+    function(x) is.character(attr(x, "label", exact = TRUE)),
+    logical(1)
+  )
+  expect_true(all(has_label))
   expect_equal(attr(nhanes_2017$riagendr, "label", exact = TRUE), "Gender")
+})
+
+test_that("no column of nhanes_2017 carries value labels", {
+  # NHANES publishes SAS XPORT files. That format stores a label for each
+  # variable, but no labels for the codes inside a variable. ?nhanes_2017
+  # documents the code meanings in its Format section instead (issue #214).
+  has_labels <- vapply(
+    nhanes_2017,
+    function(x) !is.null(attr(x, "labels", exact = TRUE)),
+    logical(1)
+  )
+  expect_false(any(has_labels))
+})
+
+test_that("every attribute the dataset docs tell the reader to read exists", {
+  # One row per attr() call shown in R/data.R, in @details or in @examples. A
+  # documented call that returns NULL runs clean and passes R CMD check,
+  # because NULL is a legal result, so nothing else catches it (issue #214).
+  documented <- list(
+    c("nhanes_2017", "riagendr", "label"),
+    c("nhanes_2017", "ridreth3", "label"),
+    c("anes_2024", "v241177", "label"),
+    c("anes_2024", "v241177", "labels"),
+    c("anes_2024", "v241550", "label"),
+    c("anes_2024", "v241550", "labels"),
+    c("gss_2024", "happy", "label"),
+    c("gss_2024", "happy", "labels"),
+    c("pew_npors_2025", "smuse_fb", "label"),
+    c("pew_npors_2025", "smuse_fb", "labels"),
+    c("pew_npors_2025", "smuse_fb", "question_preface"),
+    c("pew_jewish_2020", "relconsider_a", "label"),
+    c("pew_jewish_2020", "relconsider_a", "labels"),
+    c("pew_jewish_2020", "discrim_a", "label"),
+    c("pew_jewish_2020", "discrim_a", "labels"),
+    c("pew_jewish_2020", "discrim_a", "question_preface"),
+    c("ns_wave1", "group_favorability_blacks", "label"),
+    c("ns_wave1", "group_favorability_blacks", "question_preface"),
+    c("ns_wave1", "news_sources_cnn", "labels"),
+    c("ca_api_2000", "api00", "label"),
+    c("ca_api_2000", "stype", "labels")
+  )
+
+  for (row in documented) {
+    dataset <- get(row[1], envir = asNamespace("surveycore"))
+    value <- attr(dataset[[row[2]]], row[3], exact = TRUE)
+    expect_false(
+      is.null(value),
+      label = paste0("attr(", row[1], "$", row[2], ', "', row[3], '")')
+    )
+  }
 })
 
 test_that("acs_pums_wy has 80 replicate weights", {


### PR DESCRIPTION
Closes #214.

## What was wrong

`?nhanes_2017` said all columns carry value labels and gave the reader two
calls to read them with. No column carries value labels. Both calls returned
`NULL`, and `NULL` is a legal result, so the examples ran clean and
`R CMD check` passed.

## The cause is not a stripping bug

`data-raw/download-nhanes.R` saves and restores both `label` and `labels`
across the `merge()`, and the second attribute never existed. NHANES publishes
the data as SAS XPORT files. That format stores a label for each variable but
no labels for the codes inside a variable, so the code meanings live only in
the published codebooks — and `?nhanes_2017` already lists them in its Format
section.

`tests/testthat/test-datasets.R:20-26` recorded this in a comment before this
PR: "NHANES XPT files embed variable labels but not value labels." `R/data.R`
was the only place in the package that disagreed.

Measured: 14 of 14 columns carry a `label`, 0 of 14 carry `labels`.

## Which option, and why

Issue #214 offered two. This is option 1, correcting the documentation.

Option 2 — hardcode the codebook into `data-raw/` and rebuild the dataset —
would invent metadata the source does not have. It also has a wide blast
radius: 30+ test files read `nhanes_2017`, and `get_freqs()` level names plus
select-all-that-apply detection both read value labels, so snapshots would
churn.

## Changes

| File | Change |
|---|---|
| `R/data.R` | The Metadata block says variable labels only, and says why the value labels are absent. The two `attr(..., "labels")` examples become `attr(..., "label")`. |
| `man/nhanes_2017.Rd` | Regenerated by `devtools::document()`. |
| `tests/testthat/test-datasets.R` | Three blocks — see below. |
| `NEWS.md` | Entry under Bug fixes, matching the `(#207)` doc-correction precedent. |
| `data-raw/README.md` | The `labels` bullet names `nhanes_2017` and `acs_pums_wy` as the two datasets without value labels. Also "six datasets" → "eight". |
| `data-raw/download-nhanes.R` | The section 5 comment made the same wrong claim about `read_xpt()`. It is what the documentation was written from. |

The dataset is unchanged. No `.rda` file is touched.

## The guard the issue asked for

Three new blocks in `test-datasets.R`:

1. every column of `nhanes_2017` carries a variable label;
2. no column of `nhanes_2017` carries value labels;
3. every attribute the dataset documentation tells the reader to read exists —
   21 rows covering every `attr()` call in `R/data.R`, across all eight bundled
   datasets.

Block 3 is the one that would have caught this. Pointed at
`attr(nhanes_2017$riagendr, "labels")` it fails and names the call:
`Expected attr(nhanes_2017$riagendr, "labels") to be FALSE`.

All 22 documented `attr()` calls were audited. Only the three `nhanes_2017`
value-label references were ever false.

## Verification

- `devtools::check()`: 0 errors, 0 warnings, 1 note. The note is
  `hidden files and directories: .git`, an artifact of checking inside a git
  worktree.
- `devtools::test()`: `FAIL 0 | WARN 256 | SKIP 4 | PASS 10855`. The warnings
  are the pre-existing AAPOR small-cell warnings the tests raise deliberately.
- `air format` on the changed files: no further edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
