### PR TITLE
chore(ci): run test-coverage on develop and enforce the 95% floor (#159)

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -31,9 +31,12 @@ jobs:
       - name: Test coverage
         id: coverage
         env:
-          # Eleven test files carry a file-level skip_on_cran(). covr does not
-          # set NOT_CRAN, so without this the files skip, their source reads as
-          # untested, and coverage reports several points low (issue #159).
+          # Pins a value the job already had: r-lib/actions/setup-r exports
+          # NOT_CRAN=true, so this changes nothing today. It is here so the
+          # floor check below cannot start reading a false number if that
+          # default ever changes. Eleven test files carry a file-level
+          # skip_on_cran(); covr does not set the variable itself, and without
+          # it their source reads as untested (issue #159).
           NOT_CRAN: true
         run: |
           cov <- covr::package_coverage(

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 name: test-coverage
 
@@ -29,6 +29,12 @@ jobs:
           needs: coverage
 
       - name: Test coverage
+        id: coverage
+        env:
+          # Eleven test files carry a file-level skip_on_cran(). covr does not
+          # set NOT_CRAN, so without this the files skip, their source reads as
+          # untested, and coverage reports several points low (issue #159).
+          NOT_CRAN: true
         run: |
           cov <- covr::package_coverage(
             quiet = FALSE,
@@ -37,6 +43,12 @@ jobs:
           )
           print(cov)
           covr::to_cobertura(cov)
+          pct <- covr::percent_coverage(cov)
+          cat(
+            sprintf("percent=%.4f\n", pct),
+            file = Sys.getenv("GITHUB_OUTPUT"),
+            append = TRUE
+          )
         shell: Rscript {0}
 
       - uses: codecov/codecov-action@v5
@@ -48,6 +60,24 @@ jobs:
           disable_search: true
           skip_validation: true
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Check the coverage floor
+        env:
+          # The 95% floor comes from .claude/rules/testing-standards.md.
+          COVERAGE_FLOOR: "95"
+          COVERAGE_PERCENT: ${{ steps.coverage.outputs.percent }}
+        run: |
+          if [ -z "$COVERAGE_PERCENT" ]; then
+            echo "::error::coverage did not run"
+            exit 1
+          fi
+          if awk "BEGIN { exit !($COVERAGE_PERCENT >= $COVERAGE_FLOOR) }"; then
+            echo "coverage ${COVERAGE_PERCENT}% meets the ${COVERAGE_FLOOR}% floor"
+          else
+            echo "::error::coverage ${COVERAGE_PERCENT}% is below the ${COVERAGE_FLOOR}% floor"
+            exit 1
+          fi
+        shell: bash
 
       - name: Show testthat output
         if: always()

--- a/changelog/chore-test-coverage-ci-develop.md
+++ b/changelog/chore-test-coverage-ci-develop.md
@@ -27,8 +27,9 @@ therefore enforced by the local pipeline gate alone — `run-gates.sh` gate 7
 and the reviewer's Step 5. A contributor who skips the local pipeline could
 merge a regression into `develop` with CI fully green.
 
-Three changes: `develop` on both triggers, `NOT_CRAN=true` on the coverage
-step, and a step that fails below the floor.
+Two fixes: `develop` on both triggers, and a step that fails below the floor.
+A third change, `NOT_CRAN=true` on the coverage step, pins a value the job
+already had — see below.
 
 ### The floor check reads covr, not Codecov
 
@@ -46,15 +47,31 @@ reads `covr::percent_coverage()`. This PR uses the covr step:
 The check runs after the Codecov upload, so the report still lands when
 coverage drops.
 
-### `NOT_CRAN` is what makes the number honest
+### `NOT_CRAN` was already set — this pins it
+
+#159 says the CI workflow does not set `NOT_CRAN`, and infers that CI coverage
+read several points low. The first half is true of the workflow file. The
+inference is wrong: `r-lib/actions/setup-r` exports `NOT_CRAN=true` job-wide,
+so the value was already in place for `covr::package_coverage()`.
+
+Measured against the run before this change — `main`, 2026-06-28, run
+28338451338:
+
+| Observation | Value |
+|---|---|
+| Coverage the job printed | 95.90% |
+| `NOT_CRAN` occurrences in its log | 22 |
+
+95.90% is the honest figure, not the ~93.7% a skipped run gives. So the
+explicit `NOT_CRAN: true` in this PR fixes no live defect. It is kept for one
+reason: the floor check now reads that number and fails on it, so the job
+should state the variable it depends on rather than inherit it from a third
+party's default.
 
 Eleven test files carry a file-level `skip_on_cran()`. `covr` does not set
-`NOT_CRAN`, so without it those files skip, their source reads as untested,
-and the package total lands several points low — a false failure against the
-floor. Commit `7cf0704` fixed the same defect in `run-gates.sh` gate 7.
-`.claude/rules/testing-surveycore.md` states the rule and cites this issue.
-
-#159 says ten files. The repository has eleven, which matches the rule file:
+`NOT_CRAN` itself — that part of #159 holds, and it is why
+`run-gates.sh` gate 7 sets it explicitly (commit `7cf0704`) and why
+`.claude/rules/testing-surveycore.md` states the rule for local runs:
 
 ```
 tests/testthat/test-analysis-corr-latent-variance.R
@@ -70,11 +87,14 @@ tests/testthat/test-variance-twophase.R
 tests/testthat/test-variance-vendored-saddlepoint.R
 ```
 
+#159 says ten files. The repository has eleven, which matches the rule file.
+
 ## Files Modified
 
 - `.github/workflows/test-coverage.yaml` — `develop` added to the `push` and
   `pull_request` branch lists, matching `R-CMD-check.yaml`; `NOT_CRAN: true`
-  on the coverage step, with a comment naming the eleven files and the issue;
+  pinned on the coverage step, with a comment saying it restates a value
+  `setup-r` already exports;
   the step gains `id: coverage` and writes `percent` to `$GITHUB_OUTPUT`; a
   new "Check the coverage floor" step reads that output and exits 1 when the
   figure is below 95 or when coverage did not run
@@ -84,8 +104,9 @@ tests/testthat/test-variance-vendored-saddlepoint.R
 
 - Run the coverage workflow on `develop` pushes and on PRs that target
   `develop`, so feature PRs are coverage-checked before they merge
-- Set `NOT_CRAN=true` for `covr::package_coverage()`, so the eleven
-  `skip_on_cran()` files run and the reported total is the true one
+- Pin `NOT_CRAN=true` for `covr::package_coverage()`. `setup-r` already
+  exported it, so no reported total moves; the job now states the variable its
+  floor check depends on
 - Fail the job when coverage is below the 95% floor, and fail it when the
   coverage step produced no figure at all
 
@@ -106,6 +127,16 @@ What was checked locally:
 | 4 | It fails 94.9 and an empty figure | pass |
 
 Assertions 3 and 4 ran the step's `awk` expression and its empty-value guard
-directly, not the workflow. The workflow runs on GitHub only, so the first CI
-run on this PR is the real check — and it is also the first run of the job on
-a `develop`-targeted PR.
+directly, not the workflow.
+
+The workflow itself runs on GitHub only, so this PR's own CI run is the real
+check. Run 33792891286 confirmed all three parts:
+
+| Assertion | Result |
+|---|---|
+| The job triggers on a `develop`-targeted PR | pass — first such run in the repository |
+| The coverage step hands the floor step a figure | pass — `COVERAGE_PERCENT: 96.1878` |
+| The floor step reads it and does not pass vacuously | pass — "coverage 96.1878% meets the 95% floor" |
+
+96.1878% against 95.90% on the June `main` run is drift from tests added
+since, not an effect of this change.

--- a/changelog/chore-test-coverage-ci-develop.md
+++ b/changelog/chore-test-coverage-ci-develop.md
@@ -1,0 +1,111 @@
+# Changelog: chore/test-coverage-ci-develop
+
+**Branch:** `JDenn0514/test-coverage-workflow-never-runs-on-develop-prs`
+**Status:** Complete
+**Date:** 2026-09-03
+
+## Summary
+
+Closes #159. `.github/workflows/test-coverage.yaml` ran on `main` only, and it
+had no failure condition:
+
+```yaml
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+```
+
+Feature branches target `develop` (`.claude/rules/github-strategy.md`), so no
+feature PR was ever coverage-checked. The job measured coverage, converted it
+to Cobertura and uploaded it to Codecov. Nothing read the number back, so a
+drop left CI green.
+
+The 95% floor and 98% target in `.claude/rules/testing-standards.md` were
+therefore enforced by the local pipeline gate alone — `run-gates.sh` gate 7
+and the reviewer's Step 5. A contributor who skips the local pipeline could
+merge a regression into `develop` with CI fully green.
+
+Three changes: `develop` on both triggers, `NOT_CRAN=true` on the coverage
+step, and a step that fails below the floor.
+
+### The floor check reads covr, not Codecov
+
+#159 left this open — a Codecov status check with a target, or a step that
+reads `covr::percent_coverage()`. This PR uses the covr step:
+
+- It reuses the same floor and the same instrument as `run-gates.sh` gate 7,
+  so the local gate and CI cannot disagree about what 95% means.
+- It needs no Codecov project settings and no `CODECOV_TOKEN`. The existing
+  upload step already treats a missing token as tolerable on a PR, and a
+  status check gated on that token would inherit the same hole.
+- The threshold lives next to the tests it measures, in the repository, under
+  review.
+
+The check runs after the Codecov upload, so the report still lands when
+coverage drops.
+
+### `NOT_CRAN` is what makes the number honest
+
+Eleven test files carry a file-level `skip_on_cran()`. `covr` does not set
+`NOT_CRAN`, so without it those files skip, their source reads as untested,
+and the package total lands several points low — a false failure against the
+floor. Commit `7cf0704` fixed the same defect in `run-gates.sh` gate 7.
+`.claude/rules/testing-surveycore.md` states the rule and cites this issue.
+
+#159 says ten files. The repository has eleven, which matches the rule file:
+
+```
+tests/testthat/test-analysis-corr-latent-variance.R
+tests/testthat/test-analysis-corr-latent.R
+tests/testthat/test-analysis-diffs-marginaleffects.R
+tests/testthat/test-analysis-diffs-numerical.R
+tests/testthat/test-analysis-t-test-numerical.R
+tests/testthat/test-analysis-variance-twophase-nonprob.R
+tests/testthat/test-glm-anova-numerical.R
+tests/testthat/test-glm-marginaleffects.R
+tests/testthat/test-glm-numerical.R
+tests/testthat/test-variance-twophase.R
+tests/testthat/test-variance-vendored-saddlepoint.R
+```
+
+## Files Modified
+
+- `.github/workflows/test-coverage.yaml` — `develop` added to the `push` and
+  `pull_request` branch lists, matching `R-CMD-check.yaml`; `NOT_CRAN: true`
+  on the coverage step, with a comment naming the eleven files and the issue;
+  the step gains `id: coverage` and writes `percent` to `$GITHUB_OUTPUT`; a
+  new "Check the coverage floor" step reads that output and exits 1 when the
+  figure is below 95 or when coverage did not run
+- `changelog/chore-test-coverage-ci-develop.md` — this entry
+
+## Changes
+
+- Run the coverage workflow on `develop` pushes and on PRs that target
+  `develop`, so feature PRs are coverage-checked before they merge
+- Set `NOT_CRAN=true` for `covr::package_coverage()`, so the eleven
+  `skip_on_cran()` files run and the reported total is the true one
+- Fail the job when coverage is below the 95% floor, and fail it when the
+  coverage step produced no figure at all
+
+## Verification
+
+`.Rbuildignore` excludes both changed paths — `.github` (line 4) and
+`changelog` (line 5) — so the built package is byte-identical and no package
+gate figure can move. `devtools::check()` and `devtools::test()` were not run
+for that reason.
+
+What was checked locally:
+
+| # | Assertion | Result |
+|---|---|---|
+| 1 | The file parses as YAML; `on:` lists both branches | pass |
+| 2 | The eight steps read back in the intended order | pass |
+| 3 | The floor comparison passes 96.0938 and 95 | pass |
+| 4 | It fails 94.9 and an empty figure | pass |
+
+Assertions 3 and 4 ran the step's `awk` expression and its empty-value guard
+directly, not the workflow. The workflow runs on GitHub only, so the first CI
+run on this PR is the real check — and it is also the first run of the job on
+a `develop`-targeted PR.


### PR DESCRIPTION
## What

Runs the test-coverage workflow on `develop` pushes and `develop`-targeted PRs,
and fails the job when coverage is below the 95% floor.

Closes #159.

## Why

`.github/workflows/test-coverage.yaml` triggered on `main` only. Feature
branches target `develop`, so no feature PR was ever coverage-checked — coverage
was measured only after work had already reached `main`. The job also read no
number back from `covr`, so a drop left CI green. The 95% floor in
`.claude/rules/testing-standards.md` was enforced by the local pipeline gate
alone (`run-gates.sh` gate 7).

## Changes

Two fixes:

- `develop` added to the `push` and `pull_request` branch lists, matching
  `R-CMD-check.yaml`
- A new "Check the coverage floor" step. The coverage step writes `percent` to
  `$GITHUB_OUTPUT`; the new step exits 1 below 95, and exits 1 when coverage
  produced no figure at all. It runs after the Codecov upload, so the report
  still lands when coverage drops

And one pin:

- `NOT_CRAN: true` on the coverage step. **This fixes no live defect** —
  see the correction below.

#159 left the enforcement mechanism open — a Codecov status check, or a `covr`
step. This uses the `covr` step: it reuses the same floor and instrument as gate
7, so local and CI cannot disagree, and it needs no Codecov settings or
`CODECOV_TOKEN`.

## Correction to #159 — `NOT_CRAN` was already set

#159 says the CI workflow does not set `NOT_CRAN` and infers that CI coverage
read several points low. The first half is true of the workflow file; the
inference is wrong. `r-lib/actions/setup-r` exports `NOT_CRAN=true` job-wide,
so the value was already reaching `covr::package_coverage()`.

Measured on the run before this change — `main`, 2026-06-28, run 28338451338:

| Observation | Value |
|---|---|
| Coverage the job printed | 95.90% |
| `NOT_CRAN` occurrences in its log | 22 |

95.90% is the honest figure, not the ~93.7% a skipped run gives. The explicit
`NOT_CRAN: true` is kept as a pin: the floor check now reads that number and
fails on it, so the job should state the variable it depends on rather than
inherit it from a third party's default.

The rest of #159's `NOT_CRAN` note holds — `covr` does not set the variable
itself, which is why gate 7 sets it explicitly (commit `7cf0704`). The
repository has eleven files with a file-level `skip_on_cran()`, not ten;
eleven matches `.claude/rules/testing-surveycore.md`.

## Verification

`.Rbuildignore` excludes both changed paths — `.github` (line 4) and `changelog`
(line 5) — so the built package is byte-identical and no package gate figure can
move. `devtools::check()` and `devtools::test()` were not run for that reason.

Run 33792891286, on commit `c0a013c`, confirmed all three parts against the real
CI environment:

| Assertion | Result |
|---|---|
| The job triggers on a `develop`-targeted PR | pass — first such run in the repository |
| The coverage step hands the floor step a figure | pass — `COVERAGE_PERCENT: 96.1878` |
| The floor step reads it, and does not pass vacuously | pass — "coverage 96.1878% meets the 95% floor" |

96.1878% against 95.90% in June is drift from tests added since, not an effect
of this change. The floor expression was also exercised directly against
96.0938, 95, 94.9 and an empty figure: pass, pass, fail, fail.

## Checklist

- [x] PR title is a valid Conventional Commit
- [x] PR targets `develop`, not `main`
- [x] Changelog entry added (`changelog/chore-test-coverage-ci-develop.md`)
- [ ] N/A — `devtools::test()`: no test or source file changed
- [ ] N/A — `devtools::check()`: no file reaches the built package
- [ ] N/A — roxygen / `devtools::document()`: no roxygen changed
- [ ] N/A — `plans/error-messages.md`: no new error or warning class
- [ ] N/A — `VENDORED.md`: no vendored code