### PR TITLE
docs(plans): fix two stale claims in archive/haven-labelled (#212)

### DIFF
--- a/archive/haven-labelled/decisions-haven-labelled.md
+++ b/archive/haven-labelled/decisions-haven-labelled.md
@@ -227,7 +227,7 @@ One cost the spec must state: the setter runs on **every** `@data` write,
 including inside every dplyr verb method. The helper must return early when
 no column carries the class.
 
-## D5 — `survey_data(x, haven_class = FALSE)` restores the class on request
+## D5 — `survey_data(x, haven_class = TRUE)` restores the class on request
 
 **Decided**: 2026-08-28, by the user. Resolves HOLD-2 and BLOCK B3 from
 `spec-review.md`.

--- a/archive/haven-labelled/implementation-plan-haven-labelled.md
+++ b/archive/haven-labelled/implementation-plan-haven-labelled.md
@@ -811,8 +811,12 @@ Branch from `develop` after PR 7 merges.
 - **Acceptance criteria**
   - **The six profile gates, verbatim from `test-spec.md` §8:**
     - `document` — `devtools::document()` clean, `man/` committed in sync.
-    - `test` — `Rscript -e "devtools::test()"`: 0 failures, 0 errors, 0
-      warnings.
+    - `test` — `Rscript -e "devtools::test()"`: 0 failures, 0 errors, and
+      **no warning attributable to this feature** (`spec.md` §XI.2).
+      Measured 2026-09-01: 256 warnings, unchanged from the baseline's
+      256 — the AAPOR small-cell and `survey_nonprob` SRS-approximation
+      notices, both raised by design; issue #167 tracks them. The
+      0-warning form has never held, on this tree or on the feature base.
     - `run_examples` — `devtools::run_examples()` clean.
     - `R CMD check --as-cran` — 0 errors, 0 warnings, at most the two
       pre-approved notes from


### PR DESCRIPTION
Closes #212. Two one-line fixes in `archive/haven-labelled/`. Documentation only — no R source, no tests.

## 1. D5's heading said `FALSE` where it means `TRUE`

`decisions-haven-labelled.md:230` read:

```
## D5 — `survey_data(x, haven_class = FALSE)` restores the class on request
```

`FALSE` is the default and returns the stripped column. `TRUE` restores the class. The body of D5 was already correct, so the heading alone changed.

## 2. PR 8 still demanded a gate the same PR declared unreachable

`implementation-plan-haven-labelled.md:814-815` read `0 failures, 0 errors, 0 warnings`. #202 reworded that gate to "no warning attributable to this feature" at `spec.md` §XI.2 and at four sites in the plan. This was a fifth site, inside the acceptance criteria of the PR that runs the gate.

The new text matches §XI.2: it carries the 256-warning measurement, names the AAPOR small-cell and `survey_nonprob` SRS-approximation notices, points at #167, and records that the 0-warning form has never held.

I checked the remaining `0 warnings` and `haven_class = FALSE` matches in the directory. Every one is correct: the `0 warnings` hits are `R CMD check` gates, and the `haven_class = FALSE` hits describe the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
